### PR TITLE
Expose LDAP authenticated bind options in server.conf

### DIFF
--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -158,6 +158,11 @@ repo_group_publish_history: 60
 #
 # filter: directive to set more restrictive LDAP filter to limit the LDAP
 #     users who can authenticate to Pulp
+#
+# binddn: If set, perform an authenticated bind with this user DN instead of
+#     an anonymous bind
+#
+# bindpw: The password to use with binddn to perform an authenticated bind
 
 # [ldap]
 # enabled: true

--- a/server/pulp/server/managers/auth/authentication.py
+++ b/server/pulp/server/managers/auth/authentication.py
@@ -89,7 +89,15 @@ class AuthenticationManager(object):
         if config.has_option('ldap', 'filter'):
             ldap_filter = config.get('ldap', 'filter')
     
-        ldap_server = ldap_connection.LDAPConnection(server=ldap_uri, tls=ldap_tls)
+        ldap_admin = None
+        if config.has_option('ldap', 'binddn'):
+            ldap_admin = config.get('ldap', 'binddn')
+        ldap_passwd = None
+        if config.has_option('ldap', 'bindpw'):
+            ldap_passwd = config.get('ldap', 'bindpw')
+            ldap_server = ldap_connection.LDAPConnection(admin=ldap_admin,
+                                                         password=ldap_passwd,
+                                                         server=ldap_uri, tls=ldap_tls)
         ldap_server.connect()
         user = ldap_server.authenticate_user(ldap_base, username, password,
                                              filter=ldap_filter)


### PR DESCRIPTION
The LDAPConnection class already had support for this, it just needed to be exposed in the config file.
