### PR TITLE
1115715 - syslog handler works with string formatting tokens in stack traces.

### DIFF
--- a/server/pulp/server/logs.py
+++ b/server/pulp/server/logs.py
@@ -117,10 +117,11 @@ class CompliantSysLogHandler(logging.handlers.SysLogHandler):
         :type  record: logging.LogRecord
         """
         if record.exc_info:
+            trace = self.formatter.formatException(record.exc_info)
             if not isinstance(record.msg, basestring):
                 record.msg = unicode(record.msg)
             record.msg += u'\n'
-            record.msg += self.formatter.formatException(record.exc_info)
+            record.msg += trace.replace('%', '%%')
             record.exc_info = None
         formatter_buffer = self._calculate_formatter_buffer(record)
         for line in record.getMessage().split('\n'):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1115715

Also added (1) test for unrelated missing coverage.

```
[jortel@localhost unit]$ nosetests --with-coverage --cover-package=pulp.server.logs server/test_logs.py
.......................
Name               Stmts   Miss  Cover   Missing
------------------------------------------------
pulp.server.logs      71      0   100%   
----------------------------------------------------------------------
Ran 23 tests in 0.032s

OK
```
