### PR TITLE
871952 - Hardened the distributor code so the clean up occurs

### DIFF
--- a/platform/src/pulp/server/managers/repo/cud.py
+++ b/platform/src/pulp/server/managers/repo/cud.py
@@ -158,14 +158,22 @@ class RepoManager(object):
         # error block. That call will take care of all of the cleanup.
         distributor_manager = manager_factory.repo_distributor_manager()
 
+        if not isinstance(distributor_list, (list, tuple)):
+            self.delete_repo(repo_id)
+            raise InvalidValue(['distributor_list'])
+
         for distributor in distributor_list or []:
-            # Don't bother with any validation here, the manager will run it
-            type_id = distributor.get('distributor_type')
-            plugin_config = distributor.get('distributor_config')
-            auto_publish = distributor.get('auto_publish', False)
-            distributor_id = distributor.get('distributor_id')
+            if not isinstance(distributor, dict):
+                self.delete_repo(repo_id)
+                raise InvalidValue(['distributor_list'])
 
             try:
+                # Don't bother with any validation here, the manager will run it
+                type_id = distributor.get('distributor_type')
+                plugin_config = distributor.get('distributor_config')
+                auto_publish = distributor.get('auto_publish', False)
+                distributor_id = distributor.get('distributor_id')
+
                 distributor_manager.add_distributor(repo_id, type_id, plugin_config, auto_publish, distributor_id)
             except Exception, e:
                 _LOG.exception('Exception adding distributor to repo [%s]; the repo will be deleted' % repo_id)

--- a/platform/test/unit/test_repo_manager.py
+++ b/platform/test/unit/test_repo_manager.py
@@ -228,6 +228,44 @@ class RepoManagerTests(base.PulpAsyncServerTests):
         # Cleanup
         mock_plugins.MOCK_DISTRIBUTOR.validate_config.return_value = True
 
+    def test_create_and_configure_non_list_distributor_list(self):
+        """
+        Tests cleanup is successful if the distributor list is malformed.
+        """
+
+        # Test
+        distributors = 'bad data'
+
+        # Verify
+        try:
+            self.manager.create_and_configure_repo('repo-1', distributor_list=distributors)
+            self.fail()
+        except exceptions.InvalidValue, e:
+            self.assertEqual(e.property_names[0], 'distributor_list')
+
+        # Verify the repo was deleted
+        repo = Repo.get_collection().find_one({'id' : 'repo-1'})
+        self.assertTrue(repo is None)
+
+    def test_create_and_configure_bad_distributor_in_list(self):
+        """
+        Tests cleanup is successful if the distributor list is malformed.
+        """
+
+        # Test
+        distributors = ['bad-data']
+
+        # Verify
+        try:
+            self.manager.create_and_configure_repo('repo-1', distributor_list=distributors)
+            self.fail()
+        except exceptions.InvalidValue, e:
+            self.assertEqual(e.property_names[0], 'distributor_list')
+
+        # Verify the repo was deleted
+        repo = Repo.get_collection().find_one({'id' : 'repo-1'})
+        self.assertTrue(repo is None)
+
     def test_create_i18n(self):
         # Setup
         i18n_text = 'Brasília'


### PR DESCRIPTION
This wasn't as bad off as I had anticipated. The rollback logic was there, but didn't account for a malformed request, only the distributor configuration validation failures. Added checks in case the REST caller submits a request in an invalid format, which is what Preethi was seeing (the Puppet CLI was using the old API signature).
