### PR TITLE
882403 - Flushed out the task state to user display mapping as was

### DIFF
--- a/platform/src/pulp/bindings/responses.py
+++ b/platform/src/pulp/bindings/responses.py
@@ -177,6 +177,15 @@ class Task(object):
         """
         return self.state == STATE_ERROR
 
+    def was_skipped(self):
+        """
+        Indicates if a task was skipped. If the task is not finished, this call
+        returns False
+
+        :rtype: bool
+        """
+        return self.state == STATE_SKIPPED
+
     def was_cancelled(self):
         """
         Indicates if a task was cancelled.


### PR DESCRIPTION
always the intention but never actually came to fruition.

There aren't unit tests for this commit. There weren't any to begin with for this extension. The contents of it eventually need to get pulled into pulp.client, at which point it'll be easier to test instead of having to jump through source path munging.

I'm less concerned with the mechanics of the code than I am the logic I'm applying to the task information. That's not to say it doesn't need to be unit tested, just that I don't believe the code to be risky in the sense that it'll crash and the bigger issue will be in my interpretation of the data.

https://bugzilla.redhat.com/show_bug.cgi?id=882403
