### PR TITLE
Changed unassociate manager to return the list of removed units so the

### DIFF
--- a/platform/test/unit/server/test_repo_unit_association_manager.py
+++ b/platform/test/unit/server/test_repo_unit_association_manager.py
@@ -458,9 +458,17 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.assertEqual(4, len(list(unit_coll.find({'repo_id' : self.repo_id}))))
 
         # Test
-        self.manager.unassociate_all_by_ids(self.repo_id, self.unit_type_id, [self.unit_id, self.unit_id_2], OWNER_TYPE_USER, 'admin')
+        unassociated = self.manager.unassociate_all_by_ids(self.repo_id, self.unit_type_id,
+                                                           [self.unit_id, self.unit_id_2],
+                                                           OWNER_TYPE_USER, 'admin')
 
         # Verify
+        self.assertEqual(len(unassociated), 2)
+        for u in unassociated:
+            self.assertTrue(isinstance(u, dict))
+            self.assertTrue(u['type_id'], self.unit_type_id)
+            self.assertTrue(u['unit_key'] in [self.unit_key, self.unit_key_2])
+
         self.assertEqual(2, len(list(unit_coll.find({'repo_id' : self.repo_id}))))
 
         self.assertTrue(unit_coll.find_one({'repo_id' : self.repo_id, 'unit_type_id' : 'type-2', 'unit_id' : 'unit-1'}) is not None)


### PR DESCRIPTION
client can display it

There was very little to do here. When I did this for copy, I put the transfer object translation into the transfer object itself, so this code simply calls that so the return value is the same as for copy.

There will be PRs in pulp_rpm and pulp_puppet that correspond to this.
