### PR TITLE
moving content-type loading to the beginning of the pulp-manage-db workf...

### DIFF
--- a/server/pulp/server/db/manage.py
+++ b/server/pulp/server/db/manage.py
@@ -123,6 +123,14 @@ def _auto_manage_db(options):
 
     :param options: The command line parameters from the user.
     """
+    message = _('Loading content types.')
+    print message
+    logger.info(message)
+    load_content_types()
+    message = _('Content types loaded.')
+    print message
+    logger.info(message)
+
     message = _('Beginning database migrations.')
     print message
     logger.info(message)
@@ -131,13 +139,6 @@ def _auto_manage_db(options):
     print message
     logger.info(message)
 
-    message = _('Loading content types.')
-    print message
-    logger.info(message)
-    load_content_types()
-    message = _('Content types loaded.')
-    print message
-    logger.info(message)
     return os.EX_OK
 
 


### PR DESCRIPTION
...low, so that migrations can depend on having the latest content types loaded.
