### PR TITLE
Updating consumer content docs.

### DIFF
--- a/docs/sphinx/dev-guide/conventions/scheduled.rst
+++ b/docs/sphinx/dev-guide/conventions/scheduled.rst
@@ -10,7 +10,7 @@ Pulp utilizes the ISO8601 interval format for specifying these schedules. It
 supports recurrences, start times, and durations for any scheduled task. The
 recurrence and start time is optional on any schedule. When the recurrence is
 omitted, it is assumed to recur indefinitely. When the start time is omitted,
-the start time is calculated as now plus the length of one duration.
+the start time is assumed to be now.
 
 More information on ISO8601 interval formats can be found here:
 http://en.wikipedia.org/wiki/ISO_8601#Time_intervals
@@ -26,24 +26,44 @@ resources in Pulp's REST API. All scheduled tasks will have the following fields
  * ``consecutive_failures`` The number of consecutive failures the scheduled tasks has experienced
  * ``remaining_runs`` The number of runs remaining
  * ``first_run`` The date and time of the first run as an ISO8601 datetime
- * ``last_run`` The date and time of the last run as an ISO8601 datetime
+ * ``last_run_at`` The date and time of the last run as an ISO8601 datetime (changed in 2.4 from ``last_run``)
  * ``next_run`` The date and time of the next run as an ISO8601 datetime
+ * ``task`` The name (also the python path) of the task that will be executed
 
 Scheduled tasks may have additional fields that are specific to that particular
 task.
 
 Sample scheduled task resource ::
 
- {
-  '_id': '505cba846157770636000000',
-  '_href': '/pulp/api/v2/<collection>/<resource id>/schedules/<type>/505cba846157770636000000/',
-  'schedule': 'R5/2012-10-31T02:00:00Z/P1WT',
-  'failure_threshold': 3,
-  'enabled': true,
-  'consecutive_failures': 0,
-  'remaining_runs': 5,
-  'first_run': '2012-10-31T02:00:00Z',
-  'last_run': null,
-  'next_run': '2012-10-31T02:00:00Z',
- }
+  {
+    "next_run": "2014-01-28T16:33:26Z",
+    "task": "pulp.server.tasks.consumer.update_content",
+    "last_updated": 1390926003.828128,
+    "first_run": "2014-01-28T10:35:08Z",
+    "schedule": "2014-01-28T10:35:08Z/P1D",
+    "args": [
+      "me"
+    ],
+    "enabled": true,
+    "last_run_at": null,
+    "_id": "52e7d8b3dd01fb0c8428b8c2",
+    "total_run_count": 0,
+    "failure_threshold": null,
+    "kwargs": {
+      "units": [
+        {
+          "unit_key": {
+            "name": "pulp-server"
+          },
+          "type_id": "rpm"
+        }
+      ],
+      "options": {}
+    },
+    "resource": "pulp:consumer:me",
+    "remaining_runs": null,
+    "consecutive_failures": 0,
+    "options": {},
+    "_href": "/pulp/api/v2/consumers/me/schedules/content/update/52e7d8b3dd01fb0c8428b8c2/"
+  }
 

--- a/docs/sphinx/dev-guide/integration/rest-api/consumer/scheduled_content.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/consumer/scheduled_content.rst
@@ -8,16 +8,13 @@ with the following APIs.
 Note that all schedule resources are in the format described in
 :ref:`scheduled_tasks`.
 
-
-
-Scheduling Content Installs
----------------------------
+For each request, ``<action>`` should be one of ``install``, ``update``, or ``uninstall``.
 
 Listing Schedules
-^^^^^^^^^^^^^^^^^
+-----------------
 
 | :method:`GET`
-| :path:`/v2/consumers/<consumer id>/schedules/install/`
+| :path:`/v2/consumers/<consumer id>/schedules/<action>/`
 | :permission:`READ`
 | :response_list:`_`
 
