### PR TITLE
908676 - make pulp-selinux conflict with pulp-selinux-server instead of ...

### DIFF
--- a/platform/pulp.spec
+++ b/platform/pulp.spec
@@ -365,7 +365,7 @@ BuildRequires:  make
 BuildRequires:  checkpolicy
 BuildRequires:  selinux-policy-devel
 BuildRequires:  hardlink
-Obsoletes: pulp-selinux-server
+Conflicts: pulp-selinux-server
 
 %if "%{selinux_policyver}" != ""
 Requires: selinux-policy >= %{selinux_policyver}
@@ -378,20 +378,15 @@ Requires(postun): /usr/sbin/semodule
 %description    selinux
 SELinux policy for Pulp's components
 
-#%post selinux
+%post selinux
 # Enable SELinux policy modules
-#if /usr/sbin/selinuxenabled ; then
-# %{_datadir}/pulp/selinux/server/enable.sh %{_datadir}
-#fi
+if /usr/sbin/selinuxenabled ; then
+ %{_datadir}/pulp/selinux/server/enable.sh %{_datadir}
+fi
 
 # restorcecon wasn't reading new file contexts we added when running under 'post' so moved to 'posttrans'
 # Spacewalk saw same issue and filed BZ here: https://bugzilla.redhat.com/show_bug.cgi?id=505066
 %posttrans selinux
-if [ $1 -gt 1 ]; then
- if /usr/sbin/selinuxenabled ; then
-  %{_datadir}/pulp/selinux/server/enable.sh %{_datadir}
- fi
-fi
 if /usr/sbin/selinuxenabled ; then
  %{_datadir}/pulp/selinux/server/relabel.sh %{_datadir}
 fi


### PR DESCRIPTION
...obsoleting pulp-selinux-server

https://bugzilla.redhat.com/show_bug.cgi?id=908676

Since pulp-selinux-server is renamed to pulp-selinux, update to the latest version from the one in v1.0 is causing %preun steps when removing old pulp-selinux-server to execute and remove policies installed by new pulp-selinux. I tried to find a way around this but there is not easy way around it. Since migrate from v1.0 to v2.x anyway contains other manual steps, I have updated spec file such that we conflict pulp-selinux with pulp-selinux-server instead of obsoleting. If user has pulp-selinux installed, he will have to uninstall it when upgrading to 2.x. 
