### PR TITLE
888058 - Changed model for the client-side exception handler to be

### DIFF
--- a/platform/bin/pulp-admin
+++ b/platform/bin/pulp-admin
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Pulp client utility
-# Copyright (c) 2010 Red Hat, Inc.
+# Copyright (c) 2010-2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -13,24 +13,9 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-#
 
-import os
-import sys
+from pulp.client.clients.admin import main
 
-import pulp.client.launcher
 
-if __name__ == "__main__":
-    # Default static config
-    config_files = ['/etc/pulp/admin/admin.conf']
-
-    # Any conf.d entries
-    conf_d_dir = '/etc/pulp/admin/conf.d'
-    config_files += [os.path.join(conf_d_dir, i) for i in sorted(os.listdir(conf_d_dir))]
-
-    # Local user overrides
-    override = os.path.expanduser('~/.pulp/admin.conf')
-    if os.path.exists(override):
-        config_files.append(override)
-
-    sys.exit(pulp.client.launcher.main(config_files))
+if __name__ == '__main__':
+    main()

--- a/platform/bin/pulp-consumer
+++ b/platform/bin/pulp-consumer
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
 # Pulp client utility
-# Copyright (c) 2012 Red Hat, Inc.
+# Copyright (c) 2012-2013 Red Hat, Inc.
 #
 # This software is licensed to you under the GNU General Public License,
 # version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -13,24 +13,9 @@
 # Red Hat trademarks are not licensed under GPLv2. No permission is
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
-#
 
-import os
-import sys
+from pulp.client.clients.consumer import main
 
-import pulp.client.launcher
 
-if __name__ == "__main__":
-    # Default static config
-    config_files = ['/etc/pulp/consumer/consumer.conf']
-
-    # Any conf.d entries
-    conf_d_dir = '/etc/pulp/consumer/conf.d'
-    config_files += [os.path.join(conf_d_dir, i) for i in sorted(os.listdir(conf_d_dir))]
-
-    # Local user overrides
-    override = os.path.expanduser('~/.pulp/consumer.conf')
-    if os.path.exists(override):
-        config_files.append(override)
-
-    sys.exit(pulp.client.launcher.main(config_files))
+if __name__ == '__main__':
+    main()

--- a/platform/src/pulp/client/clients/__init__.py
+++ b/platform/src/pulp/client/clients/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.

--- a/platform/src/pulp/client/clients/admin.py
+++ b/platform/src/pulp/client/clients/admin.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+from gettext import gettext as _
+import os
+import sys
+
+from M2Crypto import X509
+
+import pulp.client.launcher
+from pulp.client.extensions.exceptions import ExceptionHandler, CODE_PERMISSIONS_EXCEPTION
+
+
+# -- admin client overrides ---------------------------------------------------
+
+class AdminExceptionHandler(ExceptionHandler):
+
+    def handle_permission(self, e):
+        """
+        Handles an authentication error from the server.
+
+        @return: appropriate exit code for this error
+        """
+
+        self._log_client_exception(e)
+
+        msg = _('Authentication Failed')
+
+        # If the certificate exists, parse the expiration date
+        id_cert_dir = self.config['filesystem']['id_cert_dir']
+        id_cert_dir = os.path.expanduser(id_cert_dir)
+        id_cert_name = self.config['filesystem']['id_cert_filename']
+        full_cert_path = os.path.join(id_cert_dir, id_cert_name)
+
+        expiration_date = None
+        try:
+            f = open(full_cert_path, 'r')
+            certificate = f.read()
+            f.close()
+
+            certificate_section = str(certificate[certificate.index('-----BEGIN CERTIFICATE'):])
+            x509_cert = X509.load_cert_string(certificate_section)
+            expiration_date = x509_cert.get_not_after()
+        except Exception:
+            # Leave the expiration_date as None and show generic login message
+            pass
+
+        if expiration_date:
+            desc = _('The session certificate expired on %(e)s. Use the login '
+                     'command to begin a new session.')
+            desc = desc % {'e' : expiration_date}
+        else:
+            desc = _('Use the login command to authenticate with the server and '
+                     'download a session certificate for use in future calls to this script. '
+                     'If credentials were specified, please double check the username and '
+                     'password and attempt the request again.')
+            desc = desc
+
+        self.prompt.render_failure_message(msg)
+        self.prompt.render_paragraph(desc)
+
+        return CODE_PERMISSIONS_EXCEPTION
+
+# -- script execution ---------------------------------------------------------
+
+def main():
+    # Default static config
+    config_files = ['/etc/pulp/admin/admin.conf']
+
+    # Any conf.d entries
+    conf_d_dir = '/etc/pulp/admin/conf.d'
+    config_files += [os.path.join(conf_d_dir, i) for i in sorted(os.listdir(conf_d_dir))]
+
+    # Local user overrides
+    override = os.path.expanduser('~/.pulp/admin.conf')
+    if os.path.exists(override):
+        config_files.append(override)
+
+    exit_code = pulp.client.launcher.main(
+        config_files, exception_handler_class=AdminExceptionHandler
+    )
+    sys.exit(exit_code)

