### PR TITLE
1099945 - use correct serializer when publishing events

### DIFF
--- a/server/pulp/server/event/http.py
+++ b/server/pulp/server/event/http.py
@@ -27,7 +27,7 @@ import httplib
 import logging
 import threading
 
-from pulp.server.compat import json
+from pulp.server.compat import json, json_util
 
 # -- constants ----------------------------------------------------------------
 
@@ -45,7 +45,7 @@ def handle_event(notifier_config, event):
 
     LOG.info(data)
 
-    body = json.dumps(data)
+    body = json.dumps(data, default=json_util.default)
 
     thread = threading.Thread(target=_send_post, args=[notifier_config, body])
     thread.setDaemon(True)

--- a/server/pulp/server/event/mail.py
+++ b/server/pulp/server/event/mail.py
@@ -21,7 +21,7 @@ except ImportError:
     # python 2.4 version
     from email.MIMEText import MIMEText
 
-from pulp.server.compat import json
+from pulp.server.compat import json, json_util
 from pulp.server.config import config
 
 TYPE_ID = 'email'
@@ -43,7 +43,7 @@ def handle_event(notifier_config, event):
     """
     if not config.getboolean('email', 'enabled'):
         return
-    body = json.dumps(event.data(), indent=2)
+    body = json.dumps(event.data(), indent=2, default=json_util.default)
     subject = notifier_config['subject']
     addresses = notifier_config['addresses']
 

--- a/server/pulp/server/managers/event/remote.py
+++ b/server/pulp/server/managers/event/remote.py
@@ -17,6 +17,7 @@ from qpid.messaging import Connection
 from qpid.messaging.exceptions import ConnectionError, MessagingError
 
 from pulp.common.compat import json
+from pulp.server.compat import json_util
 from pulp.server.config import config
 
 
@@ -84,7 +85,7 @@ class TopicPublishManager(object):
             destination = '%s/%s; {create:always, node:{type:topic}, link:{x-declare:{auto-delete:True}}}' % (
                 exchange or cls.EXCHANGE, subject)
 
-            data = json.dumps(event.data())
+            data = json.dumps(event.data(), default=json_util.default)
             try:
                 cls.connection().session().sender(destination).send(data)
             except MessagingError, e:


### PR DESCRIPTION
Previously, the default json serializer was used when publishing events. If an
event had a bson ObjectId in it, the publish would fail due to a json
serialization error.

Instead, use the serializer from json_util.
