### PR TITLE
1091427: pulp-server should run systemctl daemon-reload on upgrade/removal

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -245,6 +245,11 @@ Requires: genisoimage
 %if 0%{?rhel} == 6
 Requires: nss >= 3.12.9
 %endif
+%if %{pulp_systemd} == 1
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+%endif
 Obsoletes: pulp
 
 %description server
@@ -323,6 +328,11 @@ then
   pulp-gen-ca-certificate
 fi
 %endif # End pulp_server if block
+
+%postun server
+%if %{pulp_systemd} == 1
+%systemd_postun
+%endif
 
 
 # ---- Common ------------------------------------------------------------------


### PR DESCRIPTION
Some systemd macros were missing from the pulp-server spec to automatically run
systemctl daemon-reload. Adding to %postun covers both upgrades and removals.

This could be done in %post as well, but doing it only in %postun seems to be the
convention. A macro [exists](http://cgit.freedesktop.org/systemd/systemd/tree/src/core/macros.systemd.in) for %postun but not for %post. 

To test, you will have to update the rpm _twice_. The first update will put the script in %postun, but it will not actually get executed until the second update. Verification can be done via `journalctl | tail`, output will look like this on success:

```
May 02 13:33:30 localhost.localdomain systemd[1]: Reloading.
<other mesages related to reloading>
```
