### PR TITLE
Rbarlow fix coverage

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -22,20 +22,9 @@ subprocess.call(['find', PROJECT_DIR, '-name', '*.pyc', '-delete'])
 
 
 PACKAGES = [
-    'agent/pulp',
-    'bindings/pulp',
-    'client_admin/pulp',
-    'client_consumer/pulp',
-    'client_lib/pulp',
-    'common/pulp',
-    'devel/pulp',
-    'nodes/child/pulp_node',
-    'nodes/common/pulp_node',
-    'nodes/extensions/admin/pulp_node',
-    'nodes/extensions/consumer/pulp_node',
-    'nodes/parent/pulp_node',
-    'server/pulp',
-]
+    os.path.dirname(__file__),
+    'pulp',
+    'pulp_node',]
 
 
 TESTS_ALL_PLATFORMS = [


### PR DESCRIPTION
This pull request fixes coverage in a way that will work on both RHEL 6, RHEL 7, and Fedora 19, 20, and rawhide.

The important bit for EL 7 and rawhide is that the local directory needs to be included in the PACKAGES list. Also, we had a lot of packages in there that didn't need to be included.
