### PR TITLE
Fixed progress bar call to not be a divide by zero for situations with 1

### DIFF
--- a/platform/src/pulp/server/upgrade/publish.py
+++ b/platform/src/pulp/server/upgrade/publish.py
@@ -58,7 +58,7 @@ def run_publish():
     for index, task in enumerate(distributors_to_publish):
         repo_id, data = task
         _publish(repo_id, data)
-        bar.render(index, len(distributors_to_publish)-1)
+        bar.render(index + 1, len(distributors_to_publish))
     p.write('')
 
     # Poll until the publish requests are finished


### PR DESCRIPTION
repo

The off by one handling was in the wrong area. Instead of making the amount completed correct, it originally lowered the upper boundary of how much work needed to be done. 
That's wrong in its own right; after the first completed item it still showed 0%. It also had the added effect of causing the progress calculation to divide by zero in the event a single repo is specified.
