### PR TITLE
1084716 - Register with Celery's setup_logging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tags
 
 # Ninja IDE
 *.nja
+
+# Sublime
+.codeintel

--- a/server/pulp/server/async/app.py
+++ b/server/pulp/server/async/app.py
@@ -14,10 +14,10 @@
 # This import will load our configs
 from pulp.server import config
 from pulp.server import initialization
+# We need this import so that the Celery setup_logging signal gets registered
 from pulp.server import logs
 # This import is here so that Celery will find our application instance
 from pulp.server.async.celery_instance import celery
 
 
-logs.start_logging()
 initialization.initialize()


### PR DESCRIPTION
Celery provides a setup_logging signal that allows us to declare that we
will be handling the definition of the loggers and handlers. This solves
bug #1084716, wherein we were having trouble capturing all of the log
messages.

The nice thing about this commit is that we were able to remove a lot of
our code that was trying to undo some of the logging setup that Celery
had done before our start_logging() method was run. Now we can simply
define the root logger's handler.

This commit also adds a new feature where we can blacklist loggers using
pulp.server.logs.LOG_BLACKLIST. If we wanted to, we could make this a
setting in the future, but for now it's just a module level variable.

https://bugzilla.redhat.com/show_bug.cgi?id=1084716