--- a/platform/src/pulp/client/clients/consumer.py
+++ b/platform/src/pulp/client/clients/consumer.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+from gettext import gettext as _
+import os
+import sys
+
+import pulp.client.launcher
+from pulp.client.extensions.exceptions import ExceptionHandler, CODE_PERMISSIONS_EXCEPTION
+
+
+# -- consumer client overrides ------------------------------------------------
+
+class ConsumerExceptionHandler(ExceptionHandler):
+
+    def handle_permission(self, e):
+        """
+        For this script, the register command is used and requires a valid user
+        on the server to authenticate against. This override is used to tailor
+        the displayed error message to that behavior.
+        """
+
+        self._log_client_exception(e)
+
+        msg = _('Authentication Failed')
+
+        desc = _('A valid Pulp user is required to register a new consumer. '
+                 'Please double check the username and password and attempt the '
+                 'request again.')
+
+        self.prompt.render_failure_message(msg)
+        self.prompt.render_paragraph(desc)
+
+        return CODE_PERMISSIONS_EXCEPTION
+
+# -- script execution ---------------------------------------------------------
+
+def main():
+    # Default static config
+    config_files = ['/etc/pulp/consumer/consumer.conf']
+
+    # Any conf.d entries
+    conf_d_dir = '/etc/pulp/consumer/conf.d'
+    config_files += [os.path.join(conf_d_dir, i) for i in sorted(os.listdir(conf_d_dir))]
+
+    # Local user overrides
+    override = os.path.expanduser('~/.pulp/consumer.conf')
+    if os.path.exists(override):
+        config_files.append(override)
+
+    exit_code = pulp.client.launcher.main(
+        config_files, exception_handler_class=ConsumerExceptionHandler
+    )
+    sys.exit(exit_code)

--- a/platform/src/pulp/client/launcher.py
+++ b/platform/src/pulp/client/launcher.py
@@ -34,7 +34,7 @@ from   pulp.common.config import Config
 
 # -- main execution -----------------------------------------------------------
 
-def main(config_filenames):
+def main(config_filenames, exception_handler_class=ExceptionHandler):
     """
     Entry point into the launcher. Any extra necessary values will be pulled
     from the given configuration files.
@@ -69,7 +69,7 @@ def main(config_filenames):
 
     # General UI pieces
     prompt = _create_prompt(config)
-    exception_handler = ExceptionHandler(prompt, config)
+    exception_handler = exception_handler_class(prompt, config)
 
     # REST Bindings
     username = options.username

--- a/platform/test/unit/test_admin_exception_handler.py
+++ b/platform/test/unit/test_admin_exception_handler.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+from pulp.client.clients.admin import AdminExceptionHandler
+
+from pulp.client.extensions import exceptions
+from pulp.client.extensions.core import TAG_FAILURE, TAG_PARAGRAPH
+
+import base
+
+class AdminExceptionHandlerTests(base.PulpClientTests):
+
+    def setUp(self):
+        super(AdminExceptionHandlerTests, self).setUp()
+
+        self.handler = AdminExceptionHandler(self.prompt, self.config)
+
+    def test_permission(self):
+        """
+        Tests a client-side error when the connection is rejected due to auth reasons.
+        """
+
+        # Test
+        e = exceptions.PermissionsException()
+        code = self.handler.handle_permission(e)
+
+        # Verify
+        self.assertEqual(code, exceptions.CODE_PERMISSIONS_EXCEPTION)
+        self.assertTrue('Authentication' in self.recorder.lines[0])
+        self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
+        self.assertTrue('certificate' in self.recorder.lines[2]) # skip blank line
+        self.assertEqual(TAG_PARAGRAPH, self.prompt.get_write_tags()[1])
+

--- a/platform/test/unit/test_client_exception_handler.py
+++ b/platform/test/unit/test_client_exception_handler.py
@@ -65,9 +65,8 @@ class ExceptionsLoaderTest(base.PulpClientTests):
 
         code = self.exception_handler.handle_exception(exceptions.PermissionsException({}))
         self.assertEqual(code, handler.CODE_PERMISSIONS_EXCEPTION)
-        self.assertEqual(2, len(self.prompt.tags))
+        self.assertEqual(1, len(self.prompt.tags))
         self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
-        self.assertEqual(TAG_PARAGRAPH, self.prompt.get_write_tags()[1])
         self.prompt.tags = []
 
         code = self.exception_handler.handle_exception(exceptions.PulpServerException({}))
@@ -227,9 +226,9 @@ class ExceptionsLoaderTest(base.PulpClientTests):
         self.assertEqual(code, handler.CODE_CONNECTION_EXCEPTION)
         self.assertTrue('contact the server' in self.recorder.lines[0])
 
-    def test_permission(self):
+    def test_permissions(self):
         """
