### PR TITLE
1099168 - move %postun block inside pulp_server if block

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -326,12 +326,12 @@ if [ $1 -eq 1 ]; # not an upgrade
 then
   pulp-gen-ca-certificate
 fi
-%endif # End pulp_server if block
 
 %if %{pulp_systemd} == 1
 %postun server
 %systemd_postun
 %endif
+%endif # End pulp_server if block
 
 
 # ---- Common ------------------------------------------------------------------


### PR DESCRIPTION
Previously, the %postun was fenced only by %use_systemd. This caused strange
issues when importing the srpm to our build system, even though the srpm built
fine.

Instead, fence %postun by %pulp_server as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1099168
