### PR TITLE
nodes performance tweaks

### DIFF
--- a/nodes/child/pulp_node/importers/http/importer.py
+++ b/nodes/child/pulp_node/importers/http/importer.py
@@ -11,13 +11,12 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-import json
-
 from logging import getLogger
 from gettext import gettext as _
 
 from nectar.downloaders.curl import HTTPSCurlDownloader
 
+from pulp.server.compat import json
 from pulp.plugins.importer import Importer
 from pulp.plugins.util.nectar_config import importer_config_to_nectar_config
 

--- a/nodes/common/pulp_node/manifest.py
+++ b/nodes/common/pulp_node/manifest.py
@@ -17,7 +17,6 @@ json encoded file.  For performance reasons, the unit files are compressed.
 """
 
 import os
-import json
 import gzip
 import errno
 
@@ -25,6 +24,8 @@ from logging import getLogger
 
 from nectar.request import DownloadRequest
 from nectar.listener import AggregatingEventListener
+
+from pulp.server.compat import json
 
 from pulp_node import pathlib
 from pulp_node.error import ManifestDownloadError

--- a/nodes/parent/pulp_node/distributors/http/distributor.py
+++ b/nodes/parent/pulp_node/distributors/http/distributor.py
@@ -11,14 +11,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-import json
-
 from gettext import gettext as _
 from logging import getLogger
 
 from pulp.plugins.distributor import Distributor
 from pulp.server.managers import factory
 from pulp.server.config import config as pulp_conf
+from pulp.server.compat import json
 
 from pulp_node import constants
 from pulp_node import pathlib

--- a/nodes/parent/pulp_node/distributors/publisher.py
+++ b/nodes/parent/pulp_node/distributors/publisher.py
@@ -13,7 +13,6 @@ import os
 import tarfile
 
 from uuid import uuid4
-from shutil import rmtree
 from tempfile import mkdtemp
 from logging import getLogger
 
@@ -163,7 +162,7 @@ class FilePublisher(Publisher):
             # nothing to commit
             return
         dir_path = pathlib.join(self.publish_dir, self.repo_id)
-        rmtree(dir_path, ignore_errors=True)
+        os.system('rm -rf %s' % dir_path)
         os.rename(self.tmp_dir, dir_path)
         self.staged = False
 
@@ -171,7 +170,7 @@ class FilePublisher(Publisher):
         """
         Un-stage publishing.
         """
-        rmtree(self.tmp_dir, ignore_errors=True)
+        os.system('rm -rf %s' % self.tmp_dir)
         self.staged = False
 
     def __enter__(self):


### PR DESCRIPTION
simplejson is much faster than std lib json.  the pulp.server.compat attempts to import simplejson so better to use import json from there.

shutl.rmtree() is REALLY slow.  Removing a published RHEL 6 tree takes ~10 seconds using rmtree() and ~5 ms. using 'rm -rf'.  Not as portable but we can deal with that if we have to.  But for new, this really improves nodes publishing performance.
