### PR TITLE
1091980 - Update install and upgrade docs with qpid client deps

### DIFF
--- a/docs/sphinx/user-guide/installation.rst
+++ b/docs/sphinx/user-guide/installation.rst
@@ -124,7 +124,7 @@ Server
    that you will run Pulp on, or it can be elsewhere as you please. For yum based systems, you can
    install Qpid with this command::
     
-    $ sudo yum install qpid-cpp-server
+    $ sudo yum install qpid-cpp-server python-qpid-qmf python-qpid
 
    Configure the Qpid broker using the Qpid configuration file ``qpidd.conf``.  For Qpid 0.24+ the
    config file is expected at ``/etc/qpid/qpidd.conf``, and earlier Qpid versions expect the

--- a/docs/sphinx/user-guide/release-notes/2.4.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.4.x.rst
@@ -56,6 +56,11 @@ You can see the complete list of bugs that were
 Upgrade Instructions for 2.3.x --> 2.4.0
 ----------------------------------------
 
+Pulp 2.4 introduces new client library dependencies if you are using Qpid as your message broker.
+Ensure you have the necessary dependencies installed by running::
+
+    $ sudo yum install python-qpid-qmf python-qpid
+
 To upgrade to the new Pulp release from version 2.3.x, you should begin by using yum to install the
 latest RPMs from the Pulp repository and run the database migrations::
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1091980

Adds qpid client dependency installation to the Installation and Pulp 2.3->2.4 upgrade docs.  We haven't made the docs broker agnostic, so this is written with the assumption that Qpid is being used, which is consistent with the existing docs.
