### PR TITLE
1051700 - Don't build pulp-admin on RHEL 5.

### DIFF
--- a/docs/sphinx/user-guide/installation.rst
+++ b/docs/sphinx/user-guide/installation.rst
@@ -25,21 +25,21 @@ Supported Operating Systems
 ---------------------------
 Server
 
-* RHEL 6
+* RHEL 6 & 7
 * Fedora 19 & 20
-* CentOS 6
+* CentOS 6 & 7
 
 Consumer
 
-* RHEL 5 & 6
+* RHEL 5, 6, & 7
 * Fedora 19 & 20
-* CentOS 5 & 6
+* CentOS 5, 6 & 7
 
 Admin Client
 
-* RHEL 6
-* Fedora 18 & 19
-* CentOS 6
+* RHEL 6 & 7
+* Fedora 19 & 20
+* CentOS 6 & 7
 
 Prerequisites
 -------------


### PR DESCRIPTION
Also, update the installation docs to include the supported OS's for Pulp 2.4.

https://bugzilla.redhat.com/show_bug.cgi?id=1051700
