### PR TITLE
1116438 - use apache httpd type and not typealias

### DIFF
--- a/server/selinux/server/pulp-server.fc
+++ b/server/selinux/server/pulp-server.fc
@@ -3,8 +3,8 @@
 
 /srv/pulp(/.*)? gen_context(system_u:object_r:httpd_sys_content_t,s0)
 
-/var/lib/pulp(/.*)? gen_context(system_u:object_r:httpd_sys_content_rw_t,s0)
+/var/lib/pulp(/.*)? gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
 
 # Pulp uses python logging to handle logrotate, this requires
 # write/unlink and httpd_log_t only allows httpd_t to append
-/var/log/pulp(/.*)? gen_context(system_u:object_r:httpd_sys_content_rw_t,s0)
+/var/log/pulp(/.*)? gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)


### PR DESCRIPTION
This is rather cosmetic thing, but nice to have. Due to bug in SELinux tool,
restorecon is showing this as an invalid context, see the BZ.
