### PR TITLE
Distributor dev guide implementation

### DIFF
--- a/docs/sphinx/dev-guide/newtypesupport/plugin/common.rst
+++ b/docs/sphinx/dev-guide/newtypesupport/plugin/common.rst
@@ -13,7 +13,7 @@ It is up to the plugin writer to determine what configuration values are necessa
 plugin to function.
 
 Pulp performs no validation on the configuration for a plugin. The ``validate_config``
-method in the each plugin subclass is used to verify the user-entered values for a repository.
+method in each plugin subclass is used to verify the user-entered values for a repository.
 This is called when the plugin is first added to the repository and on all subsequent
 configuration changes. The configuration is sent to the Pulp server as a JSON document through its
 REST APIs and will be deserialized before being passed to the plugin.

--- a/docs/sphinx/dev-guide/newtypesupport/plugin/distributors.rst
+++ b/docs/sphinx/dev-guide/newtypesupport/plugin/distributors.rst
@@ -7,7 +7,7 @@ Overview
 While an :doc:`importer <importers>` is responsible for bringing content into a repository, a
 distributor is used to expose that content from the Pulp server. The specifics for what it means
 to expose the repository, performed through an operation referred to as *publishing*, is
-dependent on the distributor's implementation. Publishing examples include serving the repository
+dependent on the distributor's goals. Publishing examples include serving the repository
 over HTTP/HTTPS, packaging it as an ISO, or using rsync to transfer it into a legacy system.
 
 Operations cannot be performed on a distributor until it is attached to a repository. When adding
@@ -70,11 +70,11 @@ Publish a Repository
 
 Methods: ``publish_repo``, ``cancel_publish_repo``
 
-The distributor's role in publishing a repository is to take the units currently in the repository,
-be it from a sync, uploaded, or copied from another repository, and make them available outside of
-the Pulp server. The approach for how that is done will vary based on needs. The typical approach
-is to serve the repository over HTTP/HTTPS. However, it is also possible to use a variety of other
-protocols depending on the nature of the content being served or the specific needs of a deployment.
+The distributor's role in publishing a repository is to take the units currently in the repository and
+make them available outside of the Pulp server. The approach for how that is done will vary based on
+needs. The typical approach is to serve the repository over HTTP/HTTPS. However, it is also possible to
+use a variety of other protocols depending on the nature of the content being served or the specific needs
+of a deployment.
 
 The :term:`conduit` passed to the publish call provides the necessary methods to query the content
 in a repository. In the event a directory of the repository's content must be created, it is
@@ -82,14 +82,15 @@ highly recommended to symlink from the unit's ``storage_path`` rather than copyi
 
 The conduit defines a ``set_progress`` call that should be used throughout the process
 to update the Pulp server with details on what has been accomplished and what remains to be
-done. The Pulp server does not require these calls; they are intended to be displayed to
-the user. The progress message must be JSON-serializable (primitives, lists, dictionaries)
-but is otherwise entirely at the discretion of the plugin writer.
+done. The Pulp server does not require these calls. The progress message must be JSON-serializable
+(primitives, lists, dictionaries) but is otherwise entirely at the discretion of the plugin writer.
+The most recent progress report is saved in the database and made available to users as a means
+to track the progress of the publish.
 
 When implementing the publish functionality, the importer's ``cancel_sync_repo`` method must be
 implemented as well. This call will be made on the same instance performing the publish, therefore
 it is valid to use an instance variable as a flag the publish process uses to determine if it should
-continue to proceed.
+continue.
 
 Consumer Payloads
 ^^^^^^^^^^^^^^^^^

--- a/docs/sphinx/dev-guide/newtypesupport/plugin/importers.rst
+++ b/docs/sphinx/dev-guide/newtypesupport/plugin/importers.rst
@@ -114,9 +114,10 @@ outline of a common sync process.
 
 The conduit defines a ``set_progress`` call that should be used throughout the process
 to update the Pulp server with details on what has been accomplished and what remains to be
-done. The Pulp server does not require these calls; they are intended to be displayed to
-the user. The progress message must be JSON-serializable (primitives, lists, dictionaries)
-but is otherwise entirely at the discretion of the plugin writer.
+done. The Pulp server does not require these calls. The progress message must be JSON-serializable
+(primitives, lists, dictionaries) but is otherwise entirely at the discretion of the plugin writer.
+The most recent progress report is saved in the database and made available to users as a means
+to track the progress of the sync.
 
 When implementing the sync functionality, the importer's ``cancel_sync_repo`` method must be
 implemented as well. This call will be made on the same instance performing the sync, therefore


### PR DESCRIPTION
I figured this would happen, but as part of this I pulled some more things from the importer dev guide into the plugin common area so that both types can just refer to the single description (metadata and validate_config methods).

The example is coming next, so don't be surprised to not find it in here.

It's way shorter than the importer, but there's a lot less the distributor does. At the same time, this was tricky since the possibilities of how a repo is published are so vast. I'm open to suggestions on things I should dig into, especially since I'm starting to suffer from writing overload.
