### PR TITLE
Casting fields to a list

### DIFF
--- a/server/pulp/server/managers/repo/unit_association_query.py
+++ b/server/pulp/server/managers/repo/unit_association_query.py
@@ -417,9 +417,11 @@ class RepoUnitAssociationQueryManager(object):
         spec = criteria.unit_filters.copy()
         spec['_id'] = {'$in': associated_unit_ids}
 
-        fields = copy.copy(criteria.unit_fields)
+        fields = criteria.unit_fields
+
         # The _content_type_id is required for looking up the association.
         if fields is not None and '_content_type_id' not in fields:
+            fields = list(fields)
             fields.append('_content_type_id')
 
         cursor = collection.find(spec, fields=fields)


### PR DESCRIPTION
casting fields to a list will (1) guarantee that we can append to it (2)create a copy of the original, even if already a list, to keep us from changing the criteria as a side-effect
