### PR TITLE
Configure PYTHONIOENCODING to be UTF-8 for all of our celery daemons.

### DIFF
--- a/server/etc/default/systemd_pulp_celerybeat
+++ b/server/etc/default/systemd_pulp_celerybeat
@@ -4,4 +4,8 @@
 # FATAL are the allowed values.
 CELERYBEAT_LOG_LEVEL="INFO"
 
+# Path where Celery's beat process should write its log
 CELERYBEAT_LOG_FILE="/var/log/pulp/celerybeat.log"
+
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"

--- a/server/etc/default/systemd_pulp_resource_manager
+++ b/server/etc/default/systemd_pulp_resource_manager
@@ -7,3 +7,6 @@ CELERYD_LOG_FILE="/var/log/pulp/%n.log"
 # Configure the log level for the Celery worker here. DEBUG, INFO, WARNING, ERROR, CRITICAL, and
 # FATAL are the allowed values.
 CELERYD_LOG_LEVEL="INFO"
+
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"

--- a/server/etc/default/systemd_pulp_workers
+++ b/server/etc/default/systemd_pulp_workers
@@ -11,3 +11,6 @@ CELERYD_LOG_LEVEL="INFO"
 # Define the number of worker nodes you wish to have here. This defaults to the number of processors
 # that are detected on the system if left commented here.
 # PULP_CONCURRENCY=4
+
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"

--- a/server/etc/default/upstart_pulp_celerybeat
+++ b/server/etc/default/upstart_pulp_celerybeat
@@ -10,3 +10,6 @@ CELERYBEAT_LOG_LEVEL="INFO"
 
 # The user that Celerybeat runs as must be able to write to this folder
 CELERYBEAT_OPTS="--workdir=/var/lib/pulp/celery/"
+
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"

--- a/server/etc/default/upstart_pulp_resource_manager
+++ b/server/etc/default/upstart_pulp_resource_manager
@@ -11,6 +11,9 @@ CELERYD_LOG_LEVEL="INFO"
 # worker.
 CELERYD_PID_FILE="/var/run/pulp/%n.pid"
 
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"
+
 ######################################################################
 # Please do not edit any of the settings below this mark in this file!
 ######################################################################

--- a/server/etc/default/upstart_pulp_workers
+++ b/server/etc/default/upstart_pulp_workers
@@ -16,6 +16,9 @@ CELERYD_PID_FILE="/var/run/pulp/%n.pid"
 # that are detected on the system.
 # PULP_CONCURRENCY=4
 
+# Configure Python's encoding for writing all logs, stdout and stderr
+PYTHONIOENCODING="UTF-8"
+
 ######################################################################
 # Please do not edit any of the settings below this mark in this file!
 ######################################################################

--- a/server/usr/lib/systemd/system/pulp_celerybeat.service
+++ b/server/usr/lib/systemd/system/pulp_celerybeat.service
@@ -6,7 +6,7 @@ After=network.target
 EnvironmentFile=/etc/default/pulp_celerybeat
 User=apache
 WorkingDirectory=/var/lib/pulp/celery/
-ExecStart=/usr/bin/celery beat --loglevel=${CELERYBEAT_LOG_LEVEL} -A pulp.server.async.app
+ExecStart=/usr/bin/celery beat --loglevel=${CELERYBEAT_LOG_LEVEL} --logfile=${CELERYBEAT_LOG_FILE} -A pulp.server.async.app
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Also, I happened to notice that our Celery beat process wasn't logging
to its log file, so I fixed that as well.
