### PR TITLE
885128 - pulp.plugins.loader.api should use the "db" logger.

### DIFF
--- a/platform/src/pulp/plugins/loader/api.py
+++ b/platform/src/pulp/plugins/loader/api.py
@@ -22,7 +22,7 @@ from pulp.plugins.profiler import Profiler
 from pulp.plugins.types import database, parser
 from pulp.plugins.types.model import TypeDescriptor
 
-_LOG = logging.getLogger(__name__)
+_LOG = logging.getLogger('db')
 
 # implicit singleton instance of PluginManager
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=885128
