### PR TITLE
955809 - Corrected HTTP method on uploading bits

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/content/upload.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/content/upload.rst
@@ -52,7 +52,7 @@ Sends a portion of the contents of the file being uploaded to the server. If the
 entire file cannot be sent in a single call, the caller may divide up the file
 and provide offset information for Pulp to use when assembling it.
 
-| :method:`post`
+| :method:`put`
 | :path:`/v2/content/uploads/<upload_id>/<offset/`
 | :permission:`update`
 | :param_list:`post` The body of the request is the content to store in the file


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=955809

That BZ contains links to the docs that show it incorrect and the code that shows the actual HTTP method is a PUT.