-        Tests a client-side error when the connection is rejected due to auth reasons.
+        Tests a client-side permissions error.
         """
 
         # Test
@@ -238,10 +237,7 @@ class ExceptionsLoaderTest(base.PulpClientTests):
 
         # Verify
         self.assertEqual(code, handler.CODE_PERMISSIONS_EXCEPTION)
-        self.assertTrue('Authentication' in self.recorder.lines[0])
-        self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
-        self.assertTrue('certificate' in self.recorder.lines[2]) # skip blank line
-        self.assertEqual(TAG_PARAGRAPH, self.prompt.get_write_tags()[1])
+        self.assertTrue('specified user' in self.recorder.lines[0])
 
     def test_invalid_config(self):
         """

--- a/platform/test/unit/test_consumer_exception_handler.py
+++ b/platform/test/unit/test_consumer_exception_handler.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# This software is licensed to you under the GNU General Public
+# License as published by the Free Software Foundation; either version
+# 2 of the License (GPLv2) or (at your option) any later version.
+# There is NO WARRANTY for this software, express or implied,
+# including the implied warranties of MERCHANTABILITY,
+# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+# have received a copy of GPLv2 along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+from pulp.client.clients.consumer import ConsumerExceptionHandler
+
+from pulp.client.extensions import exceptions
+from pulp.client.extensions.core import TAG_FAILURE, TAG_PARAGRAPH
+
+import base
+
+class ConsumerExceptionHandlerTests(base.PulpClientTests):
+
+    def setUp(self):
+        super(ConsumerExceptionHandlerTests, self).setUp()
+
+        self.handler = ConsumerExceptionHandler(self.prompt, self.config)
+
+    def test_permission(self):
+        """
+        Tests a client-side error when the connection is rejected due to auth reasons.
+        """
+
+        # Test
+        e = exceptions.PermissionsException()
+        code = self.handler.handle_permission(e)
+
+        # Verify
+        self.assertEqual(code, exceptions.CODE_PERMISSIONS_EXCEPTION)
+        self.assertTrue('Authentication' in self.recorder.lines[0])
+        self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
+        self.assertTrue('A valid' in self.recorder.lines[2]) # skip blank line
+        self.assertEqual(TAG_PARAGRAPH, self.prompt.get_write_tags()[1])
+


### PR DESCRIPTION
overridden and specified to the launcher, allowing an individual client
(admin, consumer, future other) to customize error messages where
relevant.
- Moved the little logic that was in pulp-admin/pulp-consumer to a new package in pulp.client. This was mostly to give me a place to put the client-specific exception middleware and easily test them without all sorts of jumping through import hoops. And obviously, it's cleaner.
- admin and consumer aren't the only clients we'll ever necessarily have. One on the radar would be to work with Katello's disconnected case, which would be a client tuned towards reading a manifest and exporting the repos from it as ISOs. Given that, I feel even better about this approach of making the default exception middleware very generic (there are possibly ways to tune this further) and having the client tweak messages as appropriate.