@@ -29,30 +26,52 @@ Listing Schedules
 :sample_response:`200` ::
 
  [
-  {"_id": "505cc1216157770636000001",
-   "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/install/505cc1216157770636000001/",
-   "schedule": "P1DT",
-  "failure_threshold": null,
-   "enabled": true,
-   "consecutive_failures": 0,
-   "remaining_runs": null,
-   "first_run": "2012-09-19T00:00:00Z",
-   "last_run": "2012-09-20T00:00:00Z",
-   "next_run": "2012-09-21T00:00:00Z",
-   "options": {},
-   "units": [{"type_id": "rpm",
-              "unit_keys": {"name": "zsh"}},
-             {"type_id": "rpm",
-              "unit_keys": {"name": "bash"}},]
-  },
+  {
+    "next_run": "2014-01-28T16:33:26Z",
+    "task": "pulp.server.tasks.consumer.update_content",
+    "last_updated": 1390926003.828128,
+    "first_run": "2014-01-28T10:35:08Z",
+    "schedule": "2014-01-28T10:35:08Z/P1D",
+    "args": [
+      "me"
+    ],
+    "enabled": true,
+    "last_run_at": null,
+    "_id": "52e7d8b3dd01fb0c8428b8c2",
+    "total_run_count": 0,
+    "failure_threshold": null,
+    "kwargs": {
+      "units": [
+        {
+          "unit_key": {
+            "name": "pulp-server"
+          },
+          "type_id": "rpm"
+        }
+      ],
+      "options": {}
+    },
+    "units": [
+      {
+        "unit_key": {
+          "name": "pulp-server"
+        },
+        "type_id": "rpm"
+      }
+    ],
+    "resource": "pulp:consumer:me",
+    "remaining_runs": null,
+    "consecutive_failures": 0,
+    "options": {},
+    "_href": "/pulp/api/v2/consumers/me/schedules/content/update/52e7d8b3dd01fb0c8428b8c2/"
+  }
  ]
 
-
 Creating a Schedule
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 | :method:`POST`
-| :path:`/v2/consumers/<consumer id>/schedules/install/`
+| :path:`/v2/consumers/<consumer id>/schedules/<action>/`
 | :permission:`CREATE`
 | :param_list:`POST`
 
@@ -67,8 +86,6 @@ Creating a Schedule
 * :response_code:`201,if the schedule was successfully created`
 * :response_code:`400,if any of the required params are missing or any params are invalid`
 * :response_code:`404,if the consumer does not exist`
-* :response_code:`409,if another server-side operation is permanently preventing the schedule from being created`
-* :response_code:`503,if another server-side operation is temporarily preventing the schedule from being created`
 
 | :return:`resource representation of the new schedule`
 
@@ -80,26 +97,52 @@ Creating a Schedule
 
 :sample_response:`201` ::
 
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/install/505ccb526157770636000002/",
-  "schedule": "R1/P1DT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": 1,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
+ {
   "next_run": "2012-09-22T14:15:00Z",
+  "task": "pulp.server.tasks.consumer.update_content",
+  "last_updated": 1390926003.828128,
+  "first_run": "2012-09-22T14:15:00Z",
+  "schedule": "R1/P1DT",
+  "args": [
+    "me"
+  ],
+  "enabled": true,
+  "last_run_at": null,
+  "_id": "52e7d8b3dd01fb0c8428b8c2",
+  "total_run_count": 0,
+  "failure_threshold": null,
+  "kwargs": {
+    "units": [
+      {
+        "unit_key": {
+          "name": "gofer"
+        },
+        "type_id": "rpm"
+      }
+    ],
+    "options": {}
+  },
+  "units": [
+    {
+      "unit_key": {
+        "name": "gofer"
+      },
+      "type_id": "rpm"
+    }
+  ],
+  "resource": "pulp:consumer:me",
+  "remaining_runs": 1,
+  "consecutive_failures": 0,
   "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}],
+  "_href": "/pulp/api/v2/consumers/me/schedules/content/update/52e7d8b3dd01fb0c8428b8c2/"
  }
 
 
 Retrieving a Schedule
