### PR TITLE
Add capability to rsync to fedorapeople.  This assumes that ssh-agent is...

### DIFF
--- a/rel-eng/builder.py
+++ b/rel-eng/builder.py
@@ -457,4 +457,3 @@ if not opts.disable_packaging:
         command = 'rsync -avz --delete * pulpadmin@repos.fedorapeople.org:%s/' % \
                   target_repo_dir
         subprocess.check_call(command, shell=True)
-        print command


### PR DESCRIPTION
... being used to manage identity.
