### PR TITLE
Put a placeholder task tagging API into place.

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -24,15 +24,36 @@ class Task(CeleryTask):
     This is a custom Pulp subclass of the Celery Task object. It allows us to inject some custom
     behavior into each Pulp task, including management of resource locking.
     """
+    def apply_async(self, *args, **kwargs):
+        """
+        A wrapper around the Celery apply_async method. It allows us to accept a few more
+        parameters than Celery does for our own purposes, listed below.
+
+        :param tags:        A list of tags (strings) to place onto the task, used for searching for
+                            tasks by tag
+        :type  tags:        list
+        :return:            An AsyncResult instance as returned by Celery's apply_async
+        :rtype:             celery.result.AsyncResult
+        """
+        tags = kwargs.pop('tags', [])
+
+        return super(Task, self).apply_async(*args, **kwargs)
+
     def apply_async_with_reservation(self, resource_id, *args, **kwargs):
         """
         This method allows the caller to schedule the Task to run asynchronously just like Celery's
         apply_async, while also making the named resource. No two tasks that claim the same
         resource reservation can execute concurrently.
 
+        For a list of parameters accepted by the *args and **kwargs parameters, please see the
+        docblock for the apply_async() method.
+
         :param resource_id: A string that identifies some named resource, guaranteeing that only one
                             task reserving this same string can happen at a time.
         :type  resource_id: basestring
+        :param tags:        A list of tags (strings) to place onto the task, used for searching for
+                            tasks by tag
+        :type  tags:        list
         :return:            An AsyncResult instance as returned by Celery's apply_async
         :rtype:             celery.result.AsyncResult
         """


### PR DESCRIPTION
The API doesn't work yet, but we want to have a way in place to express
task tags as we convert our tasks for Celery.
