### PR TITLE
854238 - creating a category without a group can cause the pkggroupids t...

### DIFF
--- a/rpm-support/src/pulp_rpm/yum_plugin/comps_util.py
+++ b/rpm-support/src/pulp_rpm/yum_plugin/comps_util.py
@@ -156,7 +156,7 @@ def dict_to_yum_category(obj, category_id=None):
         cat.translated_name[key] = obj['translated_name'][key]
     for key in obj['translated_description']:
         cat.translated_description[key] = obj['translated_description'][key]
-    for groupid in obj['packagegroupids']:
+    for groupid in obj['packagegroupids'] or []:
         cat._groups[groupid] = groupid
     return cat
 


### PR DESCRIPTION
...o be None; default to empty list if pkggroupids is None

https://bugzilla.redhat.com/show_bug.cgi?id=854238
