### PR TITLE
adding a specific selinux-policy-targeted version dependency when instal...

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -441,8 +441,11 @@ Obsoletes: pulp-selinux-server
 %if "%{selinux_policyver}" != ""
 Requires: selinux-policy >= %{selinux_policyver}
 %endif
+%if 0%{?fedora} == 19
+Requires(post): policycoreutils-python >= 3.12.1-74
+%else
 Requires(post): policycoreutils-python
-Requires(post): selinux-policy-targeted
+%endif
 Requires(post): /usr/sbin/semodule, /sbin/fixfiles, /usr/sbin/semanage
 Requires(postun): /usr/sbin/semodule
 


### PR DESCRIPTION
...ling pulp on F19 as the base version of selinux-policy-targeted has a bug causing pulp_selinux installation to fail

https://bugzilla.redhat.com/show_bug.cgi?id=1011716
