### PR TITLE
fixing role removal api doc

### DIFF
--- a/docs/sphinx/rest-api/role/cud.rst
+++ b/docs/sphinx/rest-api/role/cud.rst
@@ -145,7 +145,7 @@ Remove a User from a Role
 
 Removes a user from an existing role. 
 
-| :method:`post`
+| :method:`delete`
 | :path:`/v2/roles/<role_id>/users/<user_login>`
 | :permission:`delete`
 | :param_list:`post`


### PR DESCRIPTION
Removes a user from an existing role actually uses a delete method, not a post method.  
