### PR TITLE
Compare unit file sizes as part of determining whether a unit needs to be downloaded

### DIFF
--- a/nodes/child/pulp_node/importers/download.py
+++ b/nodes/child/pulp_node/importers/download.py
@@ -12,7 +12,6 @@
 import os
 import tarfile
 
-from tempfile import mktemp
 from logging import getLogger
 
 from nectar.listener import AggregatingEventListener
@@ -26,8 +25,33 @@ from pulp_node.error import UnitDownloadError
 log = getLogger(__name__)
 
 
+# --- constants --------------------------------------------------------------
+
+STORAGE_PATH = constants.STORAGE_PATH
 UNIT_REF = 'unit_ref'
 
+
+# --- utils -------------------------------------------------------------------
+
+def untar_dir(path, storage_path):
+    """
+    Replaces the tarball at the specified path with the extracted directory tree.
+    :param path: The absolute path to a tarball.
+    :type path: str
+    :raise IOError: on i/o errors.
+    """
+    try:
+        fp = tarfile.open(path)
+        try:
+            fp.extractall(path=storage_path)
+        finally:
+            fp.close()
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+# --- downloading ------------------------------------------------------------
 
 class UnitDownloadManager(AggregatingEventListener):
     """
@@ -40,20 +64,25 @@ class UnitDownloadManager(AggregatingEventListener):
     """
 
     @staticmethod
-    def create_request(url, storage_path, unit_ref):
+    def create_request(unit_URL, destination, unit, unit_ref):
         """
         Create a nectar download request compatible with the listener.
-        :param url: The download URL.
-        :type url: str
-
-        :param storage_path: The absolute path to where the file is to be downloaded.
-        :type storage_path: str
+        :param unit_URL: The download URL.
+        :type unit_URL: str
+        :param destination: The absolute path to where the file is to be downloaded.
+        :type destination: str
+        :param unit: A published content unit.
+        :type unit: dict
         :param unit_ref: A reference to the unit association.
         :type unit_ref: pulp_node.manifest.UnitRef.
         :return: A nectar download request.
         :rtype: DownloadRequest
         """
-        return DownloadRequest(url, storage_path, data={UNIT_REF: unit_ref})
+        data = {
+            STORAGE_PATH: unit[constants.STORAGE_PATH],
+            UNIT_REF: unit_ref
+        }
+        return DownloadRequest(unit_URL, destination, data=data)
 
     def __init__(self, strategy, request):
         """
@@ -94,12 +123,13 @@ class UnitDownloadManager(AggregatingEventListener):
         :type report: nectar.report.DownloadReport.
         """
         super(self.__class__, self).download_succeeded(report)
+        storage_path = report.data[STORAGE_PATH]
         unit_ref = report.data[UNIT_REF]
         unit = unit_ref.fetch()
-        unit['storage_path'] = report.destination
+        unit[constants.STORAGE_PATH] = storage_path
         self._strategy.add_unit(self.request, unit)
-        if unit.get(constants.PUBLISHED_AS_TARBALL):
-            self.untar_dir(report.destination)
+        if unit.get(constants.TARBALL_PATH):
+            untar_dir(report.destination, storage_path)
         if self.request.cancelled():
             self.request.downloader.cancel()
 
@@ -114,27 +144,6 @@ class UnitDownloadManager(AggregatingEventListener):
         super(self.__class__, self).download_failed(report)
         if self.request.cancelled():
             self.request.downloader.cancel()
-
-    def untar_dir(self, path):
-        """
-        Replaces the tarball at the specified path with the extracted directory tree.
-        :param path: The absolute path to a tarball.
-        :type path: str
-        :raise IOError: on i/o errors.
-        """
-        parent_dir = os.path.dirname(path)
-        tar_path = mktemp(dir=parent_dir)
-        os.link(path, tar_path)
-        os.unlink(path)
-        try:
-            fp = tarfile.open(tar_path)
-            try:
-                fp.extractall(path=path)
-            finally:
-                fp.close()
-        finally:
-            if os.path.exists(tar_path):
-                os.unlink(tar_path)
 
     def error_list(self):
         """

--- a/nodes/child/pulp_node/importers/strategies.py
+++ b/nodes/child/pulp_node/importers/strategies.py
@@ -213,12 +213,14 @@ class ImporterStrategy(object):
         inventory = UnitInventory(base_URL, parent_units, child_units)
         return inventory
 
-    def _update_storage_path(self, unit):
+    def _reset_storage_path(self, unit):
         """
