### PR TITLE
Adding mongodb-server version requirement for pulp in the documentation

### DIFF
--- a/docs/sphinx/user-guide/installation.rst
+++ b/docs/sphinx/user-guide/installation.rst
@@ -103,8 +103,8 @@ Server
 
     $ sudo yum install mongodb-server
 
-   After installing MongoDB, you should configure it to start at boot and start it. For Upstart
-   based systems::
+   You need mongodb-server with version >= 2.0 installed for Pulp server. After installing MongoDB,
+   you should configure it to start at boot and start it. For Upstart based systems::
 
     $ sudo service mongod start
     $ sudo chkconfig mongod on


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1086341

Confirmed that $rename was introduced in mongodb's version 1.7.2. Since mongo server can reside on a different server than the pulp-server, we can't add the version requirement to the spec file. I have added the update to the documentation to mention the version requirement. 
