### PR TITLE
976568 - change yum version requirement to work on RHEL 6.4.

### DIFF
--- a/deps/createrepo/createrepo.spec
+++ b/deps/createrepo/createrepo.spec
@@ -25,7 +25,7 @@ URL: http://createrepo.baseurl.org/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArchitectures: noarch
 Requires: python >= 2.1, rpm-python, rpm >= 4.1.1, libxml2-python
-Requires: yum-metadata-parser, yum >= 3.4.3-4, python-deltarpm, deltarpm, pyliblzma
+Requires: yum-metadata-parser, yum >= 3.2.29-40, python-deltarpm, deltarpm, pyliblzma
 BuildRequires: python
 
 %description


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=976568

I tested createrepo 0.9.9-21 on RHEL 6.4 (which normally has 0.9.9-17) and both createrepo and modifyrepo seem to work okay with yum 3.2.29-40 (instead of 3.4.3-4).  The changelog does not suggest a change that requires yum 3.4.3-4.  Thinking the solution might be to update the Requires: in our deps/createrepo to require yum 3.2.29-40 and run with that.  

I created a repo, modified it with a comps.xml and installed a package from the created and modified repo and installed a package using group install and yum seemed happy.
