### PR TITLE
Fix nodes unit tests to work on el6; both tarfile and gzip versions don't support closures.

### DIFF
--- a/nodes/child/pulp_node/importers/download.py
+++ b/nodes/child/pulp_node/importers/download.py
@@ -127,8 +127,11 @@ class UnitDownloadManager(AggregatingEventListener):
         os.link(path, tar_path)
         os.unlink(path)
         try:
-            with tarfile.open(tar_path) as fp:
+            fp = tarfile.open(tar_path)
+            try:
                 fp.extractall(path=path)
+            finally:
+                fp.close()
         finally:
             if os.path.exists(tar_path):
                 os.unlink(tar_path)

--- a/nodes/test/unit/test_compression.py
+++ b/nodes/test/unit/test_compression.py
@@ -39,16 +39,22 @@ class TestCompression(TestCase):
         self.assertFalse(compressed(path))
         self.assertTrue(compressed(compressed_path))
         self.assertEqual(path + FILE_SUFFIX, compressed_path)
-        with gzip.open(compressed_path) as fp:
+        fp = gzip.open(compressed_path)
+        try:
             block_in = fp.read()
+        finally:
+            fp.close()
         self.assertEqual(block, block_in)
 
     def test_decompression(self):
         # Setup
         block = 'A' * 1024
         path = mktemp(dir=self.tmp_dir) + FILE_SUFFIX
-        with gzip.open(path, 'wb') as fp:
+        fp = gzip.open(path, 'wb')
+        try:
             fp.write(block)
+        finally:
+            fp.close()
         # Test
         decompressed_path = decompress(path)
         # Verify

--- a/nodes/test/unit/test_publishers.py
+++ b/nodes/test/unit/test_publishers.py
@@ -112,8 +112,11 @@ class TestHttp(TestCase):
             else:
                 self.assertTrue(os.path.islink(path))
             if n == 0:
-                with tarfile.open(path) as tb:
+                tb = tarfile.open(path)
+                try:
                     files = sorted(tb.getnames())
+                finally:
+                    tb.close()
                 self.assertEqual(len(files), self.NUM_TARED_FILES + 1)
             else:
                 with open(path, 'rb') as fp:


### PR DESCRIPTION
Conversion of 'with' statements used with tarfile and gzip to try: finally:

Also fixes, same bug in importer/download module.