-        Update the unit's storage_path using the storage_dir defined in
+        Reset the storage_path using the storage_dir defined in
         server.conf and the relative_path injected when the unit was published.
         :param unit: A published unit.
         :type unit: dict
+        :return: The re-oriented storage path.
+        :rtype: str
         """
         storage_path = unit.get(constants.STORAGE_PATH)
         if not storage_path:
@@ -253,21 +255,37 @@ class ImporterStrategy(object):
         for unit, unit_ref in units:
             if request.cancelled():
                 return
-            self._update_storage_path(unit)
+            self._reset_storage_path(unit)
             if not self._needs_download(unit):
                 # unit has no file associated
                 self.add_unit(request, unit_ref.fetch())
                 continue
-            unit_path = pathlib.quote(unit[constants.RELATIVE_PATH])
+            unit_path, destination = self._path_and_destination(unit)
             unit_URL = pathlib.url_join(unit_inventory.base_URL, unit_path)
-            storage_path = unit[constants.STORAGE_PATH]
-            _request = manager.create_request(unit_URL, storage_path, unit_ref)
+            _request = manager.create_request(unit_URL, destination, unit, unit_ref)
             download_list.append(_request)
         if request.cancelled():
             return
         request.downloader.event_listener = manager
         request.downloader.download(download_list)
         request.summary.errors.extend(manager.error_list())
+
+    def _path_and_destination(self, unit):
+        """
+        Get the path component of the download URL and download destination.
+        :param unit: A content unit.
+        :type unit: dict
+        :return: (path, destination)
+        :rtype: tuple(2)
+        """
+        storage_path = unit[constants.STORAGE_PATH]
+        tar_path = unit.get(constants.TARBALL_PATH)
+        if not tar_path:
+            relative_path = unit[constants.RELATIVE_PATH]
+            return pathlib.quote(relative_path), storage_path
+        else:
+            return pathlib.quote(tar_path),\
+                pathlib.join(os.path.dirname(storage_path), os.path.basename(tar_path))
 
     def _needs_download(self, unit):
         """

--- a/nodes/common/pulp_node/constants.py
+++ b/nodes/common/pulp_node/constants.py
@@ -55,10 +55,7 @@ BASE_URL = 'base_url'
 STORAGE_PATH = 'storage_path'
 RELATIVE_PATH = 'relative_path'
 FILE_SIZE = 'size'
-
-PUBLISHED_AS_FILE = 'published_as_file'
-PUBLISHED_AS_TARBALL = 'published_as_tarball'
-PUBLISHING_METHODS = [PUBLISHED_AS_FILE, PUBLISHED_AS_TARBALL]
+TARBALL_PATH = 'tgz_path'
 
 
 # --- consumer notes ---------------------------------------------------------

--- a/nodes/parent/pulp_node/distributors/publisher.py
+++ b/nodes/parent/pulp_node/distributors/publisher.py
@@ -25,6 +25,41 @@ from pulp_node.manifest import Manifest, UnitWriter
 log = getLogger(__name__)
 
 
+# --- utils --------------------------------------------------------
+
+def tar_path(path):
+    """
+    Construct the tarball path.
+    :param path: A path
+    :type path: str
+    :return: The modified path
+    """
+    return path + '.TGZ'
+
+
+def tar_dir(path, tar_path, bufsize=65535):
+    """
+    Tar up the directory at the specified path.
+    :param path: The absolute path to a directory.
+    :type path: str
+    :param tar_path: The target path.
+    :type tar_path: str
+    :param bufsize: The buffer size to be used.
+    :type bufsize: int
+    :return: The path to the tarball
+    """
+    tb = tarfile.open(tar_path, 'w', bufsize=bufsize)
+    try:
+        _dir = os.path.basename(path)
+        tb.add(path, arcname=_dir)
+        return tar_path
+    finally:
+        tb.close()
+
+
+# --- publisher ----------------------------------------------------
+
+
 class Publisher(object):
     """
     The publisher does the heavy lifting for nodes distributor.
@@ -108,36 +143,16 @@ class FilePublisher(Publisher):
         storage_path = unit.get(constants.STORAGE_PATH)
         if not storage_path:
             # not all units have associated files.
-            unit[constants.FILE_SIZE] = 0
             return unit, None
-        unit[constants.FILE_SIZE] = os.path.getsize(storage_path)
         relative_path = unit[constants.RELATIVE_PATH]
         published_path = pathlib.join(self.tmp_dir, relative_path)
         pathlib.mkdir(os.path.dirname(published_path))
+        unit[constants.FILE_SIZE] = os.path.getsize(storage_path)
         if os.path.isdir(storage_path):
-            self.tar_dir(storage_path, published_path)
-            unit[constants.PUBLISHED_AS_TARBALL] = True
+            tar_dir(storage_path, tar_path(published_path))
+            unit[constants.TARBALL_PATH] = tar_path(relative_path)
         else:
             os.symlink(storage_path, published_path)
-            unit[constants.PUBLISHED_AS_FILE] = True
-
-    def tar_dir(self, path, tar_path, bufsize=65535):
-        """
-        Tar up the directory at the specified path.
-        :param path: The absolute path to a directory.
-        :type path: str
-        :param tar_path: The target path.
-        :type tar_path: str
-        :param bufsize: The buffer size to be used.
-        :type bufsize: int
-        :return:
-        """
-        tb = tarfile.open(tar_path, 'w', bufsize=bufsize)
-        try:
-            _dir = os.path.basename(path)
-            tb.add(path, arcname=_dir)
-        finally:
-            tb.close()
 
     def commit(self):
         """

