### PR TITLE
Strip out the feed URL for cloned repos

### DIFF
--- a/platform/test/upgrade/test_db_all_repos.py
+++ b/platform/test/upgrade/test_db_all_repos.py
@@ -165,3 +165,65 @@ class RepoScheduledSyncUpgradeTests(BaseDbUpgradeTests):
 
         scheduled_calls = self.tmp_test_db.database.scheduled_calls.find({})
         self.assertEqual(scheduled_calls.count(), 2)
+
+
+class CloneHandlingTests(BaseDbUpgradeTests):
+
+    def setUp(self):
+        super(CloneHandlingTests, self).setUp()
+
+        # Create two repositories, a parent and a child
+        v1_parent_repo = {'id' : 'parent',
+                          'clone_ids' : ['child'],
+                          'relative_path' : 'parent',
+                          'content_types' : ['yum'],
+                          'last_sync' : None,
+                          'feed_ca' : None,
+                          'feed_cert' : None,
+                          'source' : {'url' : 'parent-feed'}}
+        v1_child_repo = {'id' : 'child',
+                         'clone_ids' : [],
+                         'relative_path' : 'child-feed',
+                         'content_types' : ['yum'],
+                         'last_sync' : None,
+                         'feed_ca' : None,
+                         'feed_cert' : None,
+                         'source' : {'url' : 'child-feed'}}
+
+        self.v1_test_db.database.repos.insert(v1_parent_repo, safe=True)
+        self.v1_test_db.database.repos.insert(v1_child_repo, safe=True)
+
+        # This step runs after the yum repos step in the main script, so simulate that here
+        yum_repos.upgrade(self.v1_test_db.database, self.tmp_test_db.database)
+
+    def test_upgrade(self):
+        # Test
+        all_repos.upgrade(self.v1_test_db.database, self.tmp_test_db.database)
+
+        # Verify
+        v2_coll = self.tmp_test_db.database.repo_importers
+
+        #   Make sure we didn't wipe out all of the feed URLs
+        v2_parent_repo_importer = v2_coll.find_one({'repo_id' : 'parent'})
+        self.assertEqual(v2_parent_repo_importer['config']['feed_url'], 'parent-feed')
+
+        #   This one should be empty
+        v2_child_repo_importer = v2_coll.find_one({'repo_id' : 'child'})
+        self.assertEqual(v2_child_repo_importer['config']['feed_url'], None)
+
+    def test_upgrade_idempotency(self):
+        # Test
+        all_repos.upgrade(self.v1_test_db.database, self.tmp_test_db.database)
+        all_repos.upgrade(self.v1_test_db.database, self.tmp_test_db.database)
+
+        # Verify
+        v2_coll = self.tmp_test_db.database.repo_importers
+
+        #   Make sure we didn't wipe out all of the feed URLs
+        v2_parent_repo_importer = v2_coll.find_one({'repo_id' : 'parent'})
+        self.assertEqual(v2_parent_repo_importer['config']['feed_url'], 'parent-feed')
+
+        #   This one should be empty
+        v2_child_repo_importer = v2_coll.find_one({'repo_id' : 'child'})
+        self.assertEqual(v2_child_repo_importer['config']['feed_url'], None)
+


### PR DESCRIPTION
The v1 concept of cloning is entirely different in v2. It's handled through the repo copy operation and there is no relation between repositories. This change is to strip out the feed URLs of v1 cloned repos so they no longer point to the parent's location on disk (the location is no longer valid either).
