### PR TITLE
1027500 - init python-gofer before agent and tasking services started.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -182,7 +182,7 @@ Requires: mod_ssl
 Requires: openssl
 Requires: nss-tools
 Requires: python-ldap
-Requires: python-gofer >= 0.77.1
+Requires: python-gofer >= 0.77
 Requires: crontabs
 Requires: acl
 Requires: mod_wsgi >= 3.4-1.pulp

--- a/server/pulp/server/agent/direct/services.py
+++ b/server/pulp/server/agent/direct/services.py
@@ -49,15 +49,17 @@ class Services:
 
     CTAG = 'pulp.task'
 
-    @classmethod
-    def start(cls):
+    @staticmethod
+    def init():
         url = config.get('messaging', 'url')
-        log.info('Using URL: %s', url)
-        # broker configuration
         broker = Broker(url)
         broker.cacert = config.get('messaging', 'cacert')
         broker.clientcert = config.get('messaging', 'clientcert')
-        log.info('AMQP broker configured')
+        log.info('AMQP broker configured: %s', broker)
+
+    @classmethod
+    def start(cls):
+        url = config.get('messaging', 'url')
         # watchdog
         journal = Journal('/var/lib/pulp/journal/watchdog')
         cls.watchdog = WatchDog(url=url, journal=journal)

--- a/server/pulp/server/webservices/application.py
+++ b/server/pulp/server/webservices/application.py
@@ -100,6 +100,9 @@ def _initialize_pulp():
     if _IS_INITIALIZED:
         return
 
+    # configure agent services
+    AgentServices.init()
+
     # Verify the database has been migrated to the correct version. This is
     # very likely a reason the server will fail to start.
     try:
@@ -140,7 +143,7 @@ def _initialize_pulp():
     # database document reaper
     reaper.initialize()
 
-    # agent services
+    # start agent services
     AgentServices.start()
 
     # Setup debugging, if configured


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1027500

Also moving back to gofer 0.77 for now.  0.77.1 uses python-qpid builtin SSL instead of very old work around for when python-qpid SSL did not support client certificates.  However, on f19, this work around is broken because the transport API changed in python-qpid-0.24.  Long story short, the builtin SSL does validates the hostname in the server cert matches.  For MDP2, it is always localhost.  Rather than introducing installer changes, we can just relax the requirement on gofer so that 0.77 will suffice.
