### PR TITLE
1100892 - check if filename exists before printing

### DIFF
--- a/client_lib/pulp/client/commands/repo/upload.py
+++ b/client_lib/pulp/client/commands/repo/upload.py
@@ -577,7 +577,14 @@ class ListCommand(PulpCliCommand):
                 state = '[%s]' % self.context.prompt.color(_(' Paused  '), COLOR_PAUSED)
 
             template = '%s %s'
-            message = template % (state, os.path.basename(upload.source_filename))
+
+            # bz 1100892
+            if upload.source_filename:
+                source_name = os.path.basename(upload.source_filename)
+            else:
+                source_name = _('Metadata Upload')
+
+            message = template % (state, source_name)
             self.context.prompt.write(message)
 
         self.context.prompt.render_spacer()

--- a/client_lib/test/unit/client/commands/repo/test_upload.py
+++ b/client_lib/test/unit/client/commands/repo/test_upload.py
@@ -134,3 +134,16 @@ class UploadCommandTests(base.PulpClientTests):
             self.fail('Exception was not bubbled up')
         except Exception, e:
             self.assertTrue(e is mock_repo_api.side_effect)
+
+
+class ListCommandTests(base.PulpClientTests):
+
+    def test_list_no_filename(self):
+        mock_tracker = mock.MagicMock()
+        mock_tracker.is_running = False
+        mock_tracker.source_filename = None
+
+        self.mock_upload_manager = mock.MagicMock()
+        self.mock_upload_manager.list_uploads.return_value = [mock_tracker]
+        self.list_command = upload.ListCommand(self.context, self.mock_upload_manager)
+        self.list_command.run()


### PR DESCRIPTION
If a user uploads metadata like a repo category via pulp-admin and then lists
pending uploads, the list command will incorrectly look for an upload filename
on the tracker and then error when none is found.

Instead, only print the filename if it exists, and print "Metadata Upload"
otherwise.