-^^^^^^^^^^^^^^^^^^^^^
+---------------------
 
 | :method:`GET`
-| :path:`/v2/consumers/<consumer id>/schedules/install/<schedule id>/`
+| :path:`/v2/consumers/<consumer id>/schedules/<action>/<schedule id>/`
 | :permission:`READ`
 | :response_list:`_`
 
@@ -110,27 +153,51 @@ Retrieving a Schedule
 
 :sample_response:`200` ::
 
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/install/505ccb526157770636000002/",
-  "schedule": "R1/P1DT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": 1,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-22T14:15:00Z",
-  "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}],
+ {
+    "_href": "/pulp/api/v2/consumers/me/schedules/content/update/52e7d8b3dd01fb0c8428b8c2/",
+    "_id": "52e7d8b3dd01fb0c8428b8c2",
+    "args": [
+        "consumer1"
+    ],
+    "consecutive_failures": 0,
+    "enabled": true,
+    "failure_threshold": null,
+    "first_run": "2014-01-28T10:35:08Z",
+    "kwargs": {
+        "options": {},
+        "units": [
+            {
+                "type_id": "rpm",
+                "unit_key": {
+                    "name": "pulp-server"
+                }
+            }
+        ]
+    },
+    "last_run_at": null,
+    "last_updated": 1390926003.828128,
+    "next_run": "2014-01-28T16:50:47Z",
+    "options": {},
+    "remaining_runs": null,
+    "resource": "pulp:consumer:me",
+    "schedule": "2014-01-28T10:35:08Z/P1D",
+    "task": "pulp.server.tasks.consumer.update_content",
+    "total_run_count": 0,
+    "units": [
+        {
+            "type_id": "rpm",
+            "unit_key": {
+                "name": "pulp-server"
+            }
+        }
+    ]
  }
 
-
-
 Updating a Schedule
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 | :method:`PUT`
-| :path:`/v2/consumers/<consumer id>/schedules/install/<schedule id>/`
+| :path:`/v2/consumers/<consumer id>/schedules/<action>/<schedule id>/`
 | :permission:`UPDATE`
 | :param_list:`PUT`
 
@@ -145,419 +212,81 @@ Updating a Schedule
 
 
 * :response_code:`200,if the schedule was successfully updated`
-* :response_code:`202,if another server-side operation is temporarily preventing the schedule from being updated`
 * :response_code:`400,if any of the params are invalid`
 * :response_code:`404,if the consumer or schedule does not exist`
-* :response_code:`409,if another server-side operation is permanently preventing the schedule from being updated`
 
 | :return:`resource representation of the schedule`
 
 :sample_request:`_` ::
 
