### PR TITLE
Add support for config_overrides in unit association REST controller.

### DIFF
--- a/docs/sphinx/rest-api/content/associate.rst
+++ b/docs/sphinx/rest-api/content/associate.rst
@@ -16,6 +16,7 @@ with an importer that supports the type of units being copied.
 
 * :param:`source_repo_id,str,repository from which to copy units`
 * :param:`?criteria,criteria document,filters which units to copy from the source repository`
+* :param:`?override_config,object,importer configuration values that override the importer's default configuration`
 
 | :response_list:`_`
 
@@ -34,7 +35,11 @@ with an importer that supports the type of units being copied.
           '$and': [{'name': {'$regex': 'p.*'}}, {'version': {'$gt': '1.0'}}]
         }
       }
-    }
+    },
+   'override_config': {
+     'resolve_dependencies: true,
+     'recursive': true
+    },
   }
 
 

--- a/platform/src/pulp/server/managers/repo/unit_association.py
+++ b/platform/src/pulp/server/managers/repo/unit_association.py
@@ -174,7 +174,7 @@ class RepoUnitAssociationManager(object):
             manager_factory.repo_manager().update_unit_count(
                 repo_id, unique_count)
 
-    def associate_from_repo(self, source_repo_id, dest_repo_id, criteria=None):
+    def associate_from_repo(self, source_repo_id, dest_repo_id, criteria=None, import_config_override=None):
         """
         Creates associations in a repository based on the contents of a source
         repository. Units from the source repository can be filtered by
@@ -202,6 +202,10 @@ class RepoUnitAssociationManager(object):
         @param criteria: optional; if specified, will filter the units retrieved
                          from the source repository
         @type  criteria: L{UnitAssociationCriteria}
+        
+        @param import_config_override: optional config containing values to use
+                                     for this import only
+        @type  import_config_override: dict
 
         @raise MissingResource: if either of the specified repositories don't exist
         """
@@ -255,11 +259,7 @@ class RepoUnitAssociationManager(object):
         # Invoke the importer
         importer_instance, plugin_config = plugin_api.get_importer_by_id(dest_repo_importer['importer_type_id'])
 
-        # Custom options for dependency resolution
-        plugin_config['recursive'] = True
-        plugin_config['resolve_dependencies'] = True
-
-        call_config = PluginCallConfiguration(plugin_config, dest_repo_importer['config'])
+        call_config = PluginCallConfiguration(plugin_config, dest_repo_importer['config'], import_config_override)
         conduit = ImportUnitConduit(source_repo_id, dest_repo_id, source_repo_importer['id'], dest_repo_importer['id'])
 
         try:

--- a/platform/src/pulp/server/webservices/controllers/repositories.py
+++ b/platform/src/pulp/server/webservices/controllers/repositories.py
@@ -914,6 +914,7 @@ class RepoAssociate(JSONController):
         # Params
         params = self.params()
         source_repo_id = params.get('source_repo_id', None)
+        overrides = params.get('override_config', None)
 
         if source_repo_id is None:
             raise exceptions.MissingValue(['source_repo_id'])
@@ -934,7 +935,7 @@ class RepoAssociate(JSONController):
                 action_tag('associate')]
         call_request = CallRequest(association_manager.associate_from_repo,
                                    [source_repo_id, dest_repo_id],
-                                   {'criteria': criteria},
+                                   {'criteria': criteria, 'import_config_override': overrides},
                                    resources=resources,
                                    tags=tags,
                                    archive=True)

--- a/platform/test/unit/test_repo_controller.py
+++ b/platform/test/unit/test_repo_controller.py
@@ -1277,9 +1277,11 @@ class RepoAssociateTests(RepoControllersTests):
     def _test_post_with_criteria(self):
 
         # Test
+        overrides = { 'abc':'123' }
         criteria = {'filters' : {'unit' : {'key-1' : 'fus'}}}
         params = {'source_repo_id' : 'source-repo-1',
-                  'criteria' : criteria}
+                  'criteria' : criteria,
+                  'config_overrides' : overrides}
 
         status, body = self.post('/v2/repositories/dest-repo-1/actions/associate/', params=params)
 
@@ -1290,10 +1292,12 @@ class RepoAssociateTests(RepoControllersTests):
         args = self.association_manager_dummy.args
         kwargs = self.association_manager_dummy.kwargs
         self.assertEqual(2, len(args))
-        self.assertEqual(1, len(kwargs))
+        self.assertEqual(2, len(kwargs))
         self.assertEqual('source-repo-1', args[0])
         self.assertEqual('dest-repo-1', args[1])
         self.assertEqual({'key-1' : 'fus'}, kwargs['criteria'].unit_filters)
+        for k,v in overrides.items():
+            self.assertEqual(kwargs['import_config_override'][k], v)
 
     def test_post_missing_source_repo(self):
 

--- a/platform/test/unit/test_repo_unit_association_manager.py
+++ b/platform/test/unit/test_repo_unit_association_manager.py
@@ -243,13 +243,17 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.manager.associate_unit_by_id(source_repo_id, 'mock-type', 'unit-3', OWNER_TYPE_USER, 'admin')
 
         # Test
+        overrides = { 'abc': '123'}
         criteria = UnitAssociationCriteria(type_ids=['mock-type'], unit_filters={'key-1' : 'unit-2'}, unit_fields=['key-1'])
-        self.manager.associate_from_repo(source_repo_id, dest_repo_id, criteria=criteria)
+        self.manager.associate_from_repo(source_repo_id, dest_repo_id, criteria=criteria, import_config_override=overrides)
 
         # Verify
         self.assertEqual(1, mock_plugins.MOCK_IMPORTER.import_units.call_count)
 
+        args = mock_plugins.MOCK_IMPORTER.import_units.call_args[0]
         kwargs = mock_plugins.MOCK_IMPORTER.import_units.call_args[1]
+        for k,v in overrides.items():
+            self.assertEqual(args[3].get(k), v)
         self.assertEqual(1, len(kwargs['units']))
         self.assertEqual(kwargs['units'][0].id, 'unit-2')
 

--- a/rpm-support/test/unit/test_import_units.py
+++ b/rpm-support/test/unit/test_import_units.py
@@ -290,8 +290,8 @@ class TestImportDependencies(rpm_support_base.PulpRPMTests):
         units = [Unit(TYPE_ID_RPM, self.UNIT_KEY_B, {}, '')]
         conduit = importer_mocks.get_import_conduit(units, existing_units=existing_units)
         config = importer_mocks.get_basic_config()
-        config.plugin_config['recursive'] = True
-        config.plugin_config['resolve_dependencies'] = True
+        config.override_config['recursive'] = True
+        config.override_config['resolve_dependencies'] = True
         importer = YumImporter()
         # Test
         result = importer.import_units(repoA, repoB, conduit, config, units)


### PR DESCRIPTION
Removed hard coded importer config options in unit association manager.
Pass config_override as argument instead.
Update unit tests.
Update REST docs.
Options: resolve_dependencies and recursive default to (false) in the importer.
