### PR TITLE
Add support for deleting entries from the content catalog by content source id.

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/content/catalog.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/content/catalog.rst
@@ -1,0 +1,21 @@
+Catalog
+=======
+
+The content catalog contains information about content that is provided by Pulp's alternate
+content sources.
+
+
+Deleting Entries
+----------------
+
+Delete entries from the catalog by content source by ID.
+
+| :method:`delete`
+| :path:`/v2/content/catalog/<source-id>/`
+| :permission:`delete`
+| :param_list:`delete` None
+| :response_list:`_`
+
+* :response_code:`200,if the entries were successfully deleted from the catalog`
+
+| :return:`None`

--- a/docs/sphinx/dev-guide/integration/rest-api/content/index.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/content/index.rst
@@ -8,3 +8,4 @@ Content Manipulation APIs
    associate
    orphan
    retrieval
+   catalog

--- a/server/pulp/server/webservices/controllers/contents.py
+++ b/server/pulp/server/webservices/controllers/contents.py
@@ -262,8 +262,6 @@ class UploadSegmentResource(JSONController):
 
         return self.ok(None)
 
-# content orphans controller classes -------------------------------------------
-
 
 class OrphanCollection(JSONController):
 
@@ -330,6 +328,15 @@ class DeleteOrphansAction(JSONController):
         raise OperationPostponed(async_task)
 
 
+class CatalogResource(JSONController):
+
+    @auth_required(DELETE)
+    def DELETE(self, source_id):
+        manager = factory.content_catalog_manager()
+        manager.purge(source_id)
+        return self.ok(None)
+
+
 # wsgi application -------------------------------------------------------------
 
 _URLS = ('/types/$', ContentTypesCollection,
@@ -343,6 +350,7 @@ _URLS = ('/types/$', ContentTypesCollection,
          '/orphans/$', OrphanCollection,
          '/orphans/([^/]+)/$', OrphanTypeSubCollection,
          '/orphans/([^/]+)/([^/]+)/$', OrphanResource,
-         '/actions/delete_orphans/$', DeleteOrphansAction,)
+         '/actions/delete_orphans/$', DeleteOrphansAction,
+         '/catalog/([^/]+)$', CatalogResource,)
 
 application = web.application(_URLS, globals())

--- a/server/test/unit/test_contents_controller.py
+++ b/server/test/unit/test_contents_controller.py
@@ -178,6 +178,7 @@ class BaseUploadTest(base.PulpWebserviceTests):
         Repo.get_collection().remove()
         RepoImporter.get_collection().remove()
 
+
 class UploadsCollectionTests(BaseUploadTest):
 
     def test_get_no_uploads(self):
@@ -216,6 +217,7 @@ class UploadsCollectionTests(BaseUploadTest):
         upload_file = self.upload_manager._upload_file_path(body['upload_id'])
         self.assertTrue(os.path.exists(upload_file))
 
+
 class UploadResourceTests(BaseUploadTest):
 
     def test_delete(self):
@@ -231,6 +233,7 @@ class UploadResourceTests(BaseUploadTest):
 
         upload_file = self.upload_manager._upload_file_path(upload_id)
         self.assertTrue(not os.path.exists(upload_file))
+
 
 class UploadSegmentResourceTests(BaseUploadTest):
 
@@ -286,12 +289,14 @@ class UploadSegmentResourceTests(BaseUploadTest):
         # Verify
         self.assertEqual(404, status)
 
+
 class ReservedResourceApplyAsync(object):
     """
     This object allows us to mock the return value of _reserve_resource.apply_async.get().
     """
     def get(self):
         return 'some_queue'
+
 
 class ImportUnitTests(BaseUploadTest):
 
@@ -326,3 +331,18 @@ class ImportUnitTests(BaseUploadTest):
                               {'name': 'foo'}, {'stuff': 'bar'}, 
                               upload_id]
         self.assertEqual(exepcted_call_args, mock_apply_async.call_args[0][0])
+
+
+class CatalogTests(base.PulpWebserviceTests):
+
+    @mock.patch('pulp.server.managers.content.catalog.ContentCatalogManager.purge')
+    def test_delete(self, mock_purge):
+        source_id = 'test-source'
+
+        # test
+        url = '/v2/content/catalog/%s' % source_id
+        status, body = self.delete(url)
+
+        # validation
+        self.assertEqual(status, 200)
+        mock_purge.assert_called_with(source_id)


### PR DESCRIPTION
We'll likely want to add additional API calls for triggering (and scheduling) catalog refreshes, searching the catalog etc but just adding this to support the usecase we know about:  "As an admin, I want to be able to clear the content catalog."

We can add more as this feature matures.
