### PR TITLE
919134 - Add explaination to BadRequest raised when distributor not inst...

### DIFF
--- a/nodes/child/pulp_node/handlers/model.py
+++ b/nodes/child/pulp_node/handlers/model.py
@@ -45,7 +45,7 @@ log = getLogger(__name__)
 
 CONFIG_PATH = '/etc/pulp/consumer/consumer.conf'
 
-DISTRIBUTOR_PLUGIN_MISSING = _('\nA distributor of type [%(t)s] is referenced in a repository '
+DISTRIBUTOR_PLUGIN_MISSING = _('A distributor of type [%(t)s] is referenced in a repository '
                                'binding but is not installed and loaded.  It must be installed '
                                'for node synchronization to succeed.  Please make sure that ALL '
                                'plugins installed on the parent node are installed on the child '
@@ -481,7 +481,7 @@ class ChildDistributor(Child, Distributor):
             log.info('Distributor: %s/%s, added', self.repo_id, self.dist_id)
         except BadRequestException, e:
             if 'distributor_type_id' in e.extra_data['property_names']:
-                e.error_message += DISTRIBUTOR_PLUGIN_MISSING % dict(t=type_id)
+                e.error_message = DISTRIBUTOR_PLUGIN_MISSING % dict(t=type_id)
             raise
 
     def update(self, delta):

--- a/nodes/test/unit/test_plugins.py
+++ b/nodes/test/unit/test_plugins.py
@@ -706,7 +706,6 @@ class TestAgentPlugin(PluginTestBase):
             self.verify(0)
 
     @patch('pulp_node.handlers.strategies.Bundle.cn', return_value=PULP_ID)
-    @patch('pulp_node.importers.strategies.Mirror._add_units', side_effect=Exception())
     def test_plugins_missing(self, *unused):
         """
         Test the end-to-end collaboration of:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=919134

This fix is fine for now but we really need a more comprehensive approach to validating that the child node is suitable for synchronization.  I incorporated this work on a branch (jortel-nodes-reporting) making improvements to node update summary reporting in general.  But, the changes on that branch became to widespread and could not be completed and reviewed this sprint.
