### PR TITLE
fix errata list processing for multiple installed packages

### DIFF
--- a/src/pulp/client/consumer/plugins/errata.py
+++ b/src/pulp/client/consumer/plugins/errata.py
@@ -36,7 +36,6 @@ class ConsumerList(List):
 
     def run(self):
         consumerid = self.consumerid
-        repoid = self.opts.repoid
 
         List.run(self, consumerid)
 

--- a/src/pulp/server/api/consumer.py
+++ b/src/pulp/server/api/consumer.py
@@ -694,17 +694,27 @@ class ConsumerApi(BaseApi):
                         #if errata pkg not in installed profile, update is not
                         # applicable move on
                         continue
-                    for ppkg in pkg_profile_dict:
-                        if epkg_info['name'] != ppkg['name']:
-                            continue
 
-                        status = compare_packages(epkg_info, ppkg)
-                        if status == 1:
-                            # erratum pkg is newer, add to update list
-                            if not applicable_errata.has_key(erratumid):
-                                applicable_errata[erratumid] = {'packages' : [],
-                                                                'reboot_suggested' : erratum['reboot_suggested']}
-                            applicable_errata[erratumid]['packages'].append(pkg)
+                    errata_pkg_applicable = False
+                    for ppkg in pkg_profile_dict:
+                        status = compare_packages(ppkg, epkg_info)
+                        # different package, move on
+                        if status is None:
+                            continue
+                        # newer pkg than errata pkg found -> skip errata
+                        elif status >= 0:
+                            errata_pkg_applicable = False
+                            break
+                        # older pkg found, errata might be applicable if no newer pkg is found later on
+                        errata_pkg_applicable = True
+
+                    # applicable erratum found? -> add to update list
+                    if errata_pkg_applicable:
+                        if not applicable_errata.has_key(erratumid):
+                            applicable_errata[erratumid] = {'packages' : [],
+                                                            'reboot_suggested' : erratum['reboot_suggested']}
+                        applicable_errata[erratumid]['packages'].append(pkg)
+
         return applicable_errata
     
 

--- a/src/pulp/server/util.py
+++ b/src/pulp/server/util.py
@@ -377,6 +377,7 @@ def compare_packages(pkgA, pkgB):
      return 1: pkgA is newer than pkgB
      return 0: pkgA equals pkgB
      return -1: pkgB is newer than pkgA
+     return None: name or arch of pkgA differs from pkgB, e.g. different package
     """
     def build_evr(pkg):
         evr = [pkg["epoch"], pkg["version"], pkg["release"]]
@@ -384,6 +385,9 @@ def compare_packages(pkgA, pkgB):
         if evr[0] == "":
             evr[0] = None
         return evr
+
+    if pkgA["name"] != pkgB["name"] or pkgA["arch"] != pkgB["arch"]:
+        return None
 
     evrA, evrB = (build_evr(pkgA), build_evr(pkgB))
     return rpm.labelCompare(evrA, evrB)


### PR DESCRIPTION
i think the algorihm to determine which errata are applicable is not correct in PULP V1 and possibly in V2.

Example:
# yum list installed kernel

Installed Packages
kernel.i686                     2.6.32-279.22.1.el6
kernel.i686                     2.6.32-358.0.1.el6

OK, two installed kernels. Installing multiple kernel versions is default.

$ pulp-consumer errata list
Id                    Type             Title
RHSA-2013:0496        security         Important: Red Hat Enterprise Linux 6 kernel update

RHSA-2013:0496, a kernel update, is listed as applicable.

Id                      RHSA-2013:0496
Title                   Important: Red Hat Enterprise Linux 6 kernel update
Packages Effected       kernel-2.6.32-358.el6.i686.rpm,

PULP V1 (1.1.15) reports the errata as applicable because the it checks against the older
2.6.32-279.22.1.el6 and ignores the newer 2.6.32-358.0.1.el6.

i changed the algorithm, see attached patch, so, that errata are only reported as applicable if ALL installed packages older than the errata package. the example given above now reports no errata, which is correct IMHO. i also changed compare_packages to include the comparison of name and arch.
