### PR TITLE
correcting the documented permission required for sync and publish

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/repo/publish.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/repo/publish.rst
@@ -11,7 +11,7 @@ call always executes asynchronously and will return a :term:`call report`.
 
 | :method:`post`
 | :path:`/v2/repositories/<repo_id>/actions/publish/`
-| :permission:`update`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`id,str,identifies which distributor on the repository to publish`

--- a/docs/sphinx/dev-guide/integration/rest-api/repo/sync.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/repo/sync.rst
@@ -10,7 +10,7 @@ Syncs content into a repository from a feed source using the repository's
 
 | :method:`post`
 | :path:`/v2/repositories/<repo_id>/actions/sync/`
-| :permission:`update`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`override_config,object,importer configuration values that override the importer's default configuration for this sync`


### PR DESCRIPTION
I confirmed this by looking at the web controllers directly.
