### PR TITLE
1022646 - migration_0 needs to add units_size=0.

### DIFF
--- a/nodes/common/pulp_node/migration.py
+++ b/nodes/common/pulp_node/migration.py
@@ -42,6 +42,7 @@ def migration_0(manifest):
     :return: The migrated manifest.
     """
     manifest[VERSION] = 0
+    manifest[UNITS_SIZE] = 0
     manifest[UNITS_PATH] = None
     return manifest
 

--- a/nodes/test/unit/test_migration.py
+++ b/nodes/test/unit/test_migration.py
@@ -26,14 +26,13 @@ MANIFEST_ID = 'test_1'
 
 manifest_0 = {
     TOTAL_UNITS: 100,
-    UNITS_SIZE: 123,
     UNITS_PATH: 'http://rdhat.com/units.json.gz'
 }
 
 manifest_1 = {
     VERSION: 1,
     TOTAL_UNITS: 100,
-    UNITS_SIZE: 123,
+    UNITS_SIZE: 0,
 }
 
 manifest_2 = {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1022646

The <= 2.2 nodes manifest did not have the "units_size" field.  Adding the field set to 0, we enable the migration to complete, making the manifest safe to read.  With this value set to 0, the migrated manifest will be declared invalid and replaced with the downloaded manifest.  This is what we want since 2.2 manifests are not usable in 2.3 and we want them to just be re-downloaded.
