### PR TITLE
By default make migrations start at version 0 instead of the latest avai...

### DIFF
--- a/docs/sphinx/dev-guide/newtypesupport/plugin/migrations.rst
+++ b/docs/sphinx/dev-guide/newtypesupport/plugin/migrations.rst
@@ -9,18 +9,8 @@ configure your project's migrations.
 Registration
 ============
 
-Whether or not you plan to write any migrations, it is very important that you configure your project so that
-Pulp's migration system is aware of it. This is important because Pulp only tracks schema versions on projects
-that it knows about, and Pulp will always automatically migrate users to the latest available version the
-first time it becomes aware of any particular project on a user's system. This is done so that new users of
-a project don't need to run historical migrations on their new, empty database. By registering your project
-with Pulp before you have any migrations, you can ensure that anyone who installs your project will be marked
-as being at schema version 0 for your project.
-
-To illustrate why this is important, suppose that you did not register with Pulp's migration system, and
-suppose that some users have installed your package. Now suppose that you do want to make a schema change, so
-you write a migration at version 1. Now when you configure your project to register with Pulp, those users
-will automatically be marked as being at version 1, *without* running the migration for version 1.
+In order to write migrations for your Pulp plugin, you will need to register your plugin's
+migrations package with the Pulp server.
 
 How to Register
 ---------------
@@ -88,13 +78,18 @@ nobody gets hurt. Here are the rules:
    migrated to. It requires your migration versions to start with 1, and to be sequential with no
    gaps in version numbers. For example, 0001_my_first_migration.py, 0002_my_second_migration.py,
    0003_add_email_addresses_to_users.py, etc. You don't have to use leading zeros in the names, as
-   the number is processed with a regular expression that interprets it as an integer, however, the
+   the number is processed with a regular expression that interprets it as an integer. However, the
    advantage to using leading zeros is that programs like ``ls`` will display your migrations in
    order when you inspect the contents of your migration package.
 #. Each migration module should have a function called "migrate" with this signature:
    ``def migrate(*args, **kwargs)``.
 #. Inside your ``migrate()`` function, you can perform the necessary work to change the data in the
    Pulp install.
+#. Your ``migrate()`` function must be written in such a way that it will not fail for a new
+   installation. New installations will start at migration version 0, and all migrations up to the
+   most recent migration will be applied by the system. Therefore, you must not assume that there
+   is data in the database, or on the filesystem. Your migration script should detect what work, if
+   any, needs to be done before performing any operations.
 
 For example, your migrations package might look like this::
 

--- a/platform/src/pulp/server/managers/migration_tracker.py
+++ b/platform/src/pulp/server/managers/migration_tracker.py
@@ -11,6 +11,7 @@
 
 from pulp.server.db.model.migration_tracker import MigrationTracker
 
+
 class DoesNotExist(Exception):
     """
     This Exception is raised when the manager is asked to retrieve a MigrationTracker that is not

--- a/platform/test/unit/server/test_pulp_manage_db.py
+++ b/platform/test/unit/server/test_pulp_manage_db.py
@@ -19,7 +19,7 @@ from pulp.server.db import manage
 from pulp.server.db.migrate import models
 from pulp.server.db.model.migration_tracker import MigrationTracker
 from pulp.server.managers.migration_tracker import DoesNotExist, MigrationTrackerManager
-import base
+from server import base
 import pulp.plugins.types.database as types_db
 import data.test_migration_packages.a
 import data.test_migration_packages.duplicate_versions
@@ -78,6 +78,8 @@ if inPy3k:
         'truncate', 'writable', 'write', 'writelines']
 else:
     file_spec = file
+
+
 def mock_open(mock=None, read_data=None):
     if mock is None:
         mock = MagicMock(spec=file_spec)
@@ -112,7 +114,7 @@ class TestManageDB(MigrationTest):
     @patch('pkg_resources.iter_entry_points', iter_entry_points)
     @patch('pulp.server.db.migrate.models.pulp.server.db.migrations',
            data.test_migration_packages.platform)
-    @patch('sys.argv', ["pulp-manage-db",])
+    @patch('sys.argv', ["pulp-manage-db"])
     @patch('pulp.server.db.manage.logger')
     @patch('pulp.server.db.manage._start_logging')
     def test_current_version_too_high(self, mocked_start_logging, mocked_logger, mocked_stderr):
@@ -122,7 +124,7 @@ class TestManageDB(MigrationTest):
         """
         # Make sure we start out with a clean slate
         self.assertEquals(MigrationTracker.get_collection().find({}).count(), 0)
