### PR TITLE
Publish operations now use validate_config on override configuration

### DIFF
--- a/platform/src/pulp/server/managers/repo/group/publish.py
+++ b/platform/src/pulp/server/managers/repo/group/publish.py
@@ -24,7 +24,7 @@ from pulp.plugins.config import PluginCallConfiguration
 from pulp.plugins.model import PublishReport
 from pulp.server.db.model.repo_group import RepoGroupPublishResult, RepoGroupDistributor
 from pulp.server.dispatch import constants as dispatch_constants
-from pulp.server.exceptions import MissingResource, PulpExecutionException
+from pulp.server.exceptions import MissingResource, PulpExecutionException, PulpDataException
 from pulp.server.managers import factory as manager_factory
 from pulp.server.managers.repo import _common as common_utils
 
@@ -123,6 +123,12 @@ class RepoGroupPublishManager(object):
         distributor_coll = RepoGroupDistributor.get_collection()
         publish_result_coll = RepoGroupPublishResult.get_collection()
         group_id = group.id
+
+        # Validate the configuration. An empty list is passed for related_repo_groups because
+        # this configuration contains override values valid for this call only.
+        valid, msg = distributor_instance.validate_config(group, call_config, [])
+        if not valid:
+            raise PulpDataException(msg)
 
         # Perform the publish
         publish_start_timestamp = _now_timestamp()

--- a/platform/src/pulp/server/managers/repo/publish.py
+++ b/platform/src/pulp/server/managers/repo/publish.py
@@ -32,7 +32,8 @@ from pulp.plugins.conduits.repo_publish import RepoPublishConduit
 from pulp.plugins.config import PluginCallConfiguration
 from pulp.server.db.model.repository import Repo, RepoDistributor, RepoPublishResult
 from pulp.server.dispatch import factory as dispatch_factory
-from pulp.server.exceptions import MissingResource, PulpExecutionException, InvalidValue
+from pulp.server.exceptions import MissingResource, PulpExecutionException, InvalidValue, \
+    PulpDataException
 from pulp.server.managers import factory as manager_factory
 from pulp.server.managers.repo import _common as common_utils
 
@@ -114,6 +115,12 @@ class RepoPublishManager(object):
         distributor_coll = RepoDistributor.get_collection()
         publish_result_coll = RepoPublishResult.get_collection()
         repo_id = repo['id']
+
+        # Validate the configuration. An empty list is passed for related_repos because
+        # this configuration contains override values valid for this call only.
+        valid, msg = distributor_instance.validate_config(repo, call_config, [])
+        if not valid:
+            raise PulpDataException(msg)
 
         # Perform the publish
         publish_start_timestamp = _now_timestamp()

--- a/platform/test/unit/server/test_repo_group_publish_manager.py
+++ b/platform/test/unit/server/test_repo_group_publish_manager.py
@@ -15,12 +15,15 @@ import base
 import datetime
 import mock_plugins
 
+import mock
+
 from pulp.common import dateutils
 from pulp.plugins.conduits.repo_publish import RepoGroupPublishConduit
 from pulp.plugins.config import PluginCallConfiguration
+from pulp.plugins.distributor import GroupDistributor
 from pulp.plugins.model import RepositoryGroup, PublishReport
 from pulp.server.db.model.repo_group import RepoGroup, RepoGroupDistributor, RepoGroupPublishResult
-from pulp.server.exceptions import PulpExecutionException
+from pulp.server.exceptions import PulpExecutionException, PulpDataException
 from pulp.server.managers import factory as manager_factory
 
 # -- test cases ---------------------------------------------------------------
@@ -99,6 +102,19 @@ class RepoGroupPublishManagerTests(base.PulpServerTests):
 
         # Clean Up
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.publish_group.return_value = None
+
+    def test_publish_bad_override_config(self):
+        """
+        Tests a publish when invalid override configuration is passed.
+        """
+        # Setup
+        mock_object = mock.MagicMock()
+        mock_distributor = mock.Mock(spec=GroupDistributor)
+        mock_distributor.validate_config.return_value = (False, 'fake message')
+
+        # Call the publish helper method and make sure a failed config validation raises an exception
+        self.assertRaises(PulpDataException, self.publish_manager._do_publish, mock_object, mock_object,
+                          mock_distributor, mock_object, mock_object)
 
     def test_publish_with_plugin_exception(self):
         # Setup

--- a/platform/test/unit/server/test_repo_publish_manager.py
+++ b/platform/test/unit/server/test_repo_publish_manager.py
@@ -19,8 +19,9 @@ import mock_plugins
 
 from pulp.common import dateutils, constants
 from pulp.plugins.model import PublishReport
+from pulp.plugins.distributor import Distributor
 from pulp.server.db.model.repository import Repo, RepoDistributor, RepoPublishResult
-from pulp.server.exceptions import InvalidValue
+from pulp.server.exceptions import InvalidValue, PulpDataException
 import pulp.server.managers.repo.cud as repo_manager
 import pulp.server.managers.repo.distributor as distributor_manager
 import pulp.server.managers.repo.publish as publish_manager
@@ -158,6 +159,19 @@ class RepoSyncManagerTests(base.PulpAsyncServerTests):
         self.assertEqual({}, call_args[2].plugin_config)
         self.assertEqual(distributor_config, call_args[2].repo_plugin_config)
         self.assertEqual(publish_overrides, call_args[2].override_config)
+
+    def test_publish_bad_override_config(self):
+        """
+        Tests a publish when invalid override configuration is passed.
+        """
+        # Setup
+        mock_object = mock.MagicMock()
+        mock_distributor = mock.Mock(spec=Distributor)
+        mock_distributor.validate_config.return_value = (False, 'fake message')
+
+        # Call the publish helper method and make sure a failed config validation raises an exception
+        self.assertRaises(PulpDataException, self.publish_manager._do_publish, mock_object, mock_object,
+                          mock_distributor, mock_object, mock_object, mock_object)
 
     def test_publish_missing_repo(self):
         """


### PR DESCRIPTION
Repositories validated configuration when creating and updating repositories, but never checked the configuration prior to publishing, so the override configuration for a publish operation was never validated.
