### PR TITLE
1094286 - failing to include 'options' or 'units' during content calls on consumers now causes a 400 code

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/consumer/content.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/consumer/content.rst
@@ -15,9 +15,9 @@ must match a type mapped to a content :term:`handler` in the agent.  The second 
 **unit_key** which identifies the unit or units to be installed.  Both the structure and
 content are handler specific.
 
-The caller can pass additional options using an *options* object.  Both the structure and
-content are handler specific.  The options drive how the handler performs the operation.
-
+The caller must also pass an *options* object, which specifies additional install options.
+Both the structure and content are handler specific.  The options drive how the handler
+performs the operation.
 
 | :method:`post`
 | :path:`/v2/consumers/<consumer_id>/actions/content/install/`
@@ -30,7 +30,7 @@ content are handler specific.  The options drive how the handler performs the op
 | :response_list:`_`
 
 * :response_code:`202,The install request has been accepted`
-* :response_code:`400,if one or more of the parameters is invalid`
+* :response_code:`400,if one or more of the parameters is missing or invalid`
 * :response_code:`404,if the consumer does not exist`
 
 | :return:`a` :ref:`call_report`
@@ -67,8 +67,9 @@ must match a type mapped to a content :term:`handler` in the agent.  The second 
 **unit_key** which identifies the unit or units to be updated.  Both the structure and
 content are handler specific.
 
-The caller can pass additional options using an *options* object.  Both the structure and
-content are handler specific.  The options drive how the handler performs the operation.
+The caller must also pass an *options* object, which specifies additional update options.
+Both the structure and content are handler specific.  The options drive how the handler
+performs the operation.
 
 | :method:`post`
 | :path:`/v2/consumers/<consumer_id>/actions/content/update/`
@@ -81,7 +82,7 @@ content are handler specific.  The options drive how the handler performs the op
 | :response_list:`_`
 
 * :response_code:`202,The update request has been accepted`
-* :response_code:`400,if one or more of the parameters is invalid`
+* :response_code:`400,if one or more of the parameters is missing or invalid`
 * :response_code:`404,if the consumer does not exist`
 
 | :return:`a` :ref:`call_report`
@@ -115,8 +116,9 @@ must match a type mapped to a content :term:`handler` in the agent.  The second 
 **unit_key** which identifies the unit or units to be uninstalled.  The value is completely
 defined by the handler mapped to the unit's type_id.
 
-The caller can pass additional options using an *options* object.  Both the structure and
-content are handler specific.  The options drive how the handler performs the operation.
+The caller must also pass an *options* object, which specifies additional uninstall options.
+Both the structure and content are handler specific.  The options drive how the handler
+performs the operation.
 
 | :method:`post`
 | :path:`/v2/consumers/<consumer_id>/actions/content/uninstall/`
@@ -129,7 +131,7 @@ content are handler specific.  The options drive how the handler performs the op
 | :response_list:`_`
 
 * :response_code:`202,The uninstall request has been accepted`
-* :response_code:`400,if one or more of the parameters is invalid`
+* :response_code:`400,if one or more of the parameters is missing or invalid`
 * :response_code:`404,if the consumer does not exist`
 
 | :return:`a` :ref:`call_report`

--- a/server/pulp/server/webservices/controllers/consumers.py
+++ b/server/pulp/server/webservices/controllers/consumers.py
@@ -322,8 +322,17 @@ class Content(JSONController):
         :type consumer_id: str
         """
         body = self.params()
+        missing_params = []
         units = body.get('units')
+        if units is None:
+            missing_params.append('units')
         options = body.get('options')
+        if options is None:
+            missing_params.append('options')
+
+        if len(missing_params) > 0:
+            raise MissingValue(missing_params)
+
         agent_manager = managers.consumer_agent_manager()
         task = agent_manager.install_content(consumer_id, units, options)
         raise OperationPostponed(TaskResult.from_task_status_dict(task))
@@ -338,8 +347,17 @@ class Content(JSONController):
         @type consumer_id: str
         """
         body = self.params()
+        missing_params = []
         units = body.get('units')
+        if units is None:
+            missing_params.append('units')
         options = body.get('options')
+        if options is None:
+            missing_params.append('options')
+
+        if len(missing_params) > 0:
+            raise MissingValue(missing_params)
+
         agent_manager = managers.consumer_agent_manager()
         task = agent_manager.update_content(consumer_id, units, options)
         raise OperationPostponed(TaskResult.from_task_status_dict(task))
