### PR TITLE
1094647 - GET of consumer schedule that doesn't exist now returns 404

### DIFF
--- a/server/pulp/server/webservices/controllers/consumers.py
+++ b/server/pulp/server/webservices/controllers/consumers.py
@@ -689,9 +689,12 @@ class UnitActionScheduleResource(JSONController):
 
     @auth_required(READ)
     def GET(self, consumer_id, schedule_id):
-        try:
-            scheduled_call = list(self.manager.get(consumer_id, self.ACTION))[0]
-        except IndexError:
+        scheduled_call = None
+        for call in self.manager.get(consumer_id, self.ACTION):
+            if call.id == schedule_id:
+                scheduled_call = call
+                break
+        if scheduled_call is None:
             raise MissingResource(consumer_id=consumer_id, schedule_id=schedule_id)
 
         scheduled_obj = serialization.dispatch.scheduled_unit_management_obj(scheduled_call.for_display())

--- a/server/test/unit/server/webservices/controllers/test_consumers.py
+++ b/server/test/unit/server/webservices/controllers/test_consumers.py
@@ -1476,6 +1476,27 @@ class ScheduledUnitInstallTests(base.PulpWebserviceTests):
 
         self.assertEqual(status, 200)
 
+    def test_get_scheduled_install_404(self):
+        schedule = 'R1/P1DT'
+        zsh_unit = {'type_id': 'rpm',
+                    'unit_key': {'name': 'zsh'}}
+        options = {'importkeys': True}
+
+        path = '/v2/consumers/%s/schedules/content/install/' % self.consumer_id
+        body = {'schedule': schedule,
+                'units': [zsh_unit],
+                'options': options}
+
+        status, response = self.post(path, body)
+
+        self.assertEqual(status, 201)
+
+        path = '/v2/consumers/%s/schedules/content/install/%s/' % (self.consumer_id, '111111111111111')
+
+        status, response = self.get(path)
+
+        self.assertEqual(status, 404)
+
     def test_get_all_scheduled_installs(self):
         schedule = 'R1/P1DT'
         zsh_unit = {'type_id': 'rpm',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1094647
