### PR TITLE
1087015 - Capture warnings with the pulp logger

### DIFF
--- a/server/pulp/server/logs.py
+++ b/server/pulp/server/logs.py
@@ -14,7 +14,7 @@
 This module defines and configures Pulp's logging system.
 """
 import ConfigParser
-import logging.handlers
+import logging
 import os
 
 from celery.signals import setup_logging
@@ -68,6 +68,10 @@ def start_logging(*args, **kwargs):
     handler.setFormatter(formatter)
     root_logger.handlers = []
     root_logger.addHandler(handler)
+
+
+    # Celery uses warnings so let's capture those with this logger too
+    logging.captureWarnings(True)
 
     _blacklist_loggers()
 

--- a/server/test/unit/server/test_logs.py
+++ b/server/test/unit/server/test_logs.py
@@ -480,6 +480,15 @@ class TestStartLogging(unittest.TestCase):
 
         _blacklist_loggers.assert_called_once_with()
 
+    @mock.patch('pulp.server.logs.logging')
+    def test_calls__captureWarnings(self, _logging):
+        """
+        Ensure that start_logging() calls _blacklist_loggers().
+        """
+        logs.start_logging()
+
+        _logging.captureWarnings.assert_called_once_with(True)
+
     @mock.patch('pulp.server.logs.config.config.get', return_value='something wrong')
     @mock.patch('pulp.server.logs.logging.getLogger')
     def test_log_level_invalid(self, getLogger, get):


### PR DESCRIPTION
You can tell this code works because of how the pickle warning is reported on worker startup.

This comes with a new tests, but master currently has broken tests on it (unrelated to this PR).

You'll notice the Celery banner still is not captured, but [those use plain print statements](https://github.com/celery/celery/blob/master/celery/apps/worker.py#L168), so that is really a celery bug, not an issue with our logger.

Each redirected warning line is prepended with "py.warnings:WARNING: " which is ugly, but I don't know of a straightforward way of fixing that without hardcoding the removal of that string, which is probably not a good idea.
