### PR TITLE
1048297 - pulp-dev.py sets the CA cert and key world readable.

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -182,7 +182,7 @@ def getlinks():
             src, dst = apache_22_conf
 
         links.append((src, dst))
-    
+
     return links
 
 
@@ -208,6 +208,11 @@ def install(opts):
     print 'generating certificates'
     os.system(os.path.join(os.curdir, 'server/bin/pulp-gen-ca-certificate'))
     os.system(os.path.join(os.curdir, 'nodes/common/bin/pulp-gen-nodes-certificate'))
+
+    # Unfortunately, our unit tests fail to mock the CA certificate and key, so we need to make
+    # those world readable. Until we fix this, we cannot close #1048297
+    os.system('chmod 644 /etc/pki/pulp/ca.*')
+    os.system('chown apache:apache /etc/pki/pulp/content')
 
     if warnings:
         print "\n***\nPossible problems:  Please read below\n***"


### PR DESCRIPTION
It also makes /etc/pki/pulp/content owned by Apache.

https://bugzilla.redhat.com/show_bug.cgi?id=1048297
