### PR TITLE
876662 - Added middleware exception handling for when the client cannot

### DIFF
--- a/platform/test/unit/test_client_exception_handler.py
+++ b/platform/test/unit/test_client_exception_handler.py
@@ -11,10 +11,10 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+from _socket import gaierror
 from M2Crypto.SSL.Checker import WrongHost
 
 import base
-
 import pulp.bindings.exceptions as exceptions
 from pulp.client.extensions.core import TAG_FAILURE, TAG_PARAGRAPH
 import pulp.client.extensions.exceptions as handler
@@ -78,6 +78,18 @@ class ExceptionsLoaderTest(base.PulpClientTests):
 
         code = self.exception_handler.handle_exception(InvalidConfig('Test Message'))
         self.assertEqual(code, handler.CODE_INVALID_CONFIG)
+        self.assertEqual(1, len(self.prompt.tags))
+        self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
+        self.prompt.tags = []
+
+        code = self.exception_handler.handle_exception(WrongHost('expected', 'actual'))
+        self.assertEqual(code, handler.CODE_WRONG_HOST)
+        self.assertEqual(1, len(self.prompt.tags))
+        self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
+        self.prompt.tags = []
+
+        code = self.exception_handler.handle_exception(gaierror())
+        self.assertEqual(code, handler.CODE_UNKNOWN_HOST)
         self.assertEqual(1, len(self.prompt.tags))
         self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
         self.prompt.tags = []
@@ -254,6 +266,21 @@ class ExceptionsLoaderTest(base.PulpClientTests):
         self.assertEqual(code, handler.CODE_WRONG_HOST)
         self.assertTrue(expected in self.recorder.lines[0])
         self.assertTrue(actual in self.recorder.lines[0])
+        self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
+
+    def test_unknown_host(self):
+        """
+        Tests the case where the client is configured with a host that cannot
+        be resolved.
+        """
+
+        # Test
+        e = gaierror()
+        code = self.exception_handler.handle_unknown_host(e)
+
+        # Verify
+        self.assertEqual(code, handler.CODE_UNKNOWN_HOST)
+        self.assertTrue(self.config['server']['host'] in self.recorder.lines[0])
         self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
 
     def test_unexpected(self):


### PR DESCRIPTION
resolve the server hostname

Preethi went to validate the original point of that bug and used a totally fake value. That caused a still masked exception that we could do a better job on. This request is that better job.

https://bugzilla.redhat.com/show_bug.cgi?id=876662
