### PR TITLE
jdob 866996

### DIFF
--- a/platform/src/pulp/client/commands/criteria.py
+++ b/platform/src/pulp/client/commands/criteria.py
@@ -247,19 +247,19 @@ class CriteriaCommand(PulpCliCommand):
 
 
 class UnitAssociationCriteriaCommand(CriteriaCommand):
+    """
+    Provides the full suite of criteria flags plus those relevant only when
+    specifying unit associations. This command should be used in cases where
+    the command is trying to capture a set of unit associations to act on.
+    By comparison, if the command is looking to display unit associations to
+    the user, the DisplayUnitAssociationsCommand is preferred as it adds
+    display-specific flags to these.
+    """
 
-    ASSOCIATION_FLAG = PulpCliFlag(
-        '--details', _('show association details'), aliases=['-d'])
-
-    def __init__(self, method, with_details=True, *args, **kwargs):
+    def __init__(self, method, *args, **kwargs):
         """
-
         @param method: method that should be invoked when the command is executed
         @type  method: callable
-        @param with_details: if true, a standard flag for indicating to display
-               details about the associations is displayed; this would be set
-               to false for commands that are not search related
-        @type  with_details: bool
         """
         super(UnitAssociationCriteriaCommand, self).__init__(method, *args, **kwargs)
 
@@ -276,13 +276,25 @@ class UnitAssociationCriteriaCommand(CriteriaCommand):
         self.create_option('--before', m, ['-b'], required=False,
             allow_multiple=False, parse_func=parsers.iso8601)
 
-        if with_details:
-            self.add_flag(self.ASSOCIATION_FLAG)
 
+class DisplayUnitAssociationsCommand(UnitAssociationCriteriaCommand):
+    """
+    Provides the full suite of unit association criteria flags along with
+    extra flags to control the output of what will be displayed about the
+    associations. The typical usage of this command is when searching or
+    displaying unit associations to the user.
+    """
 
-class UntypedUnitAssociationCriteriaCommand(UnitAssociationCriteriaCommand):
-    def __init__(self, *args, **kwargs):
-        kwargs['filtering'] = False
-        super(UntypedUnitAssociationCriteriaCommand, self).__init__(*args, **kwargs)
-        OPTIONS_TO_REMOVE = set(['--sort', '--fields'])
-        self.options = [opt for opt in self.options if opt.name not in OPTIONS_TO_REMOVE]
+    ASSOCIATION_FLAG = PulpCliFlag(
+        '--details', _('show association details'), aliases=['-d'])
+
+    def __init__(self, method, *args, **kwargs):
+        super(DisplayUnitAssociationsCommand, self).__init__(
+            method, *args, **kwargs
+        )
+
+        # If we support more than just the details flag in the future, those
+        # options will be added here
+
+        self.add_flag(self.ASSOCIATION_FLAG)
+

--- a/platform/src/pulp/client/commands/unit.py
+++ b/platform/src/pulp/client/commands/unit.py
@@ -22,7 +22,7 @@ from pulp.client.extensions.extensions import PulpCliCommand, PulpCliOption, Pul
 class UnitCopyCommand(UnitAssociationCriteriaCommand):
     def __init__(self, method, *args, **kwargs):
         kwargs['include_search'] = False
-        super(UnitCopyCommand, self).__init__(method, with_details=False, *args, **kwargs)
+        super(UnitCopyCommand, self).__init__(method, *args, **kwargs)
         self.options = [opt for opt in self.options if opt.name != '--repo-id']
 
         m = 'source repository from which units will be copied'

--- a/platform/test/unit/test_search_command.py
+++ b/platform/test/unit/test_search_command.py
@@ -16,7 +16,9 @@ import unittest
 import mock
 from okaara.cli import CommandUsage
 
-from pulp.client.commands.criteria import CriteriaCommand, UnitAssociationCriteriaCommand, UntypedUnitAssociationCriteriaCommand
+from pulp.client.commands.criteria import (CriteriaCommand,
+                                           DisplayUnitAssociationsCommand,
+                                           UnitAssociationCriteriaCommand)
 
 class TestCriteriaCommand(unittest.TestCase):
     OPTION_NAMES = set(('--limit', '--skip', '--filters', '--fields',
@@ -130,31 +132,24 @@ class TestUnitAssociationCriteriaCommand(unittest.TestCase):
         self.assertTrue('--after' in options_present)
         self.assertTrue('--before' in options_present)
         self.assertTrue('--repo-id' in options_present)
-        self.assertTrue('--details' in options_present)
-
-    def test_command_presence_without_details(self):
-        self.command = UnitAssociationCriteriaCommand(mock.MagicMock(), with_details=False)
-
-        options_present = set([option.name for option in self.command.options])
-        self.assertTrue('--after' in options_present)
-        self.assertTrue('--before' in options_present)
-        self.assertTrue('--repo-id' in options_present)
-        self.assertTrue('--details' not in options_present)
 
     def test_inherits_search(self):
         # make sure this inherits features that were tested elsewhere.
         self.assertTrue(isinstance(self.command, CriteriaCommand))
 
 
-class TestUnitSearchAllCommand(unittest.TestCase):
+class TestDisplayUnitAssociationsCommand(unittest.TestCase):
     def setUp(self):
-        self.command = UntypedUnitAssociationCriteriaCommand(mock.MagicMock())
+        self.command = DisplayUnitAssociationsCommand(mock.MagicMock())
 
     def test_command_presence(self):
         options_present = set([option.name for option in self.command.options])
-        self.assertTrue('--sort' not in options_present)
-        self.assertTrue('--fields' not in options_present)
+        self.assertTrue('--after' in options_present)
+        self.assertTrue('--before' in options_present)
+        self.assertTrue('--repo-id' in options_present)
+        self.assertTrue('--details' in options_present)
 
     def test_inherits_search(self):
         # make sure this inherits features that were tested elsewhere.
-        self.assertTrue(isinstance(self.command, UnitAssociationCriteriaCommand))
+        self.assertTrue(isinstance(self.command, CriteriaCommand))
+


### PR DESCRIPTION
New plan: Make a differentiation at the abstraction as to if the command is a unit association specification command or a unit association query one.

https://bugzilla.redhat.com/show_bug.cgi?id=866996

This change meant changing the search command subclasses in rpm and puppet, so check those out too.
