### PR TITLE
making "auth" command description more consistent with other description...

### DIFF
--- a/builtins/extensions/admin/pulp_auth/pulp_cli.py
+++ b/builtins/extensions/admin/pulp_auth/pulp_cli.py
@@ -45,7 +45,7 @@ class AuthSection(PulpCliSection):
         @param context: pre-populated context that is given to the extensions by loader
         @type  context: pulp.client.extensions.core.ClientContext
         """
-        PulpCliSection.__init__(self, 'auth', _('user, role and permission commands'))
+        PulpCliSection.__init__(self, 'auth', _('manage users, roles and permissions'))
 
         self.context = context
         self.prompt = context.prompt # for easier access

--- a/builtins/extensions/admin/pulp_binding/pulp_cli.py
+++ b/builtins/extensions/admin/pulp_binding/pulp_cli.py
@@ -30,7 +30,7 @@ class BindingSection(PulpCliSection):
         """
         :type  context: pulp.client.extensions.core.ClientContext
         """
-        PulpCliSection.__init__(self, 'bindings', _('search bindings'))
+        PulpCliSection.__init__(self, 'bindings', _('search consumer bindings'))
         self.context = context
         # search
         self.add_command(Search(context))


### PR DESCRIPTION
...s by including a verb.

clarifying that the "bindings" command pertains to consumers

https://bugzilla.redhat.com/show_bug.cgi?id=868022
