### PR TITLE
Revert "881120 - strip the private key from returned consumer object."

### DIFF
--- a/platform/src/pulp/server/managers/consumer/cud.py
+++ b/platform/src/pulp/server/managers/consumer/cud.py
@@ -89,6 +89,7 @@ class ConsumerManager(object):
         Consumer.get_collection().save(create_me, safe=True)
 
         factory.consumer_history_manager().record_event(id, 'consumer_registered')
+        create_me.certificate = Bundle.join(key, crt)
         return create_me
 
 


### PR DESCRIPTION
This reverts commit d0cc5c4cd02b14ff680f00b4f9b5b68313e3c47e.

This patch breaks registration.  The created consumer containing both the key and certificate needs to be returned to pulp-consumer (caller).  This is how it gets on the consumer to begin with :)
