### PR TITLE
1073154 - Do not log newlines or long messages.

### DIFF
--- a/server/test/unit/server/test_logs.py
+++ b/server/test/unit/server/test_logs.py
@@ -125,7 +125,7 @@ class TestCompliantSysLogHandler(unittest.TestCase):
         """
         msg = u'Please do not kill ☃'
 
-        # This one cuts exactly before the snowman starts, so it's OK.
+        # This one cuts exactly after the snowman, so it's OK.
         with mock.patch('pulp.server.logs.CompliantSysLogHandler.MAX_MSG_LENGTH', 22):
             messages = list(logs.CompliantSysLogHandler._cut_message(msg, 0))
 


### PR DESCRIPTION
This commit also fixes two more bugs:

885230 - pulp-manage-db now uses syslog.
1075128 - log settings are now configured entirely in /etc/pulp/server.conf

https://bugzilla.redhat.com/show_bug.cgi?id=1073154
https://bugzilla.redhat.com/show_bug.cgi?id=1075128
https://bugzilla.redhat.com/show_bug.cgi?id=885230
