### PR TITLE
make spec build on rhel5

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -329,8 +329,8 @@ then
 fi
 %endif # End pulp_server if block
 
-%postun server
 %if %{pulp_systemd} == 1
+%postun server
 %systemd_postun
 %endif
 


### PR DESCRIPTION
The builder seems to have not liked the empty %postun field.
