### PR TITLE
Fixing pulp-dev to create 'catalogers' folder.

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -65,6 +65,7 @@ DIRS = (
     '/var/lib/pulp_client/consumer',
     '/var/lib/pulp_client/consumer/extensions',
     '/usr/lib/pulp/plugins',
+    '/usr/lib/pulp/plugins/catalogers',
     '/usr/lib/pulp/plugins/distributors',
     '/usr/lib/pulp/plugins/importers',
     '/usr/lib/pulp/plugins/profilers',


### PR DESCRIPTION
When using journalctl to look at the log output as Pulp starts, the celery workers were showing this exception in the logs.  It was due to the pulp-dev.py script not creating this folder correctly.  The file path is truncated because journalctl was showing output in a terminal.

 pulp.plugins.loader.loading:CRITICAL: Cannot load plugins: path does not exist or cannot be read: /usr/l...atalogers 
