### PR TITLE
 1092467: error when calling /v2/content/actions/delete_orphans/

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/content/orphan.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/content/orphan.rst
@@ -192,6 +192,9 @@ The task created will have the following tag.  ``"pulp:content_unit:orphans"``
 
 Remove Orphaned Content Units by Type and Id
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. deprecated:: 2.4
+   Please use `/v2/content/orphans/` instead for deletions.
+
 Individual content units across types may be deleted by this call. The body of
 the call consists of an array of JSON objects with the fields:
 

--- a/docs/sphinx/user-guide/release-notes/2.4.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.4.x.rst
@@ -226,6 +226,10 @@ Here are other APIs that have changed, arranged by path:
   own applicability. To allow this, we have introduced a new API which can be used by consumers and
   is documented on the same page as other applicability APIs.
 
+``/v2/content/actions/delete_orphans/``
+
+    This has been deprecated in version 2.4, in favor of ``/v2/content/orphans/``.
+
 Binding API Changes
 -------------------
 

--- a/server/pulp/server/webservices/controllers/contents.py
+++ b/server/pulp/server/webservices/controllers/contents.py
@@ -319,12 +319,13 @@ class OrphanResource(JSONController):
 
 
 class DeleteOrphansAction(JSONController):
-    # TODO: Do we really need this in addition to the OrphanResource.DELETE method?
+    # deprecated in 2.4, please use the more restful OrphanResoruce delete instead
     @auth_required(DELETE)
     def POST(self):
+        orphans = self.params()
         tags = [action_tag('delete_orphans'),
                 resource_tag(dispatch_constants.RESOURCE_CONTENT_UNIT_TYPE, 'orphans')]
-        async_task = orphan.delete_orphans_by_id.apply_async((orphan,), tags=tags)
+        async_task = orphan.delete_orphans_by_id.apply_async([orphans], tags=tags)
         raise OperationPostponed(async_task)
 
 
@@ -350,7 +351,7 @@ _URLS = ('/types/$', ContentTypesCollection,
          '/orphans/$', OrphanCollection,
          '/orphans/([^/]+)/$', OrphanTypeSubCollection,
          '/orphans/([^/]+)/([^/]+)/$', OrphanResource,
-         '/actions/delete_orphans/$', DeleteOrphansAction,
+         '/actions/delete_orphans/$', DeleteOrphansAction,  # deprecated in 2.4
          '/catalog/([^/]+)$', CatalogResource,)
 
 application = web.application(_URLS, globals())

--- a/server/test/unit/server/webservices/controllers/test_contents.py
+++ b/server/test/unit/server/webservices/controllers/test_contents.py
@@ -1,0 +1,35 @@
+"""
+Test the pulp.server.webservices.controllers.contents module.
+"""
+
+import mock
+
+from .... import base
+from pulp.devel import mock_plugins
+from pulp.plugins.loader import api as plugin_api
+
+
+class ContentsTest(base.PulpWebserviceTests):
+
+    def setUp(self):
+        super(ContentsTest, self).setUp()
+        plugin_api._create_manager()
+        mock_plugins.install()
+
+    def tearDown(self):
+        super(ContentsTest, self).tearDown()
+        mock_plugins.reset()
+
+    @mock.patch('pulp.server.managers.content.orphan.delete_all_orphans')
+    def test_post_to_deleteorphan(self, mock_delete_all_orphans):
+        """
+        Tests deleting an orphan via DeleteOrphansAction
+        """
+        # Setup
+        path = '/v2/content/actions/delete_orphans/'
+        post_body = '[{"content_type_id": "rpm", "unit_id": "d692be5f-f585-4e6d-b816-0285ffecd847"}]'
+        # Test
+        status, body = self.post(path, post_body)
+        # Verify
+        self.assertEqual(202, status)
+        mock_delete_all_orphans.assert_called_once()


### PR DESCRIPTION
This commit fixes calls to /v2/content/actions/delete_orphans/, and marks the
API as deprecated in favor of /v2/content/orphans/.