--- a/nodes/test/unit/test_importer_strategies.py
+++ b/nodes/test/unit/test_importer_strategies.py
@@ -337,6 +337,21 @@ class TestBase(TestCase):
         self.assertTrue(request.downloader.download.called)
         self.assertTrue(request.downloader.cancel.called)
 
+    def test_needs_update(self):
+        # Setup
+        path = os.path.join(self.TMP_ROOT, 'unit_1')
+        with open(path, 'w+') as fp:
+            fp.write('123')
+        size = os.path.getsize(path)
+        strategy = ImporterStrategy()
+        # Test
+        unit = {constants.STORAGE_PATH: path, constants.FILE_SIZE: size}
+        self.assertFalse(strategy._needs_download(unit))
+        unit = {constants.STORAGE_PATH: '&&&&&&&', constants.FILE_SIZE: size}
+        self.assertTrue(strategy._needs_download(unit))
+        unit = {constants.STORAGE_PATH: path, constants.FILE_SIZE: size + 1}
+        self.assertTrue(strategy._needs_download(unit))
+
     def test_strategy_factory(self):
         for name, strategy in STRATEGIES.items():
             self.assertEqual(find_strategy(name), strategy)

--- a/nodes/test/unit/test_publishers.py
+++ b/nodes/test/unit/test_publishers.py
@@ -100,19 +100,18 @@ class TestHttp(TestCase):
         units = manifest.get_units()
         n = 0
         for unit, ref in units:
-            if n == 0:
-                self.assertTrue(unit[constants.PUBLISHED_AS_TARBALL])
-            else:
-                self.assertFalse(unit.get(constants.PUBLISHED_AS_TARBALL, False))
-            path = pathlib.join(publish_dir, repo_id, unit[constants.RELATIVE_PATH])
             self.assertEqual(
                 manifest.publishing_details[constants.BASE_URL],
                 pathlib.url_join(base_url, publish_dir, repo_id))
-            if n == 0:
+            if n == 0:  # TARBALL
+                path = pathlib.join(publish_dir, repo_id, unit[constants.TARBALL_PATH])
                 self.assertTrue(os.path.isfile(path))
             else:
+                path = pathlib.join(publish_dir, repo_id, unit[constants.RELATIVE_PATH])
                 self.assertTrue(os.path.islink(path))
-            if n == 0:
+                self.assertEqual(unit[constants.FILE_SIZE], os.path.getsize(path))
+            if n == 0:  # TARBALL
+                path = pathlib.join(publish_dir, repo_id, unit[constants.TARBALL_PATH])
                 tb = tarfile.open(path)
                 try:
                     files = sorted(tb.getnames())
@@ -120,6 +119,7 @@ class TestHttp(TestCase):
                     tb.close()
                 self.assertEqual(len(files), self.NUM_TARED_FILES + 1)
             else:
+                path = pathlib.join(publish_dir, repo_id, unit[constants.RELATIVE_PATH])
                 with open(path, 'rb') as fp:
                     unit_content = fp.read()
                     self.assertEqual(unit_content, unit_content)


### PR DESCRIPTION
Compare unit file sizes as part of determining whether a unit needs to be downloaded.  The main reason for doing this is to be sure we are not fooled by partial downloads.  This includes:
- publishing the file sizes
- comparing the file size specified in the unit to the file on disk.

Also, slight reworking of published directories (read as distributions).  Fixes case where downloading the tarball associated with a unit referencing a directory in the storage_path would fail because it would try to download the tarball to the storage_path, which is a directory.  The change is to write the tarball as a file with a different name and store that path as tarball_path in the content unit instead of the published_as_xx flag.  Download that and extract into the actual directory.