@@ -354,8 +372,17 @@ class Content(JSONController):
         @type consumer_id: str
         """
         body = self.params()
+        missing_params = []
         units = body.get('units')
+        if units is None:
+            missing_params.append('units')
         options = body.get('options')
+        if options is None:
+            missing_params.append('options')
+
+        if len(missing_params) > 0:
+            raise MissingValue(missing_params)
+
         agent_manager = managers.consumer_agent_manager()
         task = agent_manager.uninstall_content(consumer_id, units, options)
         raise OperationPostponed(TaskResult.from_task_status_dict(task))

--- a/server/test/unit/server/webservices/controllers/test_consumers.py
+++ b/server/test/unit/server/webservices/controllers/test_consumers.py
@@ -29,7 +29,7 @@ from pulp.server.db.model.consumer import (Consumer, Bind, RepoProfileApplicabil
 from pulp.server.db.model.criteria import Criteria
 from pulp.server.db.model.dispatch import ScheduledCall
 from pulp.server.db.model.repository import Repo, RepoDistributor
-from pulp.server.exceptions import InvalidValue, OperationPostponed
+from pulp.server.exceptions import InvalidValue, OperationPostponed, MissingValue
 from pulp.server.managers import factory
 from pulp.server.managers.consumer.bind import BindManager
 from pulp.server.managers.consumer.profile import ProfileManager
@@ -692,6 +692,16 @@ class BindTest(base.PulpWebserviceTests):
 
 class ContentTest(PulpWebservicesTests):
 
+    def test_bad_request(self):
+        """
+        Test that requesting a non-existent action raises a BadRequest exception
+        """
+        # Setup
+        webservice = consumers.Content()
+
+        # Test
+        self.assertRaises(BadRequest, webservice.POST, 'test-consumer', 'not_an_op')
+
     @mock.patch('pulp.server.webservices.controllers.consumers.managers')
     def test_install(self, mock_factory):
         # Setup
@@ -704,6 +714,42 @@ class ContentTest(PulpWebservicesTests):
         # Test
         self.assertRaises(OperationPostponed, webservice.install, 'consumer-foo')
         mock_task.assert_called_once_with('consumer-foo', 'foo-unit', 'bar')
+
+    def test_install_no_options(self):
+        """
+        Test that when no options are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={'units': 'foo-unit'})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.install, 'test-consumer')
+
+    def test_install_no_units(self):
+        """
+        Test that when no units are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={'options': {}})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.install, 'test-consumer')
+
+    def test_install_no_params(self):
+        """
+        Test that when no units are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.install, 'test-consumer')
 
     @mock.patch('pulp.server.webservices.controllers.consumers.managers')
     def test_uninstall(self, mock_factory):
@@ -718,6 +764,42 @@ class ContentTest(PulpWebservicesTests):
         self.assertRaises(OperationPostponed, webservice.uninstall, 'consumer-foo')
         mock_task.assert_called_once_with('consumer-foo', 'foo-unit', 'bar')
 
+    def test_uninstall_no_options(self):
+        """
+        Test that when no options are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={'units': 'foo-unit'})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.uninstall, 'test-consumer')
+
+    def test_uninstall_no_units(self):
+        """
+        Test that when no units are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={'options': {}})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.uninstall, 'test-consumer')
+
+    def test_uninstall_no_params(self):
+        """
+        Test that when no units are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.uninstall, 'test-consumer')
+
     @mock.patch('pulp.server.webservices.controllers.consumers.managers')
     def test_update(self, mock_factory):
         # Setup
@@ -731,6 +813,41 @@ class ContentTest(PulpWebservicesTests):
         self.assertRaises(OperationPostponed, webservice.update, 'consumer-foo')
         mock_task.assert_called_once_with('consumer-foo', 'foo-unit', 'bar')
 
+    def test_update_no_options(self):
+        """
+        Test that when no options are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={'units': 'foo-unit'})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.update, 'test-consumer')
+
+    def test_update_no_units(self):
+        """
+        Test that when no units are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={'options': {}})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.update, 'test-consumer')
+
+    def test_update_no_params(self):
+        """
+        Test that when no units are provided in the request, the proper
+        exception is raised
+        """
+        # Setup
+        webservice = consumers.Content()
+        webservice.params = mock.Mock(return_value={})
+
+        # Test
+        self.assertRaises(MissingValue, webservice.update, 'test-consumer')
 
 class TestProfilesNoWSGI(PulpWebservicesTests):
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1094286
