### PR TITLE
a small performance improvement in applicability generation to get the p...

### DIFF
--- a/platform/src/pulp/server/managers/consumer/applicability.py
+++ b/platform/src/pulp/server/managers/consumer/applicability.py
@@ -242,7 +242,7 @@ class ApplicabilityRegenerationManager(object):
         :type:               boolean
         """
         query_params = {'repo_id': repo_id, 'profile_hash': profile_hash}
-        if RepoProfileApplicability.get_collection().find(query_params, fields=['_id']):
+        if RepoProfileApplicability.get_collection().find_one(query_params, fields=['_id']):
             return True
         return False
 


### PR DESCRIPTION
...rofile from existing_applicability instead of looking up in the db when existing_applicability is not None

This also contains -
1. Minor updates to a few comments
2. Changing _get_existing_applicability to _is_existing_applicability since we already have objects.get to get the entire object. When checking for whether applicability exists, we don't need to load an entire object with profile in it.
3.  Using cursor for all existing_applicabilities instead of a list of objects since we only need to load and act on one object at a time.
