### PR TITLE
Refactored repo delete command to use the polling base class

### DIFF
--- a/platform/src/pulp/client/commands/polling.py
+++ b/platform/src/pulp/client/commands/polling.py
@@ -112,6 +112,8 @@ class PollingCommand(PulpCliCommand):
 
                 # Display the appropriate message based on the result of the task
 
+                self.prompt.render_spacer(1)
+
                 if task.was_successful():
                     self.succeeded(task)
 
@@ -120,6 +122,8 @@ class PollingCommand(PulpCliCommand):
 
                 if task.was_cancelled():
                     self.cancelled(task)
+
+                self.prompt.render_spacer(1)
 
                 completed_task_list.append(task)
 


### PR DESCRIPTION
I may still tweak the base command output, but that shouldn't affect the code in this request. This also contains some fixes to python variable shadowing (id).

New output:

$ pulp-admin rpm repo delete --repo-id doomed
This command may be exited via ctrl+c without affecting the request.

Waiting to begin...
[-]

Repository [doomed] successfully deleted
