### PR TITLE
881120 - strip the private key from returned consumer object.

### DIFF
--- a/platform/src/pulp/server/managers/consumer/cud.py
+++ b/platform/src/pulp/server/managers/consumer/cud.py
@@ -89,7 +89,6 @@ class ConsumerManager(object):
         Consumer.get_collection().save(create_me, safe=True)
 
         factory.consumer_history_manager().record_event(id, 'consumer_registered')
-        create_me.certificate = Bundle.join(key, crt)
         return create_me
 
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=881120
