### PR TITLE
1096289 - Only start scheduler threads if lazy=False.

### DIFF
--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -147,10 +147,11 @@ class Scheduler(beat.Scheduler):
         self._schedule = None
         self._failure_watcher = FailureWatcher()
         self._loaded_from_db_count = 0
-        # start monitoring events in a thread
-        thread = threading.Thread(target=self._failure_watcher.monitor_events)
-        thread.daemon = True
-        thread.start()
+        if kwargs.get('lazy', True) is False:
+            # start monitoring events in a thread
+            thread = threading.Thread(target=self._failure_watcher.monitor_events)
+            thread.daemon = True
+            thread.start()
 
         kwargs['app'] = app
         super(Scheduler, self).__init__(*args, **kwargs)

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -194,12 +194,18 @@ class TestHandleFailedTask(unittest.TestCase):
 class TestSchedulerInit(unittest.TestCase):
     @mock.patch('threading.Thread')
     @mock.patch.object(scheduler.Scheduler, 'setup_schedule', new=mock.MagicMock())
-    def test_starts_monitor(self, mock_thread):
-        sched_instance = scheduler.Scheduler()
+    def test_starts_monitor_lazy_False(self, mock_thread):
+        sched_instance = scheduler.Scheduler(lazy=False)
 
         mock_thread.assert_called_once_with(target=sched_instance._failure_watcher.monitor_events)
         mock_thread.return_value.start.assert_called_once_with()
         self.assertTrue(mock_thread.return_value.daemon is True)
+
+    @mock.patch('threading.Thread')
+    @mock.patch.object(scheduler.Scheduler, 'setup_schedule', new=mock.MagicMock())
+    def test_starts_monitor_lazy_True(self, mock_thread):
+        scheduler.Scheduler(lazy=True)
+        self.assertTrue(not mock_thread.called)
 
 
 class TestSchedulerTick(unittest.TestCase):


### PR DESCRIPTION
Multiple threads were being started when only should have been, and some were being started earlier than expected. This is a known celery behavior[0].  This could interfere with Celery's forking model of celerybeat, causing the traceback related to BZ 1096289   [1].

[0]. https://github.com/celery/celery/issues/1549
[1]. https://bugzilla.redhat.com/show_bug.cgi?id=1096289
