### PR TITLE
fixing a unit test that would only pass in the central time zone, which ...

### DIFF
--- a/platform/src/pulp/common/dateutils.py
+++ b/platform/src/pulp/common/dateutils.py
@@ -301,7 +301,7 @@ def format_iso8601_timestamp(timestamp):
     @rtype: str
     @return: iso8601 representation of the passed in timestamp
     """
-    dt = datetime.datetime.fromtimestamp(timestamp)
+    dt = datetime.datetime.utcfromtimestamp(timestamp).replace(tzinfo=utc_tz())
     return format_iso8601_datetime(dt)
 
 # timestamp functions ----------------------------------------------------------

--- a/platform/test/unit/server/test_content_serialization.py
+++ b/platform/test/unit/server/test_content_serialization.py
@@ -11,6 +11,7 @@
 
 
 from unittest import TestCase
+
 from mock import patch
 
 from pulp.server.webservices.serialization import content
@@ -29,4 +30,4 @@ class TestSerialization(TestCase):
         serialized = content.content_unit_obj(unit)
         mock.assert_called_once_with(unit)
         self.assertTrue(LAST_UPDATED in serialized)
-        self.assertEqual(serialized[LAST_UPDATED], '2012-10-24T00:00:00')
+        self.assertEqual(serialized[LAST_UPDATED], '2012-10-24T05:00:00Z')

--- a/platform/test/unit/test_dateutils.py
+++ b/platform/test/unit/test_dateutils.py
@@ -163,7 +163,7 @@ class TestFormatting(unittest.TestCase):
         dt = datetime.datetime(2012, 10, 24, tzinfo=None)
         ts = time.mktime(dt.timetuple())
         formatted = dateutils.format_iso8601_timestamp(ts)
-        self.assertEqual(formatted, '2012-10-24T00:00:00')
+        self.assertEqual(formatted, '2012-10-24T04:00:00Z')
 
 
 # datetime math tests ----------------------------------------------------------


### PR DESCRIPTION
...involved fixing a function that turns a unix timestamp into an ISO8601 string.
