### PR TITLE
Updates qpid-cpp to release 8.

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -4,7 +4,7 @@
         "platform": ["el6"]
     },
     "qpid-cpp": {
-        "version": "0.26-7",
+        "version": "0.26-8",
         "platform": ["el6"]
     },
     "qpid-qmf": {


### PR DESCRIPTION
This change will cause pulp to use [NVR qpid-cpp-0.26-8.el6](http://koji.katello.org/koji/buildinfo?buildID=12285). I tested these RPMs (both install and uninstall) on EL6 and did not see any selinux errors.
