### PR TITLE
Add SyncStep to platform

### DIFF
--- a/server/pulp/plugins/util/sync_step.py
+++ b/server/pulp/plugins/util/sync_step.py
@@ -1,0 +1,99 @@
+import logging
+
+from pulp.plugins.util.publish_step import PublishStep, UnitPublishStep
+
+_LOG = logging.getLogger(__name__)
+
+
+class SyncStep(PublishStep):
+    """
+    This currently inherits from PublishStep because they share a lot of code.
+    Ideally they would inherit from a SyncPublishStep but I'm trying to keep
+    the changes small for now.
+    """
+
+    def __init__(self, step_type, repo=None, sync_conduit=None, config=None, importer_type=None):
+        """
+        Set the default parent, step_type and unit_type for the the sync step
+        the unit_type defaults to none since some steps are not used for processing units.
+
+        :param step_type: The id of the step this processes
+        :type step_type: str
+        :param repo: The repo to be synced to
+        :type repo: pulp.plugins.model.Repository
+        :param sync_conduit: The sync conduit for the repo to be synced
+        :type sync_conduit: tbd
+        :param config: The sync configuration
+        :type config: PluginCallConfiguration
+        :param importer_type: The type of the importer that is being synced
+        :type importer_type: str
+        """
+        super(SyncStep, self).__init__(step_type, repo, sync_conduit, config,
+                                       None, importer_type)
+        self.importer_type = importer_type
+        self.repo = repo
+        self.sync_conduit = sync_conduit
+        self.config = config
+
+    def sync(self):
+        """
+        Perform the sync action the repo & information specified in the constructor
+        """
+        self.process_lifecycle()
+        return self._build_final_report()
+
+    def get_conduit(self):
+        """
+        :returns: Return the conduit for this sync action
+        :rtype: tbd
+        """
+        if self.sync_conduit:
+            return self.sync_conduit
+        return self.parent.get_conduit()
+
+
+class UnitSyncStep(UnitPublishStep):
+
+    def __init__(self, step_type, unit_type=None, association_filters=None,
+                 unit_fields=None):
+        """
+        Set the default parent, step_type and unit_type for the sync step
+        the unit_type defaults to none since some steps are not used for processing units.
+
+        :param step_type: The id of the step this processes
+        :typstep_typeid: str
+        :param unit_type: The type of unit this step processes
+        :type unit_type: str or list of str
+        """
+        super(UnitSyncStep, self).__init__(step_type, unit_type, association_filters, unit_fields)
+        if isinstance(unit_type, list):
+            self.unit_type = unit_type
+        else:
+            self.unit_type = [unit_type]
+        self.skip_list = set()
+        self.unit_fields = unit_fields
+
+    def get_unit_generator(self):
+        """
+        This method returns a generator for the unit_type specified on the SyncStep.
+        The units created by this generator will be iterated over by the process_unit method.
+
+        You'll want this to return a generator that is based on whatever metadata you downloaded.
+
+        :return: generator of units
+        :rtype:  GeneratorType of Units
+        """
+        raise NotImplementedError()
+
+    def _get_total(self, id_list=None):
+        """
+        Return the total number of units that are processed by this step.
+        This is used generally for progress reporting.  The value returned should not change
+        during the processing of the step.
+
+        You'll want this to be the number of items to work with from your metadata.
+
+        :param id_list: List of type ids to get the total count of
+        :type id_list: list of str
+        """
+        raise NotImplementedError()

--- a/server/test/unit/plugins/util/test_sync_step.py
+++ b/server/test/unit/plugins/util/test_sync_step.py
@@ -1,0 +1,82 @@
+import unittest
+
+from mock import Mock
+
+from pulp.plugins.util.sync_step import SyncStep, UnitSyncStep
+
+
+class SyncStepTests(unittest.TestCase):
+
+    def setUp(self):
+        self.repo_id = 'publish-test-repo'
+        self.mock_repo = Mock()
+        self.mock_conduit = Mock()
+        self.mock_conduit.get_repo_scratchpad = Mock(return_value={})
+        self.mock_config = Mock()
+
+    def test_get_conduit(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, sync_conduit=self.mock_conduit,
+                          config=self.mock_config, importer_type='test_importer_type')
+        self.assertEquals(self.mock_conduit, syncer.get_conduit())
+
+    def test_get_conduit_parent(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, sync_conduit=None,
+                          config=self.mock_config, importer_type='test_importer_type')
+        parent_conduit = Mock()
+        syncer.parent = Mock()
+        syncer.parent.get_conduit.return_value = parent_conduit
+        self.assertEquals(parent_conduit, syncer.get_conduit())
+
+    def test_sync(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, sync_conduit=self.mock_conduit,
+                          config=self.mock_config, importer_type='test_importer_type')
+        syncer.process_lifecycle = Mock()
+        mock_report = Mock()
+        syncer._build_final_report = Mock()
+        syncer._build_final_report.return_value = mock_report
+        retval = syncer.sync()
+        syncer.process_lifecycle.assert_called_once()
+        self.assertEquals(retval, mock_report)
+
+    def test_init(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, sync_conduit=self.mock_conduit,
+                          config=self.mock_config, importer_type='test_importer_type')
+        self.assertEquals(syncer.repo, self.mock_repo)
+        self.assertEquals(syncer.sync_conduit, self.mock_conduit)
+        self.assertEquals(syncer.config, self.mock_config)
+        self.assertEquals(syncer.importer_type, 'test_importer_type')
+
+
+class UnitSyncStepTests(unittest.TestCase):
+
+    def test_init(self):
+        unitsync = UnitSyncStep("foo-type", unit_type="baz", unit_fields="bar")
+        self.assertEquals(unitsync.unit_type, ["baz"])
+        self.assertTrue(isinstance(unitsync.skip_list, set))
+        self.assertEquals(unitsync.unit_fields, "bar")
+
+    def test_init_unit_type_list(self):
+        unitsync = UnitSyncStep("foo-type", unit_type=["baz", "quux"], unit_fields="bar")
+        self.assertEquals(unitsync.unit_type, ["baz", "quux"])
+        self.assertTrue(isinstance(unitsync.skip_list, set))
+        self.assertEquals(unitsync.unit_fields, "bar")
+
+    def test_unit_generators(self):
+        unitsync = UnitSyncStep("foo-type")
+        try:
+            unitsync.get_unit_generator()
+            self.assertTrue(False, "exception not thrown")
+        except NotImplementedError:
+            pass
+        except:
+            self.assertTrue(False, "wrong exception thrown")
+
+    def test_get_total(self):
+        unitsync = UnitSyncStep("foo-type")
+        try:
+            unitsync._get_total()
+            self.assertTrue(False, "exception not thrown")
+        except NotImplementedError:
+            pass
+        except:
+            self.assertTrue(False, "wrong exception thrown")


### PR DESCRIPTION
This is used by pulp_openstack and other plugins to perform syncs with the step
processor.

This is a very low-change implementation; a cleaner implementation would factor
out a lot of shared code between SyncStep and PublishStep.
