### PR TITLE
1097247 - Add status to pulp_celerybeat script.

### DIFF
--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -14,7 +14,7 @@
 # Required-Stop:     $network $local_fs $remote_fs
 # Should-Start:      mongod qpidd rabbitmq-server
 # Default-Start:     3 4 5
-# Default-Stop:      0 1 6
+# Default-Stop:      0 1 2 6
 # Short-Description: pulp's celery periodic task scheduler
 ### END INIT INFO
 
@@ -192,6 +192,28 @@ check_paths() {
 }
 
 
+check_status() {
+    if [ ! -e $CELERYBEAT_PID_FILE ]; then
+        local pid=
+    else
+        local pid=`cat "$CELERYBEAT_PID_FILE"`
+    fi
+
+    if [ -z "$pid" ]; then
+        echo "${SCRIPT_NAME} is stopped."
+        exit 1
+    fi
+    local failed=
+    kill -0 $pid 2> /dev/null || failed=true
+    if [ "$failed" ]; then
+        echo "${SCRIPT_NAME} is missing."
+        exit 1
+    fi
+    echo "${SCRIPT_NAME} (pid $pid) is running."
+    exit 0
+}
+
+
 create_paths () {
     create_default_dir "$CELERYBEAT_LOG_DIR"
     create_default_dir "$CELERYBEAT_PID_DIR"
@@ -263,6 +285,9 @@ case "$1" in
         check_dev_null
         start_beat
     ;;
+    status)
+        check_status
+    ;;
     create-paths)
         check_dev_null
         create_paths
@@ -272,7 +297,7 @@ case "$1" in
         check_paths
     ;;
     *)
-        echo "Usage: /etc/init.d/${SCRIPT_NAME} {start|stop|restart|create-paths|check-paths}"
+        echo "Usage: /etc/init.d/${SCRIPT_NAME} {start|stop|restart|status|create-paths|check-paths}"
         exit 64  # EX_USAGE
     ;;
 esac

--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -293,21 +293,25 @@ check_status () {
     found_pids=0
 
     local one_failed=
-    for pid_file in "$CELERYD_PID_DIR"/*.pid; do
-        local node=`basename "$pid_file" .pid`
-        local pid=`cat "$pid_file"`
-        local cleaned_pid=`echo "$pid" | sed -e 's/[^0-9]//g'`
-        if [ -z "$pid" ] || [ "$cleaned_pid" != "$pid" ]; then
-            echo "bad pid file ($pid_file)"
+    for node in $CELERYD_NODES; do
+        local pid_file="$CELERYD_PID_DIR/$node.pid"
+        if [ ! -e $pid_file ]; then
+            local pid=
+        else
+            local pid=`cat "$pid_file"`
+        fi
+
+        if [ -z "$pid" ]; then
+            echo "node $node is stopped..."
             one_failed=true
         else
             local failed=
             kill -0 $pid 2> /dev/null || failed=true
             if [ "$failed" ]; then
-                echo "${SCRIPT_NAME} (node $node) (pid $pid) is stopped, but pid file exists!"
+                echo "node $node (pid $pid) is missing..."
                 one_failed=true
             else
-                echo "${SCRIPT_NAME} (node $node) (pid $pid) is running..."
+                echo "node $node (pid $pid) is running..."
             fi
         fi
     done


### PR DESCRIPTION
This commit adds a status command to the pulp_celerybeat init script.

It also fixed the pulp_workers init script to report status only on the
nodes managed by it, rather than all PID files found in /var/run/pulp/.
This also adds the ability for it to report nodes being stopped when
there are no PID files for them.

Both init scripts return 0 if the expected nodes are all running, and
1 if one or more nodes are failed or stopped.

https://bugzilla.redhat.com/show_bug.cgi?id=1097247
