### PR TITLE
1004559 - python-simplejson is now required by pulp-common on rhel5. thi...

### DIFF
--- a/bindings/pulp/bindings/server.py
+++ b/bindings/pulp/bindings/server.py
@@ -20,13 +20,9 @@ import oauth2 as oauth
 from types import NoneType
 from M2Crypto import SSL, httpslib
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
-
 from pulp.bindings import exceptions
 from pulp.bindings.responses import Response, Task
+from pulp.common.compat import json
 from pulp.common.util import ensure_utf_8
 
 

--- a/client_lib/pulp/client/commands/criteria.py
+++ b/client_lib/pulp/client/commands/criteria.py
@@ -12,16 +12,13 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 from gettext import gettext as _
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 from okaara.cli import CommandUsage, OptionGroup
 
 from pulp.client import parsers
 from pulp.client import validators
 from pulp.client.extensions.extensions import PulpCliCommand, PulpCliOption, PulpCliFlag
+from pulp.common.compat import json
 
 
 _LIMIT_DESCRIPTION = _('max number of items to return')

--- a/pulp.spec
+++ b/pulp.spec
@@ -254,6 +254,10 @@ Group: Development/Languages
 Obsoletes: pulp-common
 Requires: python-isodate >= 0.5.0-1.pulp
 Requires: python-iniparse
+# RHEL5 ONLY
+%if 0%{?rhel} == 5
+Requires: python-simplejson
+%endif
 
 %description -n python-pulp-common
 A collection of components that are common between the pulp server and client.


### PR DESCRIPTION
...s also removes any direct imports of simplejson from outside the pulp-common package.

https://bugzilla.redhat.com/show_bug.cgi?id=1004559
