### PR TITLE
1092989: assume no uploads are in progress if upload working dir does not exist

### DIFF
--- a/client_lib/test/unit/test_client_upload_manager.py
+++ b/client_lib/test/unit/test_client_upload_manager.py
@@ -11,6 +11,7 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+import errno
 import math
 import os
 import shutil
@@ -79,6 +80,34 @@ class UploadManagerTests(unittest.TestCase):
 
         # Verify
         self.assertEqual(0, len(self.upload_manager.list_uploads()))
+
+    @mock.patch('os.listdir')
+    def test_no_workingdir(self, mock_listdir):
+        ex = OSError('a mock error (ENOENT)')
+        ex.errno = errno.ENOENT
+        mock_listdir.side_effect = ex
+
+        os.makedirs(self.upload_working_dir)
+
+        # Test
+        self.upload_manager.initialize()
+
+        # Verify
+        self.assertEqual(0, len(self.upload_manager.list_uploads()))
+
+    @mock.patch('os.listdir')
+    def test_workingdir_err(self, mock_listdir):
+        ex = OSError('a mock error (EIO)')
+        ex.errno = errno.EIO
+        mock_listdir.side_effect = ex
+
+        os.makedirs(self.upload_working_dir)
+
+        # Test
+        self.upload_manager.initialize()
+
+        # Verify
+        self.assertRaises(OSError, self.upload_manager.list_uploads)
 
     def test_initialize_with_trackers(self):
         # Setup


### PR DESCRIPTION
Previously, pulp-admin would output an error to ~/.pulp/admin.log if "repo
uploads list"  was run without a repo upload working dir.

Instead, check for an exception if the repo upload working dir does not exist,
and assume no uploads are in progress if this is the case.

Also, general pep8 fixups on the two edited files.
