### PR TITLE
895209 - Add Obsoletes: pulp-selinux-server to pulp-selinux sub-package.

### DIFF
--- a/platform/pulp.spec
+++ b/platform/pulp.spec
@@ -365,6 +365,7 @@ BuildRequires:  make
 BuildRequires:  checkpolicy
 BuildRequires:  selinux-policy-devel
 BuildRequires:  hardlink
+Obsoletes: pulp-selinux-server
 
 %if "%{selinux_policyver}" != ""
 Requires: selinux-policy >= %{selinux_policyver}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=895209
