### PR TITLE
checksum support in builder.

### DIFF
--- a/rel-eng/builder.py
+++ b/rel-eng/builder.py
@@ -25,7 +25,7 @@ ARCH = 'arch'
 REPO_NAME = 'repo_name'
 DIST_KOJI_NAME = 'koji_name'
 PULP_PACKAGES = 'pulp_packages'
-CHECKSUM = 'checksum'
+REPO_CHECKSUM_TYPE = 'checksum'
 
 # Mapping for the package keys in the DISTRIBUTION_INFO to the locations on disk
 PULP_PACKAGE_LOCATIONS = {
@@ -35,34 +35,37 @@ PULP_PACKAGE_LOCATIONS = {
     'pulp-puppet': 'pulp_puppet'
 }
 
+# Using 'sha' instead of 'sha1' for EL5 because createrepo documentation
+# indicates that 'sha1' may not be compatible with older versions of yum.
+
 DISTRIBUTION_INFO = {
     'el5': {
         ARCH: ['i386', 'x86_64'],
         REPO_NAME: '5Server',
         DIST_KOJI_NAME: 'rhel5',
         PULP_PACKAGES: ['pulp', 'pulp-rpm', 'pulp-puppet'],
-        CHECKSUM: 'sha'
+        REPO_CHECKSUM_TYPE: 'sha'
     },
     'el6': {
         ARCH: ['i686', 'x86_64'],
         REPO_NAME: '6Server',
         DIST_KOJI_NAME: 'rhel6',
         PULP_PACKAGES: ['pulp', 'pulp-nodes', 'pulp-rpm', 'pulp-puppet'],
-        CHECKSUM: 'sha256'
+        REPO_CHECKSUM_TYPE: 'sha256'
     },
     'fc19': {
         ARCH: ['i686', 'x86_64'],
         REPO_NAME: 'fedora-19',
         DIST_KOJI_NAME: 'fedora19',
         PULP_PACKAGES: ['pulp', 'pulp-nodes', 'pulp-rpm', 'pulp-puppet'],
-        CHECKSUM: 'sha256'
+        REPO_CHECKSUM_TYPE: 'sha256'
     },
     'fc20': {
         ARCH: ['i686', 'x86_64'],
         REPO_NAME: 'fedora-20',
         DIST_KOJI_NAME: 'fedora20',
         PULP_PACKAGES: ['pulp', 'pulp-nodes', 'pulp-rpm', 'pulp-puppet'],
-        CHECKSUM: 'sha256'
+        REPO_CHECKSUM_TYPE: 'sha256'
     },
 }
 
@@ -282,7 +285,7 @@ def build_repos(output_dir, dist):
     noarch_dir = os.path.join(output_dir, 'noarch')
     comps_file = os.path.join(WORKSPACE, 'pulp', 'comps.xml')
     arch_list = (DISTRIBUTION_INFO.get(dist)).get(ARCH)
-    checksum = (DISTRIBUTION_INFO.get(dist)).get(CHECKSUM)
+    checksum = (DISTRIBUTION_INFO.get(dist)).get(REPO_CHECKSUM_TYPE)
     for arch in arch_list:
         arch_dir = os.path.join(output_dir, arch)
         ensure_dir(arch_dir, False)


### PR DESCRIPTION
This is attempting to fix an issue report by QE.  They were seeing a checksum issue doing ``yum repolist -v` on EL5.  I rebuilt the repos for .13.beta and tested on RHEL 5.5:

```
[root@rhel5-builder yum.repos.d]# yum repolist -v
Loading "rhnplugin" plugin
Loading "security" plugin
Config time: 0.094
Looking for repo options for [rhel-x86_64-server-5]
Yum Version: 3.2.22
Repo-id     : epel
Repo-name   : Extra Packages for Enterprise Linux 5 - x86_64
Repo-status : enabled:
Repo-revision: 1399933781
Repo-tags   : binary-x86_64
Repo-updated: Mon May 12 18:31:44 2014
Repo-pkgs   : 7,694
Repo-size   : 6.1 G
Repo-mirrors: http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=x86_64

Repo-id     : pulp-v2-beta
Repo-name   : Pulp v2 Beta Builds
Repo-status : enabled:
Repo-revision: 1399997443
Repo-updated: Tue May 13 12:10:45 2014
Repo-pkgs   : 28
Repo-size   : 2.1 M
Repo-baseurl: http://repos.fedorapeople.org/repos/pulp/pulp/beta/2.4/5Server/x86_64/

Repo-id     : rhel-x86_64-server-5
Repo-name   : Red Hat Enterprise Linux (v. 5 for 64-bit x86_64)
Repo-status : enabled:
Repo-updated: Wed May 14 10:08:57 2014
Repo-pkgs   : 16,009
Repo-size   : 33 G
Repo-baseurl: https://xmlrpc.rhn.redhat.com/XMLRPC/GET-REQ/rhel-x86_64-server-5

repolist: 23,731
[root@rhel5-builder yum.repos.d]# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 5.5 (Tikanga)
```

QE reported they were still seeing an issue so not 100% sure if this change actually fixes anything or not.

Using _sha_ instead of _sha1_ because createrepo documentation says:

```
-s --checksum
              Choose the checksum type used in repomd.xml and for packages in the metadata.  The default is now "sha256"  (if  python  has
              hashlib).  The  older  default  was  "sha",  which is actually "sha1", however explicitly using "sha1" doesn't work on older
              (3.0.x) versions of yum, you need to specify "sha".
```
