### PR TITLE
Support IPv6-only hosts (HTTPS)

### DIFF
--- a/deps/m2crypto/m2crypto-0.21.1-getaddrinfo.patch
+++ b/deps/m2crypto/m2crypto-0.21.1-getaddrinfo.patch
@@ -1,0 +1,63 @@
+Index: M2Crypto/httpslib.py
+===================================================================
+--- M2Crypto/httpslib.py	(revision 739)
++++ M2Crypto/httpslib.py	(working copy)
+@@ -44,11 +44,34 @@
+         HTTPConnection.__init__(self, host, port, strict)
+ 
+     def connect(self):
+-        self.sock = SSL.Connection(self.ssl_ctx)
+-        if self.session:
+-            self.sock.set_session(self.session)
+-        self.sock.connect((self.host, self.port))
++        error = None
++        # We ignore the returned sockaddr because SSL.Connection.connect needs
++        # a host name.
++        for (family, _, _, _, _) in \
++                socket.getaddrinfo(self.host, self.port, 0, socket.SOCK_STREAM):
++            sock = None
++            try:
++                try:
++                    sock = SSL.Connection(self.ssl_ctx, family=family)
++                    if self.session is not None:
++                        sock.set_session(self.session)
++                    sock.connect((self.host, self.port))
+ 
++                    self.sock = sock
++                    sock = None
++                    return
++                except socket.error, e:
++                    # Other exception are probably SSL-related, in that case we
++                    # abort and the exception is forwarded to the caller.
++                    error = e
++            finally:
++                if sock is not None:
++                    sock.close()
++
++        if error is None:
++            raise AssertionError("Empty list returned by getaddrinfo")
++        raise error
++
+     def close(self):
+         # This kludges around line 545 of httplib.py,
+         # which closes the connection in this object;
+Index: M2Crypto/SSL/Connection.py
+===================================================================
+--- M2Crypto/SSL/Connection.py	(revision 739)
++++ M2Crypto/SSL/Connection.py	(working copy)
+@@ -38,13 +38,13 @@
+     m2_bio_free = m2.bio_free
+     m2_ssl_free = m2.ssl_free
+     
+-    def __init__(self, ctx, sock=None):
++    def __init__(self, ctx, sock=None, family=socket.AF_INET):
+         self.ctx = ctx
+         self.ssl = m2.ssl_new(self.ctx.ctx)
+         if sock is not None:    
+             self.socket = sock
+         else:
+-            self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
++            self.socket = socket.socket(family, socket.SOCK_STREAM)
+             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+         self._fileno = self.socket.fileno()
+

--- a/deps/m2crypto/m2crypto.spec
+++ b/deps/m2crypto/m2crypto.spec
@@ -10,7 +10,7 @@
 Summary: Support for using OpenSSL in python scripts
 Name: m2crypto
 Version: 0.21.1.pulp
-Release: 8%{?dist}
+Release: 9%{?dist}
 Source0: http://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-%{version}.tar.gz
 # https://bugzilla.osafoundation.org/show_bug.cgi?id=2341
 Patch0: m2crypto-0.21.1-timeouts.patch
@@ -30,6 +30,12 @@ Patch3: m2crypto-0.20.2-check.patch
 Patch4: m2crypto-0.21.1-smime-doc.patch
 # ISSUE Link to be filed
 Patch5: m2crypto-0.21.1-x509_crl.patch
+
+# SSL support for IPv6-only hosts
+# https://bugzilla.osafoundation.org/show_bug.cgi?id=13044
+# https://bugzilla.redhat.com/show_bug.cgi?id=742914
+Patch6: m2crypto-0.21.1-getaddrinfo.patch
+
 License: MIT
 Group: System Environment/Libraries
 URL: http://wiki.osafoundation.org/bin/view/Projects/MeTooCrypto
@@ -55,6 +61,7 @@ This package allows you to call OpenSSL functions from python scripts.
 #%patch4 -p1 -b .memoryview
 %patch4 -p0
 %patch5 -p1 -b .x509_crl
+%patch6 -p0 -b .getaddrinfo
 
 # Red Hat opensslconf.h #includes an architecture-specific file, but SWIG
 # doesn't follow the #include.
@@ -120,6 +127,9 @@ rm -rf $RPM_BUILD_ROOT
 %{python_sitearch}/M2Crypto-*.egg-info
 
 %changelog
+* Tue May 28 2013 Tom Lanyon <tom@netspot.com.au> 0.21.1.pulp-9
+- BZ 742914 - added patch for getaddrinfo support (IPv6)
+
 * Fri Jun 15 2012 Jeff Ortel <jortel@redhat.com> 0.21.1.pulp-8
 - Renamed dependency RPMs (jason.dobies@redhat.com)
 

--- a/rel-eng/packages/m2crypto
+++ b/rel-eng/packages/m2crypto
@@ -1,1 +1,1 @@
-0.21.1.pulp-8 deps/m2crypto/
+0.21.1.pulp-9 deps/m2crypto/


### PR DESCRIPTION
pulp-admin (or anywhere else using m2crypto for HTTPS connections) doesn't support connecting to hosts which only have IPv6 addresses as m2crypto does not resolve hostnames using getaddrinfo().

Added upstream patch to build m2crypto-0.21.1.pulp-9.el6 which adds this support.
