### PR TITLE
Add sync reporting to platform

### DIFF
--- a/common/pulp/common/plugins/progress.py
+++ b/common/pulp/common/plugins/progress.py
@@ -175,3 +175,126 @@ class ProgressReport(object):
         self.update_progress()
 
     state = property(_get_state, _set_state)
+
+
+class SyncProgressReport(ProgressReport):
+    """
+    Used to carry the state of the sync run as it proceeds. This object is used
+    to update the on going progress in Pulp at appropriate intervals through
+    the update_progress call. Once the sync is finished, this object should
+    be used to produce the final report to return to Pulp to describe the
+    sync.
+    """
+
+    # These states correspond to the progress of the manifest stage
+    STATE_MANIFEST_IN_PROGRESS = 'manifest_in_progress'
+    STATE_MANIFEST_FAILED = 'manifest_failed'
+    # These states correspond to the progress of the file's stage. Note that
+    # there is no STATE_MANIFEST_COMPLETE, as the next transition is
+    # STATE_FILES_IN_PROGRESS
+    STATE_FILES_IN_PROGRESS = 'files_in_progress'
+    STATE_FILES_FAILED = 'files_failed'
+
+    # A mapping of current states to allowed next states
+    ALLOWED_STATE_TRANSITIONS = {
+        ProgressReport.STATE_NOT_STARTED: (STATE_MANIFEST_IN_PROGRESS,
+                                           ProgressReport.STATE_FAILED,
+                                           ProgressReport.STATE_CANCELED),
+        STATE_MANIFEST_IN_PROGRESS: (STATE_MANIFEST_FAILED,
+                                     STATE_FILES_IN_PROGRESS,
+                                     ProgressReport.STATE_CANCELED),
+        STATE_FILES_IN_PROGRESS: (STATE_FILES_FAILED,
+                                  ProgressReport.STATE_COMPLETE,
+                                  ProgressReport.STATE_CANCELED)
+    }
+
+    def __init__(self, conduit=None, total_bytes=None, finished_bytes=0, num_files=None,
+                 num_files_finished=0, files_error_messages=None, **kwargs):
+        """
+        Initialize the SyncProgressReport, setting all of the given parameters
+        to it. See the superclass method of the same name for the use cases for the
+        parameters.
+
+        :param total_bytes:    The total number of bytes we need to download
+        :type  total_bytes:    int
+        :param finished_bytes: The number of bytes we have already downloaded
+        :type  finished_bytes: int
+        :param num_files:           The number of files that need to be
+                                    downloaded or published
+        :type  num_files:           int
+        :param num_files_finished:  The number of files that have finished downloading
+        :type  num_files_finished:  int
+        :param files_error_messages: A dictionary mapping file names to
+                                      errors encountered while downloading them
+        :type  files_error_messages: dict
+        :param conduit:  conduit
+        :type  conduit:  RepoSyncConduit
+        """
+        super(self.__class__, self).__init__(conduit, **kwargs)
+
+        # Let's also track how many bytes we've got on the files
+        self.total_bytes = total_bytes
+        self.finished_bytes = finished_bytes
+
+        # These variables track the state of the file download stage
+        self.num_files = num_files
+        self.num_files_finished = num_files_finished
+        # files_error_messages is a list of dictionaries with the keys 'name' and 'error'
+        if files_error_messages is None:
+            self.files_error_messages = []
+        else:
+            self.files_error_messages = files_error_messages
+
+    def add_failed_file(self, file, error_report):
+        """
+        Updates the progress report that a file failed to be imported.
+
+        :param file: The file object that failed to publish or download
+        :type  file: file
+        :param error_report: The error message that should be associated with the file
+        :type  error_report: str
+        """
+        file_error = {'name': file.name, 'error': error_report}
+        self.files_error_messages.append(file_error)
+
+    def build_progress_report(self):
+        """
+        Returns the actual report that should be sent to Pulp as the current
+        progress of the sync.
+
+        :return: description of the current state of the sync
+        :rtype:  dict
+        """
+        report = super(self.__class__, self).build_progress_report()
+
+        report['total_bytes'] = self.total_bytes
+        report['finished_bytes'] = self.finished_bytes
+        report['num_files'] = self.num_files
+        report['num_files_finished'] = self.num_files_finished
+        report['files_error_messages'] = self.files_error_messages
+
+        return report
+
+    def _set_state(self, new_state):
+        """
+        This method allows users to set a new state to the ProgressReport.
+        It enforces state transitions to only happen in a certain fashion.
+
+        :param new_state: The new state that the caller wishes the ProgressReport to be set to
+        :type  new_state: basestring
+        """
+        if new_state == self.STATE_COMPLETE and self.files_error_messages:
+            new_state = self.STATE_FILES_FAILED
+
+        if self._state == self.STATE_CANCELED:
+            # Since STATE_CANCELED can be entered asynchonously during a repo sync, it is easier to
+            # ignore other state transitions here than it is to find every place in our code where
+            # we might attempt a state transition and check to see if we are cancelled. In sync.py,
+            # all the download handlers (and the downloader itself) will do nothing if the state is
+            # cancelled, so this is here to ensure that once we are cancelled, nothing can set the
+            # state back to not cancelled.
+            return
+
+        super(self.__class__, self)._set_state(new_state)
+
+    state = property(ProgressReport._get_state, _set_state)


### PR DESCRIPTION
A lot of this code lived in the ISO plugin, but is generally useful for
reporting on syncs that involve a manifest/metadata download and then multiple
files. Adding it here keeps us from having to copy/paste between plugins.

Most of the tests for the report were moved from
test_extension_admin_iso_status.py in pulp_rpm.
