### PR TITLE
Bumping the required version of pymongo. We definitely do not work with ...

### DIFF
--- a/platform/pulp.spec
+++ b/platform/pulp.spec
@@ -149,7 +149,7 @@ rm -rf %{buildroot}
 Summary: The pulp platform server
 Group: Development/Languages
 Requires: python-%{name}-common = %{version}
-Requires: pymongo >= 1.9
+Requires: pymongo >= 2.1.1
 Requires: python-setuptools
 Requires: python-webpy
 Requires: python-okaara >= 1.0.30


### PR DESCRIPTION
...1.9 anymore, and we only test against 2.1.1. dgregor ran into an issue where he managed to do a fresh Pulp install with pymongo 1.9 and hit a migration error, so we definitely need to be more accurate with this requirement.

Since 2.1.1 is in EPEL and is what we test against, that seems like a reasonable version to require.
