### PR TITLE
Jortel queue migration

### DIFF
--- a/server/pulp/server/db/migrations/0009_qpid_queues.py
+++ b/server/pulp/server/db/migrations/0009_qpid_queues.py
@@ -25,6 +25,11 @@ def migrate(*args, **kwargs):
     - Ensure pulp.task is no longer *exclusive*.
     - Rename agent queues: consumer_id> => pulp.agent.<consumer_id>
     """
+    transport = pulp_conf.get('messaging', 'transport')
+    if transport != 'qpid':
+        # not using qpid
+        return
+
     url = urlparse(pulp_conf.get('messaging', 'url'))
     connection = Connection(
         host=url.hostname,


### PR DESCRIPTION
Related to issue resulting from changing our WSGI application to multi-process.  The issue being that the queue _task.queue_ used for agent asynchronous replies as created as _exclusive_ which prevents multiple consumers.  Now that we are running with multiple process, we need this to be non-exclusive.

Related to the story for renaming our agent queues from <consumer_id> ==> pulp.agent.<consumer_id>.  Adding the namespace (prefix) prevents queue name collisions and better supports ACLs.
