### PR TITLE
BZ 1117060 - Applies workaround to get umask to apply correctly in Upstart

### DIFF
--- a/server/etc/default/upstart_pulp_resource_manager
+++ b/server/etc/default/upstart_pulp_resource_manager
@@ -25,7 +25,7 @@ CELERYD_NODES="resource_manager"
 
 # Set the concurrency of each worker node to 1, tell the worker to participate in event
 # broadcasting, and subscribe to the resource_manager queue. DO NOT CHANGE THIS SETTING!
-CELERYD_OPTS="-c 1 --events -Q resource_manager --umask 18"
+CELERYD_OPTS="-c 1 --events -Q resource_manager --umask=18"
 
 CELERYD_USER="apache"
 

--- a/server/etc/default/upstart_pulp_workers
+++ b/server/etc/default/upstart_pulp_workers
@@ -29,7 +29,7 @@ CELERY_CREATE_DIRS=1
 CELERYD_NODES=""
 
 # Set the concurrency of each worker node to 1. DO NOT CHANGE THE CONCURRENCY!
-CELERYD_OPTS="-c 1 --events --umask 18"
+CELERYD_OPTS="-c 1 --events --umask=18"
 
 CELERYD_USER="apache"
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1117060

Without this adjustment, you'll receive errors like these when you start the service. With this patch, the errors go away, and the services start. This is a workaround which introduces a different style of argument. I've opened [BZ 1118804](https://bugzilla.redhat.com/show_bug.cgi?id=1118804) to rework the init script at another time.

```
celery init v10.0.
Using config script: /etc/default/pulp_workers
celery multi v3.1.11 (Cipater)
> Starting nodes...
        > reserved_resource_worker-0@bmbouter-pulp-beta24-testing-2: Usage: /usr/lib/python2.6/site-packages/celery/bin/celery.pyc worker [options] 

/usr/lib/python2.6/site-packages/celery/bin/celery.pyc: error: option --umask: invalid integer value: '--pidfile=/var/run/pulp/reserved_resource_worker-0.pid'
* Child terminated with errorcode 2
FAILED
        > reserved_resource_worker-1@bmbouter-pulp-beta24-testing-2: Usage: /usr/lib/python2.6/site-packages/celery/bin/celery.pyc worker [options] 

/usr/lib/python2.6/site-packages/celery/bin/celery.pyc: error: option --umask: invalid integer value: '--pidfile=/var/run/pulp/reserved_resource_worker-1.pid'
* Child terminated with errorcode 2
FAILED
        > 18@bmbouter-pulp-beta24-testing-2: Usage: /usr/lib/python2.6/site-packages/celery/bin/celery.pyc worker [options] 

/usr/lib/python2.6/site-packages/celery/bin/celery.pyc: error: option --umask: invalid integer value: '--pidfile=/var/run/pulp/18.pid'
* Child terminated with errorcode 2
FAILED
```