- {"schedule": "P1WT",
+ {
   "units": [{"type_id": "rpm", "unit_keys": {"name": "grinder"}},
             {"type_id": "rpm", "unit_keys": {"name": "gofer"}}]
  }
 
 :sample_response:`200` ::
 
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/install/505ccb526157770636000002/",
-  "schedule": "P1WT",
+ {
+  "next_run": "2014-01-28T16:54:26Z",
+  "task": "pulp.server.tasks.consumer.update_content",
+  "last_updated": 1390928066.995197,
+  "first_run": "2014-01-28T10:35:08Z",
+  "schedule": "2014-01-28T10:35:08Z/P1D",
+  "args": [
+    "me"
+  ],
+  "enabled": false,
+  "last_run_at": null,
+  "_id": "52e7d8b3dd01fb0c8428b8c2",
+  "total_run_count": 0,
   "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": null,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-29T14:15:00Z",
-  "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}},
-            {"type_id": "rpm", "unit_keys": {"name": "grinder"}}],
- }
-
-
-
-Deleting a Schedule
-^^^^^^^^^^^^^^^^^^^
-
-| :method:`DELETE`
-| :path:`/v2/consumers/<consumer id>/schedules/install/<schedule id>/`
-| :permission:`DELETE`
-| :response_list:`_`
-
-* :response_code:`200,if the schedule was deleted successfully`
-* :response_code:`202,if another server-side operation is temporarily preventing the schedule from being deleted`
-* :response_code:`404,if the consumer or schedule does not exist`
-
-| :return:`null`
-
-
-
-Scheduling Content Updates
---------------------------
-
-Listing Schedules
-^^^^^^^^^^^^^^^^^
-
-| :method:`GET`
-| :path:`/v2/consumers/<consumer id>/schedules/update/`
-| :permission:`READ`
-| :response_list:`_`
-
-* :response_code:`200, if the consumer exists`
-* :response_code:`404, if the consumer does not exist`
-
-| :return:`(possibly empty) array of schedule resources`
-
-:sample_response:`200` ::
-
- [
-  {"_id": "505cc1216157770636000001",
-   "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/update/505cc1216157770636000001/",
-   "schedule": "P1DT",
-  "failure_threshold": null,
-   "enabled": true,
-   "consecutive_failures": 0,
-   "remaining_runs": null,
-   "first_run": "2012-09-19T00:00:00Z",
-   "last_run": "2012-09-20T00:00:00Z",
-   "next_run": "2012-09-21T00:00:00Z",
-   "options": {},
-   "units": [{"type_id": "rpm",
-              "unit_keys": {"name": "zsh"}},
-             {"type_id": "rpm",
-              "unit_keys": {"name": "bash"}},]
+  "kwargs": {
+    "units": [
+      {
+        "unit_key": {
+          "name": "grinder"
+        },
+        "type_id": "rpm"
+      },
+      {
+        "unit_key": {
+          "name": "gofer"
+        },
+        "type_id": "rpm"
+      }
+    ],
+    "options": {}
   },
- ]
-
-
-Creating a Schedule
-^^^^^^^^^^^^^^^^^^^
-
-| :method:`POST`
-| :path:`/v2/consumers/<consumer id>/schedules/update/`
-| :permission:`CREATE`
-| :param_list:`POST`
-
-* :param:`schedule,string,schedule in iso8601 interval format`
-* :param:`?failure_threshold,integer,number of consecutive failures allowed before automatically disabling`
-* :param:`?enabled,boolean,whether or not the schedule is enabled (enabled by default)`
-* :param:`?options,object,key - value options to pass to the update agent`
-* :param:`units,array,array of units to update`
-
-| :response_list:`_`
-
-* :response_code:`201,if the schedule was successfully created`
-* :response_code:`400,if any of the required params are missing or any params are invalid`
-* :response_code:`404,if the consumer does not exist`
-* :response_code:`409,if another server-side operation is permanently preventing the schedule from being created`
-* :response_code:`503,if another server-side operation is temporarily preventing the schedule from being created`
-
-| :return:`resource representation of the new schedule`
-
-:sample_request:`_` ::
-
- {"schedule": "R1/P1DT",
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}]
- }
-
-:sample_response:`201` ::
-
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/update/505ccb526157770636000002/",
-  "schedule": "R1/P1DT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": 1,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-22T14:15:00Z",
-  "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}],
- }
-
-
-Retrieving a Schedule
-^^^^^^^^^^^^^^^^^^^^^
-
-| :method:`GET`
-| :path:`/v2/consumers/<consumer id>/schedules/update/<schedule id>/`
-| :permission:`READ`
-| :response_list:`_`
-
-* :response_code:`200,if both the consumer and the scheduled update exist`
-* :response_code:`404,if either the consumer or scheduled update does not exist`
-
-| :return:`schedule resource representation`
-
-:sample_response:`200` ::
-
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/update/505ccb526157770636000002/",
-  "schedule": "R1/P1DT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": 1,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-22T14:15:00Z",
-  "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}],
- }
-
-
-
-Updating a Schedule
-^^^^^^^^^^^^^^^^^^^
-
-| :method:`PUT`
-| :path:`/v2/consumers/<consumer id>/schedules/update/<schedule id>/`
-| :permission:`UPDATE`
-| :param_list:`PUT`
-
-* :param:`?schedule,string,schedule as an iso8601 interval (specifying a recurrence will affect remaining_runs)`
-* :param:`?failure_threshold,integer,number of allowed consecutive failures before the schedule is disabled`
-* :param:`?remaining_runs,integer,number of remaining runs for schedule`
-* :param:`?enabled,boolean,whether or not the schedule is enabled`
-* :param:`?options,object,key - value options to pass to the update agent`
-* :param:`?units,array,array of units to update`
-
-| :response_list:`_`
-
-
-* :response_code:`200,if the schedule was successfully updated`
-* :response_code:`202,if another server-side operation is temporarily preventing the schedule from being updated`
-* :response_code:`400,if any of the params are invalid`
-* :response_code:`404,if the consumer or schedule does not exist`
-* :response_code:`409,if another server-side operation is permanently preventing the schedule from being updated`
-
-| :return:`resource representation of the schedule`
-
-:sample_request:`_` ::
-
- {"schedule": "P1WT",
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "grinder"}},
-            {"type_id": "rpm", "unit_keys": {"name": "gofer"}}]
- }
-
-:sample_response:`200` ::
-
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/update/505ccb526157770636000002/",
-  "schedule": "P1WT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
+  "units": [
+    {
+      "unit_key": {
+        "name": "grinder"
+      },
+      "type_id": "rpm"
+    },
+    {
+      "unit_key": {
+        "name": "gofer"
+      },
+      "type_id": "rpm"
+    }
+  ],
+  "resource": "pulp:consumer:me",
   "remaining_runs": null,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-29T14:15:00Z",
