### PR TITLE
add single repo sync as CDS sync action

### DIFF
--- a/src/pulp/client/admin/plugins/cds.py
+++ b/src/pulp/client/admin/plugins/cds.py
@@ -365,11 +365,18 @@ class Sync(CDSAction):
         self.parser.add_option('--hostname', dest='hostname',
                                help=_('CDS hostname (required)'))
 
+        self.parser.add_option("--repoid", dest="repoid",
+                       help=_("repo identifier"))
+
     def run(self):
         hostname = self.get_required_option('hostname')
+        repoid = self.opts.repoid
 
-        self.cds_api.sync(hostname)
-        print(_('Sync for CDS [%s] started' % hostname))
+        self.cds_api.sync(hostname, repoid)
+        if repoid:
+            print(_('Synchronizing of repository [%s] on CDS [%s] started' % (repoid,hostname)))
+        else:
+            print(_('Synchronizing for CDS [%s] started' % hostname))
         print(_('Use "cds status" to check on the progress'))
 
 class Status(CDSAction):

--- a/src/pulp/client/api/cds.py
+++ b/src/pulp/client/api/cds.py
@@ -85,8 +85,10 @@ class CDSAPI(PulpAPI):
         path = '/cds/%s/unassociate/' % hostname
         return self.server.POST(path, data)[1]
 
-    def sync(self, hostname):
+    def sync(self, hostname, repo_id=None):
         data = {}
+        if repo_id:
+          data = {'repo_id' : repo_id}
         path = '/cds/%s/sync/' % hostname
         return self.server.POST(path, data)[1]
 


### PR DESCRIPTION
a CDS sync synchronizes all and everything which is not efficient if you just modifified/cloned/etc. a single repository. if this case you want to sync this particular repository only.

this request adds this feature by adding an optional parameter 'repoid' to cds sync:

$ pulp-admin cds sync -h
Usage: pulp-admin <options> cds sync <options>

Options:
  -h, --help           show this help message and exit
  --hostname=HOSTNAME  CDS hostname (required)
  --repoid=REPOID      repo identifier

without '--repoid' the behaviour is like the current one, synchronize all and everyting. with '--repoid' only the specified repo will by synchronized.
