### PR TITLE
1020912 - add pulp_manage_puppet selinux boolean

### DIFF
--- a/server/selinux/server/pulp-server.te
+++ b/server/selinux/server/pulp-server.te
@@ -1,9 +1,18 @@
 # When built from RPM, the below version of "0.0.0" will be 
 # replaced with the version in the spec file
 policy_module(pulp-server,0.0.0)
+
+## <desc>
+## <p>
+## Allow pulp to manage puppet content
+## </p>
+## </desc>
+gen_tunable(pulp_manage_puppet, false)
+
 require {
     type httpd_t;
     type rpm_var_lib_t;
+    type puppet_etc_t;
 }
 
 type pulp_cert_t;
@@ -11,6 +20,13 @@ miscfiles_cert_type(pulp_cert_t)
 manage_files_pattern(httpd_t, pulp_cert_t, pulp_cert_t)
 manage_dirs_pattern(httpd_t, pulp_cert_t, pulp_cert_t)
 read_lnk_files_pattern(httpd_t, pulp_cert_t, pulp_cert_t)
+
+optional_policy(`
+    tunable_policy(`pulp_manage_puppet', `
+        manage_dirs_pattern(httpd_t, puppet_etc_t, puppet_etc_t)
+        manage_files_pattern(httpd_t, puppet_etc_t, puppet_etc_t)
+    ')
+')
 
 #https://bugzilla.redhat.com/show_bug.cgi?id=784280#c2
 dontaudit httpd_t rpm_var_lib_t:dir { getattr search open };


### PR DESCRIPTION
This adds new boolean which can be turned on with

```
semanage boolean -m --on pulp_manage_puppet
```

or similar command. It is turned off by default.

Please help me testing this patch. After build and the command above, the rule
should be visible with

```
sesearch -A -s httpd_t -t puppet_etc_t -C
```

Thanks