+  "consecutive_failures": 0,
   "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}},
-            {"type_id": "rpm", "unit_keys": {"name": "grinder"}}],
+  "_href": "/pulp/api/v2/consumers/me/schedules/content/update/52e7d8b3dd01fb0c8428b8c2/"
  }
-
-
 
 Deleting a Schedule
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 | :method:`DELETE`
-| :path:`/v2/consumers/<consumer id>/schedules/update/<schedule id>/`
+| :path:`/v2/consumers/<consumer id>/schedules/<action>/<schedule id>/`
 | :permission:`DELETE`
 | :response_list:`_`
 
 * :response_code:`200,if the schedule was deleted successfully`
-* :response_code:`202,if another server-side operation is temporarily preventing the schedule from being deleted`
 * :response_code:`404,if the consumer or schedule does not exist`
 
 | :return:`null`
-
-
-
-Scheduling Content Uninstalls
------------------------------
-
-Listing Schedules
-^^^^^^^^^^^^^^^^^
-
-| :method:`GET`
-| :path:`/v2/consumers/<consumer id>/schedules/uninstall/`
-| :permission:`READ`
-| :response_list:`_`
-
-* :response_code:`200, if the consumer exists`
-* :response_code:`404, if the consumer does not exist`
-
-| :return:`(possibly empty) array of schedule resources`
-
-:sample_response:`200` ::
-
- [
-  {"_id": "505cc1216157770636000001",
-   "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/uninstall/505cc1216157770636000001/",
-   "schedule": "P1DT",
-  "failure_threshold": null,
-   "enabled": true,
-   "consecutive_failures": 0,
-   "remaining_runs": null,
-   "first_run": "2012-09-19T00:00:00Z",
-   "last_run": "2012-09-20T00:00:00Z",
-   "next_run": "2012-09-21T00:00:00Z",
-   "options": {},
-   "units": [{"type_id": "rpm",
-              "unit_keys": {"name": "zsh"}},
-             {"type_id": "rpm",
-              "unit_keys": {"name": "bash"}},]
-  },
- ]
-
-
-Creating a Schedule
-^^^^^^^^^^^^^^^^^^^
-
-| :method:`POST`
-| :path:`/v2/consumers/<consumer id>/schedules/uninstall/`
-| :permission:`CREATE`
-| :param_list:`POST`
-
-* :param:`schedule,string,schedule in iso8601 interval format`
-* :param:`?failure_threshold,integer,number of consecutive failures allowed before automatically disabling`
-* :param:`?enabled,boolean,whether or not the schedule is enabled (enabled by default)`
-* :param:`?options,object,key - value options to pass to the uninstall agent`
-* :param:`units,array,array of units to uninstall`
-
-| :response_list:`_`
-
-* :response_code:`201,if the schedule was successfully created`
-* :response_code:`400,if any of the required params are missing or any params are invalid`
-* :response_code:`404,if the consumer does not exist`
-* :response_code:`409,if another server-side operation is permanently preventing the schedule from being created`
-* :response_code:`503,if another server-side operation is temporarily preventing the schedule from being created`
-
-| :return:`resource representation of the new schedule`
-
-:sample_request:`_` ::
-
- {"schedule": "R1/P1DT",
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}]
- }
-
-:sample_response:`201` ::
-
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/uninstall/505ccb526157770636000002/",
-  "schedule": "R1/P1DT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": 1,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-22T14:15:00Z",
-  "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}],
- }
-
-
-Retrieving a Schedule
-^^^^^^^^^^^^^^^^^^^^^
-
-| :method:`GET`
-| :path:`/v2/consumers/<consumer id>/schedules/uninstall/<schedule id>/`
-| :permission:`READ`
-| :response_list:`_`
-
-* :response_code:`200,if both the consumer and the scheduled uninstall exist`
-* :response_code:`404,if either the consumer or scheduled uninstall does not exist`
-
-| :return:`schedule resource representation`
-
-:sample_response:`200` ::
-
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/uninstall/505ccb526157770636000002/",
-  "schedule": "R1/P1DT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": 1,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-22T14:15:00Z",
-  "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}}],
- }
-
-
-
-Updating a Schedule
-^^^^^^^^^^^^^^^^^^^
-
-| :method:`PUT`
-| :path:`/v2/consumers/<consumer id>/schedules/uninstall/<schedule id>/`
-| :permission:`UPDATE`
-| :param_list:`PUT`
-
-* :param:`?schedule,string,schedule as an iso8601 interval (specifying a recurrence will affect remaining_runs)`
-* :param:`?failure_threshold,integer,number of allowed consecutive failures before the schedule is disabled`
-* :param:`?remaining_runs,integer,number of remaining runs for schedule`
-* :param:`?enabled,boolean,whether or not the schedule is enabled`
-* :param:`?options,object,key - value options to pass to the uninstall agent`
-* :param:`?units,array,array of units to uninstall`
-
-| :response_list:`_`
-
-
-* :response_code:`200,if the schedule was successfully updated`
-* :response_code:`202,if another server-side operation is temporarily preventing the schedule from being updated`
-* :response_code:`400,if any of the params are invalid`
-* :response_code:`404,if the consumer or schedule does not exist`
-* :response_code:`409,if another server-side operation is permanently preventing the schedule from being updated`
-
-| :return:`resource representation of the schedule`
-
-:sample_request:`_` ::
-
- {"schedule": "P1WT",
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "grinder"}},
-            {"type_id": "rpm", "unit_keys": {"name": "gofer"}}]
- }
-
-:sample_response:`200` ::
-
- {"_id": "505ccb526157770636000002",
-  "_href": "/pulp/api/v2/consumers/<consumer id>/schedules/uninstall/505ccb526157770636000002/",
-  "schedule": "P1WT",
-  "failure_threshold": null,
-  "enabled": true,
-  "consecutive_failures": 0,
-  "remaining_runs": null,
-  "first_run": "2012-09-22T14:15:00Z",
-  "last_run": null,
-  "next_run": "2012-09-29T14:15:00Z",
-  "options": {},
-  "units": [{"type_id": "rpm", "unit_keys": {"name": "gofer"}},
-            {"type_id": "rpm", "unit_keys": {"name": "grinder"}}],
- }
-
-
-
-Deleting a Schedule
-^^^^^^^^^^^^^^^^^^^
-
-| :method:`DELETE`
-| :path:`/v2/consumers/<consumer id>/schedules/uninstall/<schedule id>/`
-| :permission:`DELETE`
-| :response_list:`_`
-
-* :response_code:`200,if the schedule was deleted successfully`
-* :response_code:`202,if another server-side operation is temporarily preventing the schedule from being deleted`
-* :response_code:`404,if the consumer or schedule does not exist`
-
-| :return:`null`
-
-

