### PR TITLE
883042 - add pulp-selinux to pulp-server comps group.

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -8,6 +8,7 @@
       <packagereq type="mandatory">pulp-server</packagereq>
       <packagereq type="default">pulp-rpm-plugins</packagereq>
       <packagereq type="default">pulp-puppet-plugins</packagereq>
+      <packagereq type="default">pulp-selinux</packagereq>
     </packagelist>
   </group>
   <group>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=883042
