### PR TITLE
Refactored remove command to be polling-based

### DIFF
--- a/platform/test/unit/test_commands_unit_copy.py
+++ b/platform/test/unit/test_commands_unit_copy.py
@@ -13,10 +13,8 @@
 import mock
 
 import base
-
 from pulp.bindings.exceptions import BadRequestException
 from pulp.client.commands.criteria import UnitAssociationCriteriaCommand
-from pulp.client.commands.options import OPTION_REPO_ID
 from pulp.client.commands.polling import PollingCommand
 import pulp.client.commands.unit as unit_commands
 from pulp.devel.unit import task_simulator


### PR DESCRIPTION
Similar to the copy command, but significantly simpler. 
- Added type_id parameter to constructor to scope the instantiated command.
- Added hook to modify user input to customize generated criteria.
- The remove command does not support an override configuration so unlike the copy command there is no hook for that.

FYI, there is no override config to the remove command since the importer isn't responsible for doing anything. The platform handles the DB changes and the importer is simply told about the changes. There may still be a need for this in the future, but as it doesn't exist in the APIs today, this wasn't the place to add it.

There will be PRs in pulp_rpm and pulp_puppet that correspond to this change, so please review them as well. I'll post links when they are filed.
