### PR TITLE
Updates NVR versions of Qpid dependencies for EL6.

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -1,14 +1,14 @@
 {
     "python-qpid": {
-        "version": "0.26-1",
+        "version": "0.26-2",
         "platform": ["el6"]
     },
     "qpid-cpp": {
-        "version": "0.26-4",
+        "version": "0.26-7",
         "platform": ["el6"]
     },
     "qpid-qmf": {
-        "version": "0.26-1",
+        "version": "0.26-2",
         "platform": ["el6"]
     }
 }


### PR DESCRIPTION
You can see these are the latest versions at the URLs below:

[python-qpid](http://koji.katello.org/koji/packageinfo?packageID=107)
[qpid-cpp](http://koji.katello.org/koji/packageinfo?packageID=690)
[qpid-qmf](http://koji.katello.org/koji/packageinfo?packageID=691)
