### PR TITLE
1093429 - Changing repo create API to match documented key name.

### DIFF
--- a/bindings/pulp/bindings/repository.py
+++ b/bindings/pulp/bindings/repository.py
@@ -59,7 +59,7 @@ class RepositoryAPI(PulpAPI):
         descriptions. Each distributor is specified as a dict containing the
         following keys:
 
-          distributor_type - ID of the type of distributor being added
+          distributor_type_id - ID of the type of distributor being added
           distributor_config - values sent to the distributor when used by
                                this repository
           auto_publish - boolean indicating if the distributor should automatically

--- a/docs/sphinx/user-guide/release-notes/2.4.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.4.x.rst
@@ -209,6 +209,13 @@ Here are other APIs that have changed, arranged by path:
 
     This is a new API.
 
+``/v2/repositories/``
+    Documentation for POST states that each distributor object should contain a
+    key named ``distributor_type_id``, but the API was actually requiring it to
+    be named ``distributor_type``. The API has been changed to match the
+    documentation, so any code providing distributors to that API will need to
+    be modified.
+
 * Deleting units is no longer blocked when the user performing the delete is different
   than the user that created the unit. This most notably has the effect of eliminating
   the restriction that units could not be deleted from repositories that are synced via a feed.

--- a/server/pulp/server/managers/repo/cud.py
+++ b/server/pulp/server/managers/repo/cud.py
@@ -177,7 +177,7 @@ class RepoManager(object):
 
             try:
                 # Don't bother with any validation here, the manager will run it
-                type_id = distributor.get('distributor_type')
+                type_id = distributor.get('distributor_type_id')
                 plugin_config = distributor.get('distributor_config')
                 auto_publish = distributor.get('auto_publish', False)
                 distributor_id = distributor.get('distributor_id')

--- a/server/test/unit/server/managers/repo/test_cud.py
+++ b/server/test/unit/server/managers/repo/test_cud.py
@@ -200,9 +200,9 @@ class RepoManagerTests(base.PulpServerTests):
         importer_type_id = 'mock-importer'
         importer_repo_plugin_config = {'i' : 'i'}
         distributors = [
-            dict(distributor_type='mock-distributor', distributor_config={'d' : 'd'},
+            dict(distributor_type_id='mock-distributor', distributor_config={'d' : 'd'},
                  auto_publish=True, distributor_id='dist1'),
-            dict(distributor_type='mock-distributor', distributor_config={'d' : 'd'},
+            dict(distributor_type_id='mock-distributor', distributor_config={'d' : 'd'},
                  auto_publish=True, distributor_id='dist2')
         ]
 
@@ -226,7 +226,7 @@ class RepoManagerTests(base.PulpServerTests):
         for d in distributors:
             distributor = RepoDistributor.get_collection().find_one({'id' : d['distributor_id']})
             self.assertEqual(distributor['repo_id'], repo_id)
-            self.assertEqual(distributor['distributor_type_id'], d['distributor_type'])
+            self.assertEqual(distributor['distributor_type_id'], d['distributor_type_id'])
             self.assertEqual(distributor['auto_publish'], d['auto_publish'])
             self.assertEqual(distributor['config'], d['distributor_config'])
 


### PR DESCRIPTION
The docs stated that each distributor should have a key named
`distributor_type_id`, but it actually required `distributor_type`.  The
API was changed to match the docs.
