### PR TITLE
Update dependency READMEs.

### DIFF
--- a/deps/python-amqp/README
+++ b/deps/python-amqp/README
@@ -1,5 +1,5 @@
 Team owner: rbarlow
 
-kombu 3.0.8 requires version 1.3.3, which is not available in EPEL or Fedora.
+kombu 3.0.12 requires version 1.4.3, which is not available in EPEL 6 or Fedora <= 20.
 
 This requirement may not actually be necessary once proton and qpid are used with celery.

--- a/deps/python-billiard/README
+++ b/deps/python-billiard/README
@@ -1,3 +1,4 @@
 Team owner: rbarlow
 
-kombu requires this, and a new-enough version is not available in Fedora or EPEL.
+celery-3.1.9 requires billiard >= 3.3.0.14, and a new-enough version is not available in
+Fedora <= 20 or EPEL 6.

--- a/deps/python-celery/README
+++ b/deps/python-celery/README
@@ -1,3 +1,3 @@
 Team owner: rbarlow
 
-Pulp requires celery 3.1, which is not available in Fedora or EPEL.
+Pulp requires celery 3.1, which is not available in Fedora <= 20 or EPEL 6.

--- a/pulp.spec
+++ b/pulp.spec
@@ -212,6 +212,7 @@ Summary: The pulp platform server
 Group: Development/Languages
 Requires: python-%{name}-common = %{pulp_version}
 Requires: python-celery >= 3.1.0
+Requires: python-celery < 3.2.0
 Requires: python-pymongo >= 2.5.2
 Requires: python-setuptools
 Requires: python-webpy


### PR DESCRIPTION
I've updated the READMEs for python-amqp, python-billiard, and
python-celery to be more current, more specific, and in one case, more
correct.
