### PR TITLE
Refactor Steps a bit to allow for syncing

### DIFF
--- a/server/pulp/plugins/util/sync_step.py
+++ b/server/pulp/plugins/util/sync_step.py
@@ -1,0 +1,84 @@
+import logging
+
+from pulp.plugins.util.publish_step import PluginStep, PluginStepIterativeProcessingMixin
+
+_LOG = logging.getLogger(__name__)
+
+
+class SyncStep(PluginStep):
+    """
+    A step to perform syncs
+    """
+
+    def __init__(self, step_type, repo=None, conduit=None, config=None, plugin_type=None):
+        """
+        Set up the sync step
+
+        :param step_type: The id of the step this processes
+        :type  step_type: str
+        :param repo: The repo to be synced to
+        :type  repo: pulp.plugins.model.Repository
+        :param conduit: The sync conduit for the repo to be synced
+        :type  conduit: pulp.plugins.conduits.repo_sync.RepoSyncConduit
+        :param config: The sync configuration
+        :type  config: PluginCallConfiguration
+        :param plugin_type: The type of the plugin that is being synced
+        :type  plugin_type: str
+        """
+        super(SyncStep, self).__init__(step_type, repo=repo, conduit=conduit, config=config,
+                                       plugin_type=plugin_type)
+        self.plugin_type = plugin_type
+        self.repo = repo
+        self.conduit = conduit
+        self.config = config
+
+    def sync(self):
+        """
+        Perform the sync action
+        """
+        self.process_lifecycle()
+        return self._build_final_report()
+
+
+class UnitSyncStep(SyncStep, PluginStepIterativeProcessingMixin):
+
+    def __init__(self, step_type, unit_type=None):
+        """
+        Set up unit sync step. This is the class to use when iterating over items to sync
+
+        :param step_type: The id of the step this processes
+        :typstep_typeid: str
+        :param unit_type: The type of unit this step processes
+        :type unit_type: str or list of str
+        """
+        super(UnitSyncStep, self).__init__(step_type, unit_type)
+        if isinstance(unit_type, list):
+            self.unit_type = unit_type
+        else:
+            self.unit_type = [unit_type]
+        self.skip_list = set()
+
+    def get_generator(self):
+        """
+        The items created by this generator will be iterated over by the process_item method.
+
+        For sync, you'll want this to return a generator that is based on
+        whatever metadata you downloaded.
+
+        :return: generator of units
+        :rtype:  GeneratorType of Units
+        """
+        raise NotImplementedError()
+
+    def _get_total(self, id_list=None):
+        """
+        Return the total number of units that are processed by this step.
+        This is used generally for progress reporting.  The value returned should not change
+        during the processing of the step.
+
+        You'll want this to be the number of items to work with from your metadata.
+
+        :param id_list: List of type ids to get the total count of
+        :type id_list: list of str
+        """
+        raise NotImplementedError()

--- a/server/test/unit/plugins/util/test_sync_step.py
+++ b/server/test/unit/plugins/util/test_sync_step.py
@@ -1,0 +1,65 @@
+import unittest
+
+from mock import Mock
+
+from pulp.plugins.util.sync_step import SyncStep, UnitSyncStep
+
+
+class SyncStepTests(unittest.TestCase):
+
+    def setUp(self):
+        self.repo_id = 'publish-test-repo'
+        self.mock_repo = Mock()
+        self.mock_conduit = Mock()
+        self.mock_conduit.get_repo_scratchpad = Mock(return_value={})
+        self.mock_config = Mock()
+
+    def test_get_conduit(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, conduit=self.mock_conduit,
+                          config=self.mock_config, plugin_type='test_importer_type')
+        self.assertEquals(self.mock_conduit, syncer.get_conduit())
+
+    def test_get_conduit_parent(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, conduit=None,
+                          config=self.mock_config, plugin_type='test_importer_type')
+        parent_conduit = Mock()
+        syncer.parent = Mock()
+        syncer.parent.get_conduit.return_value = parent_conduit
+        self.assertEquals(parent_conduit, syncer.get_conduit())
+
+    def test_sync(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, conduit=self.mock_conduit,
+                          config=self.mock_config, plugin_type='test_importer_type')
+        syncer.process_lifecycle = Mock()
+        mock_report = Mock()
+        syncer._build_final_report = Mock()
+        syncer._build_final_report.return_value = mock_report
+        retval = syncer.sync()
+        syncer.process_lifecycle.assert_called_once()
+        self.assertEquals(retval, mock_report)
+
+    def test_init(self):
+        syncer = SyncStep("base-step", repo=self.mock_repo, conduit=self.mock_conduit,
+                          config=self.mock_config, plugin_type='test_importer_type')
+        self.assertEquals(syncer.repo, self.mock_repo)
+        self.assertEquals(syncer.conduit, self.mock_conduit)
+        self.assertEquals(syncer.config, self.mock_config)
+        self.assertEquals(syncer.plugin_type, 'test_importer_type')
+
+
+class UnitSyncStepTests(unittest.TestCase):
+
+    def test_init(self):
+        unitsync = UnitSyncStep("foo-type", unit_type="baz")
+        self.assertEquals(unitsync.unit_type, ["baz"])
+        self.assertTrue(isinstance(unitsync.skip_list, set))
+
+    def test_generators(self):
+        unitsync = UnitSyncStep("foo-type")
+        try:
+            unitsync.get_generator()
+            self.assertTrue(False, "exception not thrown")
+        except NotImplementedError:
+            pass
+        except:
+            self.assertTrue(False, "wrong exception thrown")


### PR DESCRIPTION
Previously, most of the Steps were related to publishing. However, with small
modification they can also be used for performing syncs.

This commit factors the shared code for both sync and publish into a new
PluginStep, and creates a mixin for unit processing.
