### PR TITLE
1051700 - Documenting that pulp-admin is not supported on RHEL5

### DIFF
--- a/docs/sphinx/user-guide/installation.rst
+++ b/docs/sphinx/user-guide/installation.rst
@@ -34,6 +34,12 @@ Consumer
 * Fedora 18 & 19
 * CentOS 6
 
+Admin Client
+
+* RHEL 6
+* Fedora 18 & 19
+* CentOS 6
+
 Prerequisites
 -------------
 


### PR DESCRIPTION
partial fix for: https://bugzilla.redhat.com/show_bug.cgi?id=1051700
