### PR TITLE
add gcc to python-billiard BuildRequires

### DIFF
--- a/deps/python-billiard/python-billiard.spec
+++ b/deps/python-billiard/python-billiard.spec
@@ -27,6 +27,7 @@ License:        BSD
 URL:            http://pypi.python.org/pypi/billiard
 Source0:        http://pypi.python.org/packages/source/b/%{srcname}/%{srcname}-%{version}.tar.gz
 
+BuildRequires:  gcc
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 BuildRequires:  python-mock


### PR DESCRIPTION
The gcc buildreq in python-billiard was missing, causing build-time errors when built using tito on a freshly provisioned instance