-        # Make sure that our mock works. There are three valid packages.
+        # Make sure that our mock works. There are four valid packages.
         self.assertEquals(len(models.get_migration_packages()), 4)
         # Set all versions to ridiculously high values
         for package in models.get_migration_packages():
@@ -143,7 +145,7 @@ class TestManageDB(MigrationTest):
     @patch('pkg_resources.iter_entry_points', iter_entry_points)
     @patch('pulp.server.db.migrate.models.pulp.server.db.migrations',
            data.test_migration_packages.platform)
-    @patch('sys.argv', ["pulp-manage-db",])
+    @patch('sys.argv', ["pulp-manage-db"])
     @patch('pulp.server.db.manage.logger')
     @patch('pulp.server.db.manage._start_logging')
     def test_migrate(self, start_logging_mock, logger_mock, mocked_apply_migration, mocked_stderr):
@@ -160,12 +162,14 @@ class TestManageDB(MigrationTest):
             package._migration_tracker.version = 0
             package._migration_tracker.save()
         manage.main()
+
         # There should have been a print to stderr about the Exception
         expected_stderr_calls = [
             'Applying migration data.test_migration_packages.raise_exception.0002_oh_no failed.',
             ' ', ' See log for details.', '\n']
         stderr_calls = [call[1][0] for call in mocked_stderr.mock_calls]
         self.assertEquals(stderr_calls, expected_stderr_calls)
+
         migration_modules_called = [call[1][1].name for call in mocked_apply_migration.mock_calls]
         # Note that none of the migrations that don't meet our criteria show up in this list. Also,
         # Note that data.test_migration_packages.raise_exception.0003_shouldnt_run doesn't appear
@@ -187,38 +191,35 @@ class TestManageDB(MigrationTest):
                 # The raised Exception should have prevented us from getting past version 1
                 self.assertEqual(package.current_version, 1)
 
+    @patch('sys.stderr')
     @patch('pkg_resources.iter_entry_points', iter_entry_points)
-    @patch('pulp.server.db.migrate.models.MigrationPackage.apply_migration')
     @patch('pulp.server.db.migrate.models.pulp.server.db.migrations',
            data.test_migration_packages.platform)
-    @patch('sys.argv', ["pulp-manage-db",])
+    @patch('sys.argv', ["pulp-manage-db"])
     @patch('pulp.server.db.manage.logger')
     @patch('pulp.server.db.manage._start_logging')
-    def test_migrate_with_new_packages(self, start_logging_mock, logger_mock, mocked_apply_migration):
+    def test_migrate_with_new_packages(self, start_logging_mock, logger_mock, mocked_stderr):
         """
-        Adding new packages to a system that doesn't have any trackers should automatically advance
-        each package to the latest available version without calling any migrate() functions.
+        Adding new packages to a system that doesn't have any trackers should advance
+        each package to the latest available version, applying all migrate() functions along the way.
         """
         # Make sure we start out with a clean slate
         self.assertEquals(MigrationTracker.get_collection().find({}).count(), 0)
-        # Make sure that our mock works. There are three valid packages.
+        # Make sure that our mock works. There are four valid packages.
         self.assertEquals(len(models.get_migration_packages()), 4)
         manage.main()
-        # No calls to apply_migration should have been made, and we should be at the latest package
-        # versions for each of the packages that have valid migrations.
-        self.assertFalse(mocked_apply_migration.called)
-        for package in models.get_migration_packages():
-            self.assertEqual(package.current_version, package.latest_available_version)
 
-        # Calling main() again should still not call apply_migration() or change the versions
-        manage.main()
-        self.assertFalse(mocked_apply_migration.called)
         for package in models.get_migration_packages():
-            self.assertEqual(package.current_version, package.latest_available_version)
+            if 'raise_exception' in str(package):
+                # The Exception raising package should get to version 1, because version 2 raises
+                self.assertEqual(package.current_version, 1)
+            else:
+                # All other packages should reach their top versions
+                self.assertEqual(package.current_version, package.latest_available_version)
 
     @patch('__builtin__.open', mock_open(read_data=_test_type_json))
     @patch('os.listdir', return_value=['test_type.json'])
