### PR TITLE
866491 - Use correct HTTP response codes for bad data on unit copy

### DIFF
--- a/platform/src/pulp/server/webservices/controllers/repositories.py
+++ b/platform/src/pulp/server/webservices/controllers/repositories.py
@@ -844,11 +844,16 @@ class RepoAssociate(JSONController):
         if source_repo_id is None:
             raise exceptions.MissingValue(['source_repo_id'])
 
-        # Make sure both repositories exist before triggering the task, causing
-        # a 404 instead of letting the task fail
+        # A 404 only applies to things in the URL, so the destination repo
+        # check allows the MissingResource to bubble up, but if the source
+        # repo doesn't exist, it's considered bad data.
         repo_query_manager = manager_factory.repo_query_manager()
         repo_query_manager.get_repository(dest_repo_id)
-        repo_query_manager.get_repository(source_repo_id)
+
+        try:
+            repo_query_manager.get_repository(source_repo_id)
+        except exceptions.MissingResource:
+            raise exceptions.InvalidValue(['source_repo_id'])
 
         criteria = params.get('criteria', None)
         if criteria is not None:

--- a/platform/test/unit/server/test_repo_controller.py
+++ b/platform/test/unit/server/test_repo_controller.py
@@ -1354,7 +1354,7 @@ class RepoAssociateTests(RepoControllersTests):
 
         status, body = self.post('/v2/repositories/dest-repo-1/actions/associate/', params=params)
 
-        self.assertEqual(404, status)
+        self.assertEqual(400, status)
 
     def test_post_unparsable_criteria(self):
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=866491

There is a corresponding pull request over in pulp_rpm and pulp_puppet for client-side changes to accomodate the invalid source repo situation.
