### PR TITLE
Add content sources download report

### DIFF
--- a/server/pulp/server/content/sources/model.py
+++ b/server/pulp/server/content/sources/model.py
@@ -369,9 +369,42 @@ class PrimarySource(ContentSource):
         pass
 
 
+class DownloadDetails(object):
+    """
+    Download details.
+    :ivar total_succeeded: The total number of downloads that succeeded.
+    :type total_succeeded: int
+    :ivar total_failed: The total number of downloads that failed.
+    :type total_failed: int
+    """
+
+    def __init__(self):
+        self.total_succeeded = 0
+        self.total_failed = 0
+
+
+class DownloadReport(object):
+    """
+    Download report.
+    :ivar total_passes: The total number of passes through the download logic.
+    :type total_passes: int
+    :ivar total_sources: The total number of loaded sources.
+    :type total_sources: int
+    :ivar downloads: Dict of: DownloadDetails keyed by source ID.
+    :type downloads: dict
+    """
+
+    def __init__(self):
+        self.total_passes = 0
+        self.total_sources = 0
+        self.downloads = {}
+
+
 class RefreshReport(object):
     """
     Refresh report.
+    :ivar source_id: The content source ID.
+    :type source_id: str
     :ivar succeeded: Indicates whether the refresh was successful.
     :type succeeded: bool
     :ivar added_count: The number of entries added to the catalog.

--- a/server/test/unit/server/content/sources/test_model.py
+++ b/server/test/unit/server/content/sources/test_model.py
@@ -17,7 +17,7 @@ from mock import patch, Mock
 from pulp.plugins.conduits.cataloger import CatalogerConduit
 from pulp.server.content.sources import constants
 from pulp.server.content.sources.model import Request, PrimarySource, ContentSource, RefreshReport
-from pulp.server.content.sources.model import PRIMARY_ID
+from pulp.server.content.sources.model import PRIMARY_ID, DownloadDetails, DownloadReport
 
 TYPE = '1234'
 TYPE_ID = 'ABCD'
@@ -549,7 +549,24 @@ class TestPrimarySource(TestCase):
         self.assertEqual(primary.priority, sys.maxint)
 
 
-class TestReport(TestCase):
+class TestDownloadDetails(TestCase):
+
+    def test_construction(self):
+        details = DownloadDetails()
+        self.assertEqual(details.total_succeeded, 0)
+        self.assertEqual(details.total_failed, 0)
+
+
+class TestDownloadReport(TestCase):
+
+    def test_construction(self):
+        report = DownloadReport()
+        self.assertEqual(report.total_passes, 0)
+        self.assertEqual(report.total_sources, 0)
+        self.assertEqual(report.downloads, {})
+
+
+class TestRefreshReport(TestCase):
 
     def test_construction(self):
         source_id = 's-1'


### PR DESCRIPTION
So, not trying to predict the future here but wanted to collect and return information that I would be useful beyond just the counts of downloads per source.  While we're at it.

The _total_passes_ is really an indicator of how efficient the defined content sources are.  Ideally, the number of passes should not be > 2.  Any more and the container is having to try too many sources and getting too many failures.  Suggests some of the sources need to be removed, re-defined or re-prioritized.

The difference between _total_sources_ and the # of sounces listed in the _downloads_ helps show the percentage of the available sources used.  If we consistently report that only 3/20 sources provide content that users want to download, users may want to rethink how they have their content sources defined.

Finally, I think it's useful for users to see the _total_failed_ counts per source.  Download failures indicate a disconnect between what's in the catalog of available content and what the source actually seems to provide.
