### PR TITLE
906426 - Create the upload directory in case someone deletes it

### DIFF
--- a/platform/src/pulp/server/managers/content/upload.py
+++ b/platform/src/pulp/server/managers/content/upload.py
@@ -256,8 +256,14 @@ class ContentUploadManager(object):
         files. This is necessary as a dynamic call so unit tests have the
         opportunity to change the constants entry for local storage.
 
+        This call will create the directory if it doesn't exist.
+
         @return: full path to the upload directory
         """
         storage_dir = pulp_config.config.get('server', 'storage_dir')
         upload_storage_dir = os.path.join(storage_dir, 'uploads')
+
+        if not os.path.exists(upload_storage_dir):
+            os.makedirs(upload_storage_dir)
+
         return upload_storage_dir

--- a/platform/test/unit/server/test_content_upload_manager.py
+++ b/platform/test/unit/server/test_content_upload_manager.py
@@ -36,15 +36,12 @@ class ContentUploadManagerTests(base.PulpServerTests):
         self.repo_manager = manager_factory.repo_manager()
         self.importer_manager = manager_factory.repo_importer_manager()
 
-        upload_storage_dir = self.upload_manager._upload_storage_dir()
-
-        if os.path.exists(upload_storage_dir):
-            shutil.rmtree(upload_storage_dir)
-        os.makedirs(upload_storage_dir)
-
     def tearDown(self):
         base.PulpServerTests.tearDown(self)
         mock_plugins.reset()
+
+        upload_storage_dir = self.upload_manager._upload_storage_dir()
+        shutil.rmtree(upload_storage_dir)
 
     def clean(self):
         base.PulpServerTests.clean(self)
@@ -229,9 +226,26 @@ class ContentUploadManagerTests(base.PulpServerTests):
         self.repo_manager.create_repo('repo-u')
         self.importer_manager.set_importer('repo-u', 'mock-importer', {})
 
-        mock_plugins.MOCK_IMPORTER.upload_unit.side_effect = InvalidValue('filename')
+        mock_plugins.MOCK_IMPORTER.upload_unit.side_effect = InvalidValue(['filename'])
 
         upload_id = self.upload_manager.initialize_upload()
 
         # Test
         self.assertRaises(InvalidValue, self.upload_manager.import_uploaded_unit, 'repo-u', 'mock-type', {}, {}, upload_id)
+
+    # -- util method tests -----------------------------------------------------
+
+    def test_upload_dir_auto_created(self):
+        # Setup
+
+        # Make sure it definitely doesn't exist before calling this
+        upload_storage_dir = self.upload_manager._upload_storage_dir()
+        shutil.rmtree(upload_storage_dir)
+
+        # Test
+        upload_storage_dir = self.upload_manager._upload_storage_dir()
+
+        # Verify
+        self.assertTrue(os.path.exists(upload_storage_dir))
+
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=906426

The change to the exception in a different test was simply because the constructor changed and it was being flagged as passing an invalid value. It had no relevance on this change.
