### PR TITLE
908934 - Fix /etc/pki/pulp and /etc/pki/pulp/consumer ownership.

### DIFF
--- a/platform/pulp.spec
+++ b/platform/pulp.spec
@@ -200,12 +200,14 @@ Pulp provides replication, access, and accounting for software repositories.
 %defattr(-,apache,apache,-)
 %dir /srv/%{name}
 %dir %{_var}/log/%{name}
-%{_sysconfdir}/pki/%{name}/
+%dir %{_sysconfdir}/pki/%{name}
 %{_var}/lib/%{name}/
 %{_usr}/lib/%{name}/plugins/distributors
 %{_usr}/lib/%{name}/plugins/importers
 %{_usr}/lib/%{name}/plugins/profilers
 %{_usr}/lib/%{name}/plugins/types
+%{_sysconfdir}/pki/%{name}/ca.key
+%{_sysconfdir}/pki/%{name}/ca.crt
 /srv/%{name}/webservices.wsgi
 %doc
 
@@ -332,10 +334,11 @@ A tool used to administer a pulp consumer.
 %defattr(-,root,root,-)
 %dir %{_sysconfdir}/%{name}/consumer
 %dir %{_sysconfdir}/%{name}/consumer/conf.d
+%dir %{_sysconfdir}/pki/%{name}/consumer/
 %dir %{_usr}/lib/%{name}/consumer/extensions/
 %config(noreplace) %{_sysconfdir}/%{name}/consumer/consumer.conf
-%config(noreplace) %{_sysconfdir}/pki/%{name}/consumer
 %{_bindir}/%{name}-consumer
+%ghost %{_sysconfdir}/pki/%{name}/consumer/consumer-cert.pem
 %doc
 
 
@@ -346,6 +349,7 @@ Summary: The Pulp agent
 Group: Development/Languages
 Requires: python-%{name}-bindings = %{version}
 Requires: python-%{name}-agent-lib = %{version}
+Requires: %{name}-consumer-client = %{version}
 Requires: gofer >= 0.74
 
 %description agent


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=908934
