### PR TITLE
1110893 - adding a trailing slash to an API path

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/event/crud.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/event/crud.rst
@@ -98,7 +98,7 @@ is found either in the create response or in the data returned by listing all
 event listeners.
 
 | :method:`delete`
-| :path:`/v2/events/<event_listener_id>`
+| :path:`/v2/events/<event_listener_id>/`
 | :permission:`delete`
 
 | :response_list:`_`


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1110893
