### PR TITLE
1115631 - The validity check should not be performed on disabled content sources

### DIFF
--- a/server/pulp/server/content/sources/model.py
+++ b/server/pulp/server/content/sources/model.py
@@ -159,9 +159,9 @@ class ContentSource(object):
             for section in cfg.sections():
                 descriptor = dict(cfg.items(section))
                 source = ContentSource(section, descriptor)
-                if not source.enabled:
-                    continue
                 if not source.is_valid():
+                    continue
+                if not source.enabled:
                     continue
                 sources[source.id] = source
         return sources
@@ -184,13 +184,15 @@ class ContentSource(object):
         :return: True if valid.
         :rtype: bool
         """
+        valid = False
         try:
-            self.get_cataloger()
-            self.get_downloader()
-            return is_valid(self.id, self.descriptor)
+            if is_valid(self.id, self.descriptor):
+                self.get_cataloger()
+                self.get_downloader()
+                valid = True
         except Exception:
             log.exception('source [%s] not valid', self.id)
-            return False
+        return valid
 
     @property
     def enabled(self):

--- a/server/test/unit/server/content/sources/test_model.py
+++ b/server/test/unit/server/content/sources/test_model.py
@@ -211,7 +211,7 @@ class TestContentSource(TestCase):
         fake_parser.assert_called_with()
         fake_parser().read.assert_called_with(os.path.join(conf_d, files[0]))
 
-        self.assertEqual(len(sources), 3)
+        self.assertEqual(len(sources), 2)
         self.assertTrue(DESCRIPTOR[1][0] in sources)
         self.assertTrue(DESCRIPTOR[3][0] in sources)
 
@@ -243,6 +243,7 @@ class TestContentSource(TestCase):
 
     @patch('pulp.server.content.sources.model.is_valid')
     def test_is_valid_no_plugin(self, mock_descriptor_is_valid):
+        mock_descriptor_is_valid.return_value = True
         source = ContentSource('s-1', {'A': 1})
         source.get_downloader = Mock()
         source.get_cataloger = Mock(side_effect=NotImplementedError())
@@ -255,11 +256,12 @@ class TestContentSource(TestCase):
 
         source.get_cataloger.assert_called_with()
         self.assertFalse(source.get_downloader.called)
-        self.assertFalse(mock_descriptor_is_valid.called)
+        self.assertTrue(mock_descriptor_is_valid.called)
         self.assertFalse(valid)
 
     @patch('pulp.server.content.sources.model.is_valid')
     def test_is_valid_no_downloader(self, mock_descriptor_is_valid):
+        mock_descriptor_is_valid.return_value = True
         source = ContentSource('s-1', {'A': 1})
         source.get_downloader = Mock(side_effect=NotImplementedError())
         source.get_cataloger = Mock()
@@ -272,7 +274,7 @@ class TestContentSource(TestCase):
 
         source.get_cataloger.assert_called_with()
         source.get_downloader.assert_called_with()
-        self.assertFalse(mock_descriptor_is_valid.called)
+        self.assertTrue(mock_descriptor_is_valid.called)
         self.assertFalse(valid)
 
     @patch('pulp.server.content.sources.model.is_valid')
@@ -288,8 +290,6 @@ class TestContentSource(TestCase):
 
         # validation
 
-        source.get_cataloger.assert_called_with()
-        source.get_downloader.assert_called_with()
         self.assertFalse(valid)
 
     def test_enabled(self):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1115631

The main thing we want to do here is make sure the is_valid does not attempt to validate the cataloger or the downloader if the source is disabled or the descriptor is not valid.

NEEDS TO BE MERGED TO MASTER TOO.
