### PR TITLE
Bugfix for 1084070

### DIFF
--- a/server/pulp/server/db/migrations/0009_qpid_queues.py
+++ b/server/pulp/server/db/migrations/0009_qpid_queues.py
@@ -13,18 +13,6 @@ from gettext import gettext as _
 import logging
 from urlparse import urlparse
 
-QPIDTOOLLIBS_AVAILABLE = True
-try:
-    from qpidtoollibs import BrokerAgent
-except ImportError:
-    QPIDTOOLLIBS_AVAILABLE = False
-
-QPID_MESSAGING_AVAILABLE = True
-try:
-    from qpid.messaging import Connection
-except ImportError:
-    QPID_MESSAGING_AVAILABLE = False
-
 from pulp.server.config import config as pulp_conf
 from pulp.server.agent.direct.services import Services
 from pulp.server.db.model.consumer import Consumer
@@ -43,13 +31,17 @@ def migrate(*args, **kwargs):
         # not using qpid
         return
 
-    if not QPID_MESSAGING_AVAILABLE:
+    try:
+        from qpid.messaging import Connection
+    except ImportError:
         msg = _('Migration 0009 did not run because the python package qpid.messaging is not installed.  Please '
                 'install qpid.messaging and rerun the migrations.')
         logger.error(msg)
         raise Exception(msg)
 
-    if not QPIDTOOLLIBS_AVAILABLE:
+    try:
+        from qpidtoollibs import BrokerAgent
+    except ImportError:
         msg = _('Migration 0009 did not run because the python package qpidtoollibs is not installed.  Please '
                 'install qpidtoollibs and rerun the migrations.')
         logger.error(msg)


### PR DESCRIPTION
This fix guards importing of qpidtoollibs and qpid.messaging from ImportErrors that occur if the libraries are missing, and is a fix for [bug 1084070](https://bugzilla.redhat.com/show_bug.cgi?id=1084070).  A generic exception with a localized error message is raised if one of the necessary libraries are missing so that it will be shown to the user, and also logged.  Raising the exception should stop the migration from being marked in the database as being run.

The code already contained behavior to verify that the user is using qpid via their configuration, so I do not check the broker string.

This fix should come with tests, but I couldn't get them to work, so they are not included.  There should be 4 tests:
1.  Verify that an ImportError is not raised if qpid.messaging is missing
2.  Verify that an ImportError is not raised if qpidtoollibs is missing
3.  Verify that an exception with the correct error message is raised and logged if qpid.messaging is missing.
4.  Verify that an exception with the correct error message is raised and logged if qpidtoollibs is missing.

Mocking an ImportError isn't very straightforward with mock, but I got that working (see example below).  Even though an ImportError is raised if you would execute a statement like `from qpid.messaging import Connection` in the conext manager, if you import pulp.server.db.migrations.0009_qpid_queues in the context manager which contains the qpid.messaging import statement, the ImportError is never raised in the pulp.server.db.migrations.0009_qpid_queues module.  Strange...  I spent enough time on it that I had to move on, but if others know how to fix, I am interested.  Below is one of the tests I wrote as an example, which should work, but does not.

```
    def test_exception_not_raised_with_qpid_messaging_missing(self):
        orig_import = __import__

        def import_mock(name, *args):
            if name == 'qpid.messaging':
                raise ImportError()
            return orig_import(name, *args)

        # test
        with patch('__builtin__.__import__', side_effect=import_mock):
            try:
                MigrationModule(MIGRATION)
            except ImportError:
                self.fail('Migration should not raise an ImportError if qpid.messaging is not found')
```
