### PR TITLE
Proposed way to get the version via server/api call easily.

### DIFF
--- a/server/pulp/__init__.py
+++ b/server/pulp/__init__.py
@@ -14,3 +14,4 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
+__version__ = '2.3.0'

--- a/server/pulp/server/webservices/controllers/status.py
+++ b/server/pulp/server/webservices/controllers/status.py
@@ -17,14 +17,24 @@ Unauthenticated status API so that other can make sure we're up (to no good).
 
 import web
 
+from pulp import __version__
+
 from pulp.server.webservices.controllers.base import JSONController
 
 # status controller ------------------------------------------------------------
 
 class StatusController(JSONController):
 
+    #: Always the full version. Ex: 2.3.1
+    _server_version = __version__
+    #: Always the current supported api version in x.y format. Ex: 2.3
+    _api_version = ".".join(__version__.split('.')[0:2])
+
     def GET(self):
-        status_data = {'api_version': '2'}
+        status_data = {
+            'api_version': self._api_version,
+            'server_version': self._server_version,
+        }
         return self.ok(status_data)
 
 # web.py application -----------------------------------------------------------

--- a/server/setup.py
+++ b/server/setup.py
@@ -9,11 +9,13 @@
 # along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+from pulp import __version__
+
 from setuptools import setup, find_packages
 
 setup(
     name='pulp-server',
-    version='2.3.0',
+    version=__version__,
     license='GPLv2+',
     packages=find_packages(exclude=['test']),
     author='Pulp Team',


### PR DESCRIPTION
Instead of hard coding the api version and placing the distribution version in setup.py this moves the version string to server/pulp/__init__.py as __version__. The api_version and server_version (new) returned in StatusController are based off of __version__ as is setup.py's version parameter. This also allows a running server to be aware of it's current version via:

``` python
from pulp import __version__
```

**Note**: This was not tested well and should either be verified before accepting OR used as an example for implementation.
