### PR TITLE
Access changes for Apache 2.4 caused other WSGI files (pulp_puppet) to n...

### DIFF
--- a/platform/etc/httpd/conf.d/pulp_f18.conf
+++ b/platform/etc/httpd/conf.d/pulp_f18.conf
@@ -35,8 +35,11 @@ WSGISocketPrefix run/wsgi
 WSGIScriptAlias /pulp/api /srv/pulp/webservices.wsgi
 WSGIImportScript /srv/pulp/webservices.wsgi process-group=pulp application-group=pulp
 
-<Files webservices.wsgi>
+<Directory /srv/pulp>
     Require all granted
+</Directory>
+
+<Files webservices.wsgi>
     WSGIPassAuthorization On
     WSGIProcessGroup pulp
     WSGIApplicationGroup pulp


### PR DESCRIPTION
...ot be accessible. This change allows access to anything in the /srv/pulp/ directory, but of course they also still need to have explicit Alias statements.
