### PR TITLE
1009118 - bindings require python-oauth.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -274,6 +274,7 @@ A collection of components that are common between the pulp server and client.
 Summary: Pulp REST bindings for python
 Group: Development/Languages
 Requires: python-%{name}-common = %{pulp_version}
+Requires: python-oauth2 >= 1.5.170-2.pulp
 Requires: m2crypto
 
 %description -n python-pulp-bindings


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1009118

Was considering making oauth optional for bindings but we already require m2crypto so this is just another dep.  I do wonder however it this requirement could simply be Requires: python-oauth2 (not our special brew).
