### PR TITLE
1105278 - Corrects double UTC conversion issue for new RepoContentUnits

### DIFF
--- a/server/pulp/server/db/model/repository.py
+++ b/server/pulp/server/db/model/repository.py
@@ -268,8 +268,8 @@ class RepoContentUnit(Model):
         self.owner_id = owner_id
 
         # store time in UTC
-        created = dateutils.to_utc_datetime(datetime.datetime.utcnow())
-        self.created = dateutils.format_iso8601_datetime(created)
+        utc_timestamp = dateutils.now_utc_timestamp()
+        self.created = dateutils.format_iso8601_utc_timestamp(utc_timestamp)
         self.updated = self.created
 
 

--- a/server/test/unit/server/db/model/test_repository.py
+++ b/server/test/unit/server/db/model/test_repository.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+
+import mock
+
+from pulp.server.db.model.repository import RepoContentUnit
+
+REPOSITORY = 'pulp.server.db.model.repository'
+
+
+class TestRepoContentUnitInit(TestCase):
+
+    def setUp(self):
+        self.patch_a = mock.patch(REPOSITORY + '.Model.__init__')
+        self.mock_Model__init__ = self.patch_a.start()
+
+        self.patch_b = mock.patch(REPOSITORY + '.dateutils')
+        self.mock_dateutils = self.patch_b.start()
+
+        self.mock_repo_id = mock.Mock()
+        self.mock_unit_id = mock.Mock()
+        self.mock_unit_type_id = mock.Mock()
+        self.mock_owner_type = mock.Mock()
+        self.mock_owner_id = mock.Mock()
+        self.repo_content_unit = RepoContentUnit(self.mock_repo_id, self.mock_unit_id,
+                                                 self.mock_unit_type_id, self.mock_owner_type,
+                                                 self.mock_owner_id)
+
+    def tearDown(self):
+        self.patch_a.stop()
+        self.patch_b.stop()
+
+    def test_repo_content_unit___init___calls_super___init__(self):
+        self.mock_Model__init__.assert_called_once_with()
+
+    def test_repo_content_unit___init___stores_repo_id(self):
+        self.assertTrue(self.repo_content_unit.repo_id is self.mock_repo_id)
+
+    def test_repo_content_unit___init___stores_unit_id(self):
+        self.assertTrue(self.repo_content_unit.unit_id is self.mock_unit_id)
+
+    def test_repo_content_unit___init___stores_unit_type_id(self):
+        self.assertTrue(self.repo_content_unit.unit_type_id is self.mock_unit_type_id)
+
+    def test_repo_content_unit___init___stores_owner_type(self):
+        self.assertTrue(self.repo_content_unit.owner_type is self.mock_owner_type)
+
+    def test_repo_content_unit___init___stores_owner_id(self):
+        self.assertTrue(self.repo_content_unit.owner_id is self.mock_owner_id)
+
+    def test_repo_content_unit___init___generates_8601_utc_timestamp(self):
+        self.mock_dateutils.now_utc_timestamp.assert_called_once_with()
+        utc_timestamp = self.mock_dateutils.now_utc_timestamp.return_value
+        self.mock_dateutils.format_iso8601_utc_timestamp.assert_called_once_with(utc_timestamp)
+
+    def test_repo_content_unit___init___stores_created(self):
+        created = self.mock_dateutils.format_iso8601_utc_timestamp.return_value
+        self.assertTrue(self.repo_content_unit.created is created)
+
+    def test_repo_content_unit___init___stores_updated_equal_to_created(self):
+        self.assertTrue(self.repo_content_unit.created is self.repo_content_unit.updated)


### PR DESCRIPTION
This fixes the timestamp problem with units of all types. The datetime was being converted to utc twice. This should resolve [BZ 1105278](https://bugzilla.redhat.com/show_bug.cgi?id=1105278).

I was able to reproduce timestamps using the existing code like:

```
> db.repo_content_units.find({repo_id: 'foo'})[0]
{
    "_id" : ObjectId("5398ba0754903459bdcad658"),
    "updated" : "2014-06-12T00:15:23Z",
    "repo_id" : "foo",
    "created" : "2014-06-12T00:15:23Z",
    "_ns" : "repo_content_units",
    "unit_id" : "fed3bef9-0066-41ba-865f-01eb582cdc4a",
    "unit_type_id" : "puppet_module",
    "owner_type" : "importer",
    "id" : "5398ba0754903459bdcad658",
    "owner_id" : "puppet_importer"
}
```

I was able to adjust the code, and it started saving them like this (which was the correct UTC time):

```
> db.repo_content_units.find({repo_id: 'foo'})[0]
{
    "_id" : ObjectId("5398ba0754903459bdcad658"),
    "updated" : "2014-06-11T20:20:23Z",
    "repo_id" : "foo",
    "created" : "2014-06-11T20:20:23Z",
    "_ns" : "repo_content_units",
    "unit_id" : "fed3bef9-0066-41ba-865f-01eb582cdc4a",
    "unit_type_id" : "puppet_module",
    "owner_type" : "importer",
    "id" : "5398ba0754903459bdcad658",
    "owner_id" : "puppet_importer"
}
```
