### PR TITLE
Update for developer setup steps, fix missing plugins directory

### DIFF
--- a/docs/sphinx/dev-guide/contributing/dev_setup.rst
+++ b/docs/sphinx/dev-guide/contributing/dev_setup.rst
@@ -46,6 +46,7 @@ and installed scripts. Setup scripts can be found in the following locations:
 * ``<pulp root>/platform/src``
 * ``<pulp root>/pulp_devel``
 * ``<pulp_rpm root>/pulp_rpm/src``
+* ``<pulp_rpm root>/plugins``
 * ``<pulp_puppet root>/pulp_puppet_common``
 * ``<pulp_puppet root>/pulp_puppet_extensions_admin``
 * ``<pulp_puppet root>/pulp_puppet_handlers``


### PR DESCRIPTION
Developer setup was missing the directory listing for pulp_rpm/plugins/ for running the setup.py command
