### PR TITLE
update pulp-dev to copy the consumer.conf instead of linking it.

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -95,7 +95,6 @@ LINKS = [
     # Consumer Configuration
     ('agent/etc/gofer/plugins/pulpplugin.conf', '/etc/gofer/plugins/pulpplugin.conf'),
     ('agent/pulp/agent/gofer/pulpplugin.py', '/usr/lib/gofer/plugins/pulpplugin.py'),
-    ('client_consumer/etc/pulp/consumer/consumer.conf', '/etc/pulp/consumer/consumer.conf'),
 ]
 
 # We only support Python >= 2.6 for the server code
@@ -205,8 +204,13 @@ def get_paths_to_copy():
     paths = []
     # We don't support server code on EL 5.
     if LSB_VERSION >= 6.0:
-        paths.extend([{'source': 'server/etc/pulp/server.conf', 'destination': '/etc/pulp/server.conf',
-                       'owner': 'root', 'group': 'apache', 'mode': '644', 'overwrite': False}])
+        paths.extend([
+            {'source': 'server/etc/pulp/server.conf', 'destination': '/etc/pulp/server.conf',
+             'owner': 'root', 'group': 'apache', 'mode': '644', 'overwrite': False},
+            {'source': 'client_consumer/etc/pulp/consumer/consumer.conf',
+             'destination': '/etc/pulp/consumer/consumer.conf', 'owner': 'root', 'group': 'root',
+             'mode': '644', 'overwrite': False},
+        ])
         if LSB_VERSION >= 7.0:
             paths.append({'source': 'server/usr/lib/systemd/system/pulp_celerybeat.service',
                           'destination': '/etc/systemd/system/pulp_celerybeat.service', 'owner': 'root',


### PR DESCRIPTION
To support changing consumer properties in the development environment.