--- a/docs/sphinx/dev-guide/integration/rest-api/repo/publish.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/repo/publish.rst
@@ -71,7 +71,6 @@ schedule options must be set on a repository's :term:`distributor`.
 | :response_list:`_`
 
 * :response_code:`201,if the schedule was successfully created`
-* :response_code:`503,if the resources needed to create the schedule are temporarily unavailable`
 
 | :return:`schedule report representing the current state of the scheduled call`
 
@@ -79,26 +78,35 @@ schedule options must be set on a repository's :term:`distributor`.
 
  {
   "override_config": {},
-  "schedule": "00:00:00Z/P1DT",
+  "schedule": "PT1H",
   "failure_threshold": 3,
  }
 
 :sample_response:`201` ::
 
  {
-  "_id": "4fa0208461577710b2000000",
-  "_href": "/pulp/api/v2/repositories/<repo_id>/distributors/<distributor_id>/publish_schedules/4fa0208461577710b2000000/",
-  "schedule": "00:00:00Z/P1DT",
-  "failure_threshold": 3,
-  "consecutive_failures": 0,
-  "first_run": null,
-  "last_run": null,
-  "next_run": "2012-07-13T00:00:00Z",
-  "remaining_runs": null,
+  "next_run": "2014-01-27T21:27:56Z",
+  "task": "pulp.server.tasks.repository.publish",
+  "last_updated": 1390858076.682694,
+  "first_run": "2014-01-27T21:27:56Z",
+  "schedule": "PT1H",
+  "args": [
+    "demo",
+    "puppet_distributor"
+  ],
   "enabled": true,
-  "override_config": {},
+  "last_run_at": null,
+  "_id": "52e6cf5cdd01fb70bd0d9c34",
+  "total_run_count": 0,
+  "failure_threshold": 3,
+  "kwargs": {
+    "overrides": {}
+  },
+  "resource": "pulp:distributor:demo:puppet_distributor",
+  "remaining_runs": null,
+  "consecutive_failures": 0,
+  "_href": "/pulp/api/v2/repositories/demo/distributors/puppet_distributor/schedules/publish/52e6cf5cdd01fb70bd0d9c34/"
  }
