### PR TITLE
955356 - pulp-nodes-child requires: pulp-agent.

### DIFF
--- a/nodes/pulp-nodes.spec
+++ b/nodes/pulp-nodes.spec
@@ -167,6 +167,7 @@ Group: Development/Languages
 Requires: %{name}-common = %{version}
 Requires: pulp-server = %{pulp_version}
 Requires: pulp-consumer-client = %{pulp_version}
+Requires: pulp-agent = %{pulp_version}
 Requires: python-pulp-agent-lib = %{pulp_version}
 Requires: gofer >= 0.74
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=955356
