### PR TITLE
updated start time and finish time for task status to be iso8601 datetim...

### DIFF
--- a/server/pulp/server/async/task_status_manager.py
+++ b/server/pulp/server/async/task_status_manager.py
@@ -11,6 +11,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+from datetime import datetime
 from pymongo.errors import DuplicateKeyError
 
 from pulp.common import dateutils
@@ -71,9 +72,11 @@ class TaskStatusManager(object):
         :param task_id: The identity of the task to be updated.
         :type  task_id: basestring
         """
+        now = datetime.now(dateutils.utc_tz())
+        start_time = dateutils.format_iso8601_datetime(now)
         delta = {
             'state': dispatch_constants.CALL_RUNNING_STATE,
-            'start_time': dateutils.now_utc_timestamp(),
+            'start_time': start_time,
         }
         TaskStatusManager.update_task_status(task_id=task_id, delta=delta)
 
@@ -86,9 +89,11 @@ class TaskStatusManager(object):
         :param result: The optional value returned by the task execution.
         :type result: anything
         """
+        now = datetime.now(dateutils.utc_tz())
+        finish_time = dateutils.format_iso8601_datetime(now)
         delta = {
             'state': dispatch_constants.CALL_FINISHED_STATE,
-            'finish_time': dateutils.now_utc_timestamp(),
+            'finish_time': finish_time,
             'result': result
         }
         TaskStatusManager.update_task_status(task_id=task_id, delta=delta)
@@ -102,9 +107,11 @@ class TaskStatusManager(object):
         :ivar traceback: A string representation of the traceback resulting from the task execution.
         :type traceback: basestring
         """
+        now = datetime.now(dateutils.utc_tz())
+        finish_time = dateutils.format_iso8601_datetime(now)
         delta = {
             'state': dispatch_constants.CALL_ERROR_STATE,
-            'finish_time': dateutils.now_utc_timestamp(),
+            'finish_time': finish_time,
             'traceback': traceback
         }
         TaskStatusManager.update_task_status(task_id=task_id, delta=delta)

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -24,6 +24,7 @@ import celery
 import mock
 
 from ...base import PulpServerTests, ResourceReservationTests
+from pulp.common import dateutils
 from pulp.server.exceptions import PulpException, PulpCodedException
 from pulp.server.async import tasks
 from pulp.server.async.task_status_manager import TaskStatusManager
@@ -625,7 +626,9 @@ class TestTask(ResourceReservationTests):
         new_task_status = TaskStatusManager.find_by_task_id(task_id)
         self.assertEqual(new_task_status['state'], 'finished')
         self.assertEqual(new_task_status['result'], retval)
-        self.assertFalse(new_task_status['finish_time'] == None)
+        self.assertFalse(new_task_status['finish_time'] is None)
+        # Make sure that parse_iso8601_datetime is able to parse the finish_time without errors
+        dateutils.parse_iso8601_datetime(new_task_status['finish_time'])
 
     @mock.patch('pulp.server.async.tasks.Task.request')
     def test_on_success_handler_spawned_task_status(self, mock_request):
@@ -654,7 +657,9 @@ class TestTask(ResourceReservationTests):
         self.assertEqual(new_task_status['state'], 'finished')
         self.assertEqual(new_task_status['result'], 'bar')
         self.assertEqual(new_task_status['error']['description'], 'error-foo')
-        self.assertFalse(new_task_status['finish_time'] == None)
+        self.assertFalse(new_task_status['finish_time'] is None)
+        # Make sure that parse_iso8601_datetime is able to parse the finish_time without errors
+        dateutils.parse_iso8601_datetime(new_task_status['finish_time'])
         self.assertEqual(new_task_status['spawned_tasks'], ['foo-id'])
 
     @mock.patch('pulp.server.async.tasks.Task.request')
@@ -679,7 +684,7 @@ class TestTask(ResourceReservationTests):
         new_task_status = TaskStatusManager.find_by_task_id(task_id)
         self.assertEqual(new_task_status['state'], 'finished')
         self.assertEqual(new_task_status['result'], 'bar')
-        self.assertFalse(new_task_status['finish_time'] == None)
+        self.assertFalse(new_task_status['finish_time'] is None)
         self.assertEqual(new_task_status['spawned_tasks'], ['foo-id'])
 
     @mock.patch('pulp.server.async.tasks.Task.request')
@@ -704,7 +709,9 @@ class TestTask(ResourceReservationTests):
         new_task_status = TaskStatusManager.find_by_task_id(task_id)
         self.assertEqual(new_task_status['state'], 'finished')
         self.assertEqual(new_task_status['result'], None)
-        self.assertFalse(new_task_status['finish_time'] == None)
+        self.assertFalse(new_task_status['finish_time'] is None)
+        # Make sure that parse_iso8601_datetime is able to parse the finish_time without errors
+        dateutils.parse_iso8601_datetime(new_task_status['finish_time'])
         self.assertEqual(new_task_status['spawned_tasks'], ['foo-id'])
 
 
@@ -736,7 +743,9 @@ class TestTask(ResourceReservationTests):
 
         new_task_status = TaskStatusManager.find_by_task_id(task_id)
         self.assertEqual(new_task_status['state'], 'error')
-        self.assertFalse(new_task_status['finish_time'] == None)
+        self.assertFalse(new_task_status['finish_time'] is None)
+        # Make sure that parse_iso8601_datetime is able to parse the finish_time without errors
+        dateutils.parse_iso8601_datetime(new_task_status['finish_time'])
         self.assertEqual(new_task_status['traceback'], einfo.traceback)
 
     @mock.patch('celery.Task.apply_async')


### PR DESCRIPTION
...e string instead of utc timestamp

https://bugzilla.redhat.com/show_bug.cgi?id=1067637

Sample output - 

Operations:  sync
Resources:   test-repo (repository)
State:       Successful
Start Time:  2014-02-26T18:40:23Z
Finish Time: 2014-02-26T18:40:31Z
Result:  
....