-
 
 Updating a Scheduled Publish
 ----------------------------
@@ -117,8 +125,6 @@ The same parameters used to create a scheduled publish may be updated at any poi
 | :response_list:`_`
 
 * :response_code:`200,if the schedule was successfully updated`
-* :response_code:`202,if the schedule is in use and the update is postponed`
-* :response_code:`503,if there is a conflicting operation in progress`
 
 | :return:`schedule report representing the current state of the scheduled call (see sample response of Scheduling a Publish for details)`
 
@@ -134,8 +140,6 @@ Delete a scheduled publish to remove it permanently from the distributor.
 | :response_list:`_`
 
 * response_code:`200,if the schedule was deleted successfully`
-* response_code:`202,if the schedule is in use and the delete is postponed`
-* response_code:`503,if the schedule is already in the processes of being deleted`
 
 | :return:`null`
 

--- a/docs/sphinx/dev-guide/integration/rest-api/repo/sync.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/repo/sync.rst
@@ -83,7 +83,6 @@ schedule options must be set on the repository's :term:`importer`.
 | :response_list:`_`
 
 * :response_code:`201,if the schedule was successfully created`
-* :response_code:`503,if the resources needed to create the schedule are temporarily unavailable`
 
 | :return:`schedule report representing the current state of the scheduled call`
 
