### PR TITLE
905588 - Adding "puppet_module" as an example unit type.

### DIFF
--- a/platform/src/pulp/client/commands/unit.py
+++ b/platform/src/pulp/client/commands/unit.py
@@ -75,7 +75,7 @@ class UnitRemoveCommand(UnitAssociationCriteriaCommand):
 
 
 type_option = PulpCliOption('--type',
-    _('restrict to one content type such as "rpm", "errata", etc.'),
+    _('restrict to one content type such as "rpm", "errata", "puppet_module", etc.'),
     required=False)
 unit_id_option = PulpCliOption('--unit-id',
     _('ID of a content unit. If specified, you must also specify a type'),


### PR DESCRIPTION
This should not become a list of every possible unit type, but it's not unreasonable here to include some mention of puppet modules.

https://bugzilla.redhat.com/show_bug.cgi?id=905588
