### PR TITLE
973402 - Handle CallReport.progress with value of {} or None

### DIFF
--- a/platform/src/pulp/client/commands/consumer/content.py
+++ b/platform/src/pulp/client/commands/consumer/content.py
@@ -382,8 +382,8 @@ class ConsumerContentProgressTracker(object):
         self.details = None
 
     def display(self, report):
+        # report can be None or {}
         if report:
-            # report can be None or {}
             self.display_steps(report['steps'])
             self.display_details(report['details'])
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=973402

The _CallReport.progress_ is initialized as _progress or {}_.  So, {} is a valid value for the progress report.  After reproducing, I verfied that the agent is not passing an invalid progress report.  Instead, we see this error when the CLI polls the tasks and attempts to render the _CallReport.progress_ report before it is ever updated by the agent.  In light of this, I believe it's safe to only render the progress report when it's not _None_ and not _{}_.