@@ -98,18 +97,28 @@ schedule options must be set on the repository's :term:`importer`.
 :sample_response:`201` ::
 
  {
-  "_id": "4fa0208461577710b2000000",
-  "_href": "/pulp/api/v2/repositories/<repo_id>/importers/<importer_id>/sync_schedules/4fa0208461577710b2000000/",
-  "schedule": "00:00:00Z/P1DT",
-  "failure_threshold": 3,
-  "consecutive_failures": 0,
-  "first_run": null,
-  "last_run": null,
-  "next_run": "2012-07-13T00:00:00Z",
-  "remaining_runs": null,
+  "next_run": "2014-01-27T21:41:50Z",
+  "task": "pulp.server.tasks.repository.sync_with_auto_publish",
+  "last_updated": 1390858910.292712,
+  "first_run": "2014-01-27T21:41:50Z",
+  "schedule": "PT1H",
+  "args": [
+    "demo"
+  ],
   "enabled": true,
-  "override_config": {},
+  "last_run_at": null,
+  "_id": "52e6d29edd01fb70bd0d9c37",
+  "total_run_count": 0,
+  "failure_threshold": 3,
+  "kwargs": {
+    "overrides": {}
+  },
+  "resource": "pulp:importer:demo:puppet_importer",
+  "remaining_runs": null,
+  "consecutive_failures": 0,
+  "_href": "/pulp/api/v2/repositories/demo/importers/puppet_importer/schedules/sync/52e6d29edd01fb70bd0d9c37/"
  }
+
 
 
 Updating a Scheduled Sync
@@ -129,8 +138,6 @@ The same parameters used to create a scheduled sync may be updated at any point.
 | :response_list:`_`
 
 * :response_code:`200,if the schedule was successfully updated`
-* :response_code:`202,if the schedule is in use and the update is postponed`
-* :response_code:`503,if there is a conflicting operation in progress`
 
 | :return:`schedule report representing the current state of the scheduled call (see sample response of Scheduling a Sync for details)`
 
@@ -146,8 +153,6 @@ Delete a scheduled sync to remove it permanently from the importer.
 | :response_list:`_`
 
 * response_code:`200,if the schedule was deleted successfully`
-* response_code:`202,if the schedule is in use and the delete is postponed`
-* response_code:`503,if the schedule is already in the processes of being deleted`
 
 | :return:`null`
 

--- a/docs/sphinx/user-guide/release-notes/2.4.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.4.x.rst
@@ -37,9 +37,16 @@ API Changes
 ScheduledCall
 ^^^^^^^^^^^^^
 
-The ScheduledCall model has changed a lot. TODO: add details
-* ``last_run`` is now ``last_run_at``
+The ScheduledCall model has changed substantially.
 
+* ``last_run`` is now ``last_run_at``
+* ``args`` and ``kwargs`` are now top-level attributes of the object.
+* ``task`` is a new attribute that is the python path to the task this schedule will execute.
+* ``resource`` is a new attribute that is a globally-unique identifier for the object
+  this task will operate on. It is used internally to query schedules based on a given resource.
+
+CRUD operations on schedules no longer depend on resource locking, so these API
+operations will never return a 202 or 409.
 
 Upgrade Instructions for 2.3.x --> 2.4.0
 ----------------------------------------

--- a/server/pulp/server/webservices/controllers/consumers.py
+++ b/server/pulp/server/webservices/controllers/consumers.py
@@ -671,7 +671,7 @@ class UnitActionScheduleResource(JSONController):
         except IndexError:
             raise MissingResource(consumer_id=consumer_id, schedule_id=schedule_id)
 
-        scheduled_obj = serialization.dispatch.scheduled_unit_management_obj(scheduled_call)
+        scheduled_obj = serialization.dispatch.scheduled_unit_management_obj(scheduled_call.for_display())
         scheduled_obj.update(serialization.link.current_link_obj())
         return self.ok(scheduled_obj)
 


### PR DESCRIPTION
Fixing a minor bug in schedule retrieval that revealed too much data to the API user.

I consolidated the content schedule docs so that instead of listing the same
exhaustive set of docs for each action (install, update, uninstall), we list
the exhaustive docs once and specify that any of the three actions can be used.
