### PR TITLE
Remove unnecessary parameters from the nose test-runner

### DIFF
--- a/devel/pulp/devel/test_runner.py
+++ b/devel/pulp/devel/test_runner.py
@@ -60,8 +60,6 @@ def run_tests(packages, tests_all_platforms, tests_non_rhel5):
 
         args.extend(['--cover-html',
                      '--cover-erase',
-                     '--all-modules',
-                     '--traverse-namespace',
                      '--cover-package',
                      ','.join(packages)])
 


### PR DESCRIPTION
the --all-modules and --traverse-namespace parameters for nose can cause tests to run outside of the intended package.  Remove them so that we don't waste time and potentially introduce errors by running tests outside of the intended packages.  
