### PR TITLE
Temporarily suspend Celery logging.

### DIFF
--- a/server/etc/pulp/logging.cfg
+++ b/server/etc/pulp/logging.cfg
@@ -28,7 +28,7 @@
 # Note:
 #  Python 2.4 has an issue with spaces between commas
 [loggers]
-keys: root,pulp,gofer,qpid,nectar,requests,urllib3,celery
+keys: root,pulp,gofer,qpid,nectar,requests,urllib3
 
 [logger_root]
 # NOTSET for 'root' means it will allow

--- a/server/pulp/server/async/app.py
+++ b/server/pulp/server/async/app.py
@@ -13,9 +13,15 @@
 from celery import Celery
 from celery.signals import worker_ready
 
+from pulp.server import config # automatically loads config
 from pulp.server import initialization
+from pulp.server import logs
 from pulp.server.async import tasks
 from pulp.server.async.celery_instance import celery
+
+
+logs.start_logging()
+initialization.initialize()
 
 
 @worker_ready.connect
@@ -29,5 +35,4 @@ def initialize_worker(*args, **kwargs):
     :param kwargs: unused
     :type  kwargs: dict
     """
-    initialization.initialize()
     tasks.babysit()

--- a/server/pulp/server/initialization.py
+++ b/server/pulp/server/initialization.py
@@ -14,11 +14,6 @@
 import logging
 import sys
 
-# We need to initialize logging early, because some of the other imports in this module can generate
-# log messages.
-from pulp.server import logs
-logs.start_logging()
-
 # It is important that we initialize the DB connection early
 from pulp.server.db import connection as db_connection
 db_connection.initialize()

--- a/server/pulp/server/logs.py
+++ b/server/pulp/server/logs.py
@@ -18,8 +18,6 @@ import os
 from pulp.server import config
 
 
-# logging configuration -------------------------------------------------------
-
 def check_log_file(file_path):
     """
     Check the write permissions on log files and their parent directory. Raise
@@ -31,6 +29,7 @@ def check_log_file(file_path):
     if not os.access(dir_path, os.W_OK):
         raise RuntimeError('Cannot write to log directory: %s' % dir_path)
     return 'Yeah!'
+
 
 def _enable_all_loggers():
     """
@@ -47,6 +46,7 @@ def _enable_all_loggers():
     for key in keys:
         logging.root.manager.loggerDict[key].disabled = 0
 
+
 def configure_pulp_logging():
     """
     Configures logging from config file specified in pulp.conf
@@ -57,9 +57,9 @@ def configure_pulp_logging():
     logging.config.fileConfig(log_config_filename)
     _enable_all_loggers() # Hack needed for RHEL-5
 
-# pulp logging api ------------------------------------------------------------
 
 started = False
+
 
 def start_logging():
     """

--- a/server/pulp/server/webservices/application.py
+++ b/server/pulp/server/webservices/application.py
@@ -30,10 +30,12 @@ import web
 web.application.handle_with_processors = _handle_with_processors
 
 from pulp.server import config # automatically loads config
+from pulp.server import logs
 
 # We need to read the config, start the logging, and initialize the db
 # connection prior to any other imports, since some of the imports will invoke
 # setup methods.
+logs.start_logging()
 from pulp.server import initialization
 
 from pulp.server.agent.direct.services import Services as AgentServices


### PR DESCRIPTION
This is a temporary fix to get master back into working condition. I'm
still not sure what happened, but we used to be able to capture Celery's
logs from Pulp, and now we cannot do that. I've also made sure that we
initialize Pulp at the Celery app's module level rather than waiting for
the worker_ready signal.
