### PR TITLE
Adding caching of pymongo Collection objects

### DIFF
--- a/server/pulp/plugins/types/database.py
+++ b/server/pulp/plugins/types/database.py
@@ -146,7 +146,7 @@ def clean():
     all_collection_names = database.collection_names()
     type_collection_names = [n for n in all_collection_names if n.startswith(TYPE_COLLECTION_PREFIX)]
     for drop_me in type_collection_names:
-        database.drop_collection(drop_me)
+        database[drop_me].drop()
 
     # Purge the types collection of all entries
     type_collection = ContentType.get_collection()

--- a/server/pulp/server/db/model/base.py
+++ b/server/pulp/server/db/model/base.py
@@ -61,6 +61,7 @@ class Model(dict):
     collection_name = None
     unique_indices = ('id',) # note, '_id' is automatically unique and indexed
     search_indices = ()
+    _collection = None
 
     # -------------------------------------------------------------------------
 
@@ -108,13 +109,6 @@ class Model(dict):
         return collection
 
     @classmethod
-    def _get_cached_collection(cls):
-        try:
-            return cls.__collection
-        except AttributeError:
-            return None
-
-    @classmethod
     def get_collection(cls):
         """
         Get the document collection for this data model.
@@ -126,5 +120,6 @@ class Model(dict):
         # collection_name
         if cls.collection_name is None:
             return None
-        # removed cached connections to handle AutoReconnect exception
-        return cls._get_collection_from_db()
+        if not cls._collection:
+            cls._collection = cls._get_collection_from_db()
+        return cls._collection

--- a/server/test/unit/base.py
+++ b/server/test/unit/base.py
@@ -158,8 +158,8 @@ class PulpWebserviceTests(PulpServerTests):
 
     def tearDown(self):
         super(PulpWebserviceTests, self).tearDown()
-        User.get_collection().remove()
-        TaskStatus.get_collection().remove()
+        User.get_collection().remove(safe=True)
+        TaskStatus.get_collection().remove(safe=True)
 
     def get(self, uri, params=None, additional_headers=None):
         return self._do_request('get', uri, params, additional_headers, serialize_json=False)

--- a/server/test/unit/server/async/test_task_status_manager.py
+++ b/server/test/unit/server/async/test_task_status_manager.py
@@ -32,7 +32,7 @@ class TaskStatusManagerTests(base.PulpServerTests):
     """
     def clean(self):
         super(TaskStatusManagerTests, self).clean()
-        TaskStatus.get_collection().remove()
+        TaskStatus.get_collection().remove(safe=True)
 
     def get_random_uuid(self):
         return str(uuid.uuid4())

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -301,11 +301,8 @@ class RepoUnitAssociationManagerTests(PulpServerTests):
         self.repo_manager.create_repo(dest_repo_id)
 
         # Test
-        try:
-            self.manager.associate_from_repo(source_repo_id, dest_repo_id)
-            self.fail('Exception expected')
-        except exceptions.MissingResource, e:
-            print(e)
+        self.assertRaises(exceptions.MissingResource,
+                          self.manager.associate_from_repo, source_repo_id, dest_repo_id)
 
     def test_associate_from_repo_importer_error(self):
         # Setup

--- a/server/test/unit/server/webservices/controllers/test_consumers.py
+++ b/server/test/unit/server/webservices/controllers/test_consumers.py
@@ -50,20 +50,20 @@ class ConsumerTest(base.PulpWebserviceTests):
 
     def setUp(self):
         base.PulpWebserviceTests.setUp(self)
-        Consumer.get_collection().remove()
-        Repo.get_collection().remove()
-        RepoDistributor.get_collection().remove()
-        Bind.get_collection().remove()
+        Consumer.get_collection().remove(safe=True)
+        Repo.get_collection().remove(safe=True)
+        RepoDistributor.get_collection().remove(safe=True)
+        Bind.get_collection().remove(safe=True)
         plugin_api._create_manager()
         mock_plugins.install()
         mock_agent.install()
 
     def tearDown(self):
         base.PulpWebserviceTests.tearDown(self)
-        Consumer.get_collection().remove()
-        Repo.get_collection().remove()
-        RepoDistributor.get_collection().remove()
-        Bind.get_collection().remove()
+        Consumer.get_collection().remove(safe=True)
+        Repo.get_collection().remove(safe=True)
+        RepoDistributor.get_collection().remove(safe=True)
+        Bind.get_collection().remove(safe=True)
         mock_plugins.reset()
 
     def test_get(self):
@@ -1368,6 +1368,7 @@ class ScheduledUnitInstallTests(base.PulpWebserviceTests):
         self.consumer_id = 'test-consumer'
         self.consumer_manager = factory.consumer_manager()
         self.consumer_manager.register(self.consumer_id)
+        ScheduledCall.get_collection().remove(safe=True)
 
     def tearDown(self):
         super(ScheduledUnitInstallTests, self).tearDown()

--- a/server/test/unit/test_types_database.py
+++ b/server/test/unit/test_types_database.py
@@ -140,7 +140,7 @@ class TypesDatabaseTests(base.PulpServerTests):
             self.assertTrue(DEF_1.id in e.missing_type_ids)
             self.assertTrue(DEF_2.id in e.missing_type_ids)
             self.assertTrue(DEF_3.id in e.missing_type_ids)
-            print(e) # used to test the __str__ impl
+            str(e) # used to test the __str__ impl
 
     def test_update_failed_create(self):
         """
@@ -159,7 +159,7 @@ class TypesDatabaseTests(base.PulpServerTests):
         except types_db.UpdateFailed, e:
             self.assertEqual(1, len(e.type_definitions))
             self.assertEqual(busted, e.type_definitions[0])
-            print(e)
+            str(e)
 
     def test_all_type_collection_names(self):
         """


### PR DESCRIPTION
Pulp retrieves Collection objects VERY frequently, and in that process, it does
a lot of extra work (such as ensuring indecies and monkey-patching). This
creates a huge drag on performance, especially on operations like unit copy.

Many of the unit tests actually depended on the behavior of ensuring indecies,
so I had to change them. There were also many tests making assumptions about
default sort orders, which we don't guarantee, so I had to change that too.
