### PR TITLE
updating description for repo create --proxy-host option

### DIFF
--- a/client_lib/pulp/client/commands/repo/importer_config.py
+++ b/client_lib/pulp/client/commands/repo/importer_config.py
@@ -51,7 +51,7 @@ class OptionsBundle(object):
 
         # -- proxy options ------------------------------------------------------------
 
-        d = _('hostname of the proxy server to use')
+        d = _('proxy server url to use')
         self.opt_proxy_host = PulpCliOption('--proxy-host', d, required=False)
 
         d = _('port on the proxy server to make requests')


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1086855

Docs already seem to mention the right way - http://pulp-rpm-user-guide.readthedocs.org/en/latest/recipes.html#use-a-proxy

I have just updated the description for --proxy-host to say url instead of hostname. I also investigated changing --proxy-host option to --proxy-url. Just changing it on cli is not invasive, but that will be different from global proxy config which is --proxy-host. If we want to change both, it is quite a bit invasive which which will require changing many files, unit tests and a migration to update previously created importer configs. I don't think it makes sense to do this for 2.4. 
