### PR TITLE
918600 - _content_type_id wasn't being set for erratum and drpm

### DIFF
--- a/platform/src/pulp/server/upgrade/db/units.py
+++ b/platform/src/pulp/server/upgrade/db/units.py
@@ -336,6 +336,8 @@ def _drpms(v1_database, v2_database, report):
                 new_drpm = {
                     "_id" : drpm_id,
                     "_storage_path" : os.path.join(DIR_DRPM, drpm.filename),
+                    "_content_type_id" : 'drpm',
+
                     "checksumtype" : drpm.checksum_type,
                     "sequence" : drpm.sequence,
                     "checksum" : drpm.checksum,
@@ -387,6 +389,8 @@ def _errata(v1_database, v2_database, report):
         new_erratum = {
             '_id' : erratum_id,
             '_storage_path' : None,
+            '_content_type_id' : 'erratum',
+
             'description' : v1_erratum['description'],
             'from_str' : v1_erratum['from_str'],
             'id' : v1_erratum['id'],
@@ -450,6 +454,7 @@ def _distributions(v1_database, v2_database, report):
         new_distro = {
             '_id' : str(uuid.uuid4()),
             '_content_type_id' : 'distribution',
+
             'id' : v1_distro['id'],
             'arch' : v1_distro['arch'],
             'version' : v1_distro['version'],
@@ -595,6 +600,7 @@ def _package_groups(v1_database, v2_database, report):
                 '_id' : v2_group_id,
                 '_storage_path' : None,
                 '_content_type_id' : 'package_group',
+
                 'conditional_package_names' : v1_group['conditional_package_names'],
                 'default' : v1_group['default'],
                 'default_package_names' : v1_group['default_package_names'],
@@ -658,6 +664,7 @@ def _package_group_categories(v1_database, v2_database, report):
                 '_id' : category_id,
                 '_storage_path' : None,
                 '_content_type_id' : 'package_category',
+
                 'description' : v1_category['description'],
                 'display_order' : v1_category['display_order'],
                 'id' : v1_category['id'],
@@ -701,6 +708,7 @@ def _isos(v1_database, v2_database, report):
         v2_iso = {
             '_id' : new_iso_id,
             '_content_type_id' : 'iso',
+
             'name' : v1_file['filename'],
             'size' : v1_file['size'],
         }

--- a/platform/test/upgrade/test_db_units.py
+++ b/platform/test/upgrade/test_db_units.py
@@ -224,6 +224,7 @@ class PackagesUpgradeTests(BaseDbUpgradeTests):
                 self.assertEqual(ass['created'], units.DEFAULT_CREATED)
                 self.assertEqual(ass['updated'], units.DEFAULT_UPDATED)
 
+
 class DRPMUpgradeTests(BaseDbUpgradeTests):
 
     def setUp(self):
@@ -231,8 +232,8 @@ class DRPMUpgradeTests(BaseDbUpgradeTests):
         new_repo = {
                 'id' : 'test_drpm_repo',
                 'content_types' : 'yum',
-                'repomd_xml_path' : os.path.join(V1_REPOS_DIR,
-                    'repos/pulp/pulp/demo_repos/test_drpm_repo/repodata/repomd.xml'),
+                'repomd_xml_path' : os.path.join(
+                    V1_REPOS_DIR, 'repos/pulp/pulp/demo_repos/test_drpm_repo/repodata/repomd.xml'),
                 'relative_path' : 'repos/pulp/pulp/demo_repos/test_drpm_repo/',
             }
         if self.v1_test_db.database.repos.find_one({'id' : 'test_drpm_repo'}):
@@ -262,6 +263,8 @@ class DRPMUpgradeTests(BaseDbUpgradeTests):
         self.assertEqual(len(v1_drpms), v2_drpms.count())
         for drpm in v1_drpms:
             v2_drpm = self.tmp_test_db.database.units_drpm.find_one({'filename' : drpm.filename})
+            self.assertTrue(isinstance(v2_drpm['_id'], basestring))
+            self.assertEqual(v2_drpm['_content_type_id'], 'drpm')
             self.assertEqual(v2_drpm["checksumtype"],  drpm.checksum_type)
             self.assertEqual(v2_drpm["sequence"], drpm.sequence)
             self.assertEqual(v2_drpm["checksum"], drpm.checksum)
@@ -398,6 +401,7 @@ class ErrataUpgradeTests(BaseDbUpgradeTests):
         for v1_erratum, v2_erratum in zip(v1_errata, v2_errata):
             self.assertTrue(isinstance(v2_erratum['_id'], basestring))
             self.assertEqual(v2_erratum['_storage_path'], None)
+            self.assertEqual(v2_erratum['_content_type_id'], 'erratum')
 
             for k in ('description', 'from_str', 'id', 'issued', 'pkglist',
                       'pushcount', 'reboot_suggested', 'references', 'release',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=918600

This showed itself in the orphaned list which uses this value. Two of the unit upgrades were missing the _content_type_id attribute.
