### PR TITLE
1051700 - adding an explicit requirement for python 2.6 to pulp-admin-client

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -357,6 +357,7 @@ for content, bind and system specific operations.
 %package admin-client
 Summary: Admin tool to administer the pulp server
 Group: Development/Languages
+Requires: python >= 2.6
 Requires: python-okaara >= 1.0.32
 Requires: python-%{name}-common = %{pulp_version}
 Requires: python-%{name}-bindings = %{pulp_version}


### PR DESCRIPTION
This is a partial fix for https://bugzilla.redhat.com/show_bug.cgi?id=1051700