-    @patch('sys.argv', ["pulp-manage-db",])
+    @patch('sys.argv', ["pulp-manage-db"])
     @patch('pulp.server.db.manage._start_logging')
     def test_pulp_manage_db_loads_types(self, start_logging_mock, listdir_mock):
         """
@@ -262,7 +263,7 @@ class TestManageDB(MigrationTest):
     @patch('pkg_resources.iter_entry_points', iter_entry_points)
     @patch('pulp.server.db.migrate.models.pulp.server.db.migrations',
            data.test_migration_packages.platform)
-    @patch('sys.argv', ["pulp-manage-db", "--test",])
+    @patch('sys.argv', ["pulp-manage-db", "--test"])
     @patch('pulp.server.db.manage.logging')
     def test_migrate_with_test_flag(self, start_logging_mock, mocked_apply_migration, mocked_stderr):
         """
@@ -320,6 +321,10 @@ class TestMigrationModule(MigrationTest):
         mm_3 = models.MigrationModule('data.test_migration_packages.z.0003_test')
         self.assertEquals(cmp(mm_2, mm_3), -1)
 
+    def test___repr__(self):
+        mm = models.MigrationModule('data.test_migration_packages.z.0003_test')
+        self.assertEqual(repr(mm), 'data.test_migration_packages.z.0003_test')
+
     def test_name(self):
         mm = models.MigrationModule('data.test_migration_packages.z.0003_test')
         self.assertEqual(mm.name, 'data.test_migration_packages.z.0003_test')
@@ -330,8 +335,8 @@ class TestMigrationPackage(MigrationTest):
         mp = models.MigrationPackage(data.test_migration_packages.z)
         self.assertEquals(mp._package.__name__, 'data.test_migration_packages.z')
         self.assertEquals(mp._migration_tracker.name, 'data.test_migration_packages.z')
-        # We auto update to the latest version since this is a new package
-        self.assertEquals(mp._migration_tracker.version, 3)
+        # By default, MigrationPackages should start at version 0
+        self.assertEquals(mp._migration_tracker.version, 0)
 
     def test_apply_migration(self):
         mp = models.MigrationPackage(data.test_migration_packages.z)
@@ -381,7 +386,8 @@ class TestMigrationPackage(MigrationTest):
 
     def test_current_version(self):
         mp = models.MigrationPackage(data.test_migration_packages.z)
-        self.assertEqual(mp.current_version, 3)
+        # By default, a MigrationPackage will be at version 0
+        self.assertEqual(mp.current_version, 0)
         # Now let's change the version to 4 and see what happens
         mp._migration_tracker.version = 4
         mp._migration_tracker.save()
@@ -480,7 +486,7 @@ class TestMigrationPackage(MigrationTest):
         error_message = 'Migration version 2 is missing in ' +\
             'data.test_migration_packages.version_gap.'
         try:
-            mp = models.MigrationPackage(data.test_migration_packages.version_gap)
+            models.MigrationPackage(data.test_migration_packages.version_gap)
             self.fail('The MigrationPackage.MissingVersion exception should have been raised, '
                 'but was not raised.')
         except models.MigrationPackage.MissingVersion, e:
@@ -494,7 +500,7 @@ class TestMigrationPackage(MigrationTest):
             'data.test_migration_packages.version_zero.0000_not_allowed has been assigned that ' +\
             'version.'
         try:
-            mp = models.MigrationPackage(data.test_migration_packages.version_zero)
+            models.MigrationPackage(data.test_migration_packages.version_zero)
             self.fail('The MigrationPackage.DuplicateVersions exception should have been raised, '
                 'but was not raised.')
         except models.MigrationPackage.DuplicateVersions, e:
@@ -593,7 +599,7 @@ class TestMigrationTrackerManager(MigrationTest):
         # Now get or create it with an incorrect version. The incorrect version should not be set
         mt = self.mtm.get_or_create('smallest_perfect_number', defaults={'version': 7})
         self.assertEquals(mt.name, 'smallest_perfect_number')
-        self.assertEquals(mt.version, 6) # not 7
+        self.assertEquals(mt.version, 6)  # not 7
         mt_bson = mt._collection.find_one({'name': 'smallest_perfect_number'})
         self.assertEquals(mt_bson['name'], 'smallest_perfect_number')
         self.assertEquals(mt_bson['version'], 6)
@@ -615,7 +621,6 @@ class TestMigrationTrackerManager(MigrationTest):
         mt_bson = mt._collection.find_one({'name': 'None'})
         self.assertEquals(mt_bson['name'], 'None')
         self.assertEquals(mt_bson['version'], None)
-
 
 
 class TestMigrationUtils(MigrationTest):


### PR DESCRIPTION
...lable.

Also, several PEP-8 fixes.

This is for https://bugzilla.redhat.com/show_bug.cgi?id=909366
