### PR TITLE
1091919 - agent load rsa keys on demand.

### DIFF
--- a/docs/sphinx/user-guide/release-notes/2.4.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.4.x.rst
@@ -113,6 +113,10 @@ For systemd::
     $ sudo systemctl enable pulp_resource_manager
     $ sudo systemctl start pulp_resource_manager
 
+On each registered consumer, run ``pulp-consumer update --keys`` to exchange RSA keys needed for
+message authentication.
+
+
 Rest API Changes
 ----------------
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1091919

Basically, the release notes need to be more explicit in the **upgrade** section.  Also, the _Authenticator_ needs to load the RSA keys on demand.  This ensures the plugin can be loaded even when the key exchange with the server has not yet taken place.  The message rate with the consumer is so low that the overhead of loading the keys each time is negligible.  Further complexity of caching the loaded key is unwarranted.
