### PR TITLE
casting a unicode object to a string to json in python 2.6 can de-serialize it

### DIFF
--- a/server/pulp/server/db/migrations/0007_scheduled_task_conversion.py
+++ b/server/pulp/server/db/migrations/0007_scheduled_task_conversion.py
@@ -111,6 +111,8 @@ def convert_schedule(save_func, call):
 
     call_request = call.pop('serialized_call_request')
     # we are no longer storing these pickled.
+    # these are cast to a string because python 2.6 sometimes fails to
+    # deserialize json from unicode.
     call['args'] = pickle.loads(str(call_request['args']))
     call['kwargs'] = pickle.loads(str(call_request['kwargs']))
     # keeping this pickled because we don't really know how to use it yet

--- a/server/pulp/server/db/model/dispatch.py
+++ b/server/pulp/server/db/model/dispatch.py
@@ -246,6 +246,8 @@ class ScheduledCall(Model):
             last_run = None
         else:
             last_run = dateutils.parse_iso8601_datetime(self.last_run_at)
+        #  self.schedule is cast to a string because python 2.6 sometimes fails to
+        #  deserialize json from unicode.
         return ScheduleEntry(self.name, self.task, last_run, self.total_run_count,
                              pickle.loads(str(self.schedule)), self.args, self.kwargs,
                              self.options, False, scheduled_call=self)


### PR DESCRIPTION
Apparently the json module in python 2.6 has trouble in some circumstances deserializing from a unicode object.
