### PR TITLE
step refactor and download step

### DIFF
--- a/server/pulp/plugins/conduits/repo_sync.py
+++ b/server/pulp/plugins/conduits/repo_sync.py
@@ -78,6 +78,7 @@ class RepoSyncConduit(RepoScratchPadMixin, ImporterScratchPadMixin, AddUnitMixin
         SearchUnitsMixin.__init__(self, ImporterConduitException)
 
         self._association_manager = manager_factory.repo_unit_association_manager()
+        self._content_query_manager = manager_factory.content_query_manager()
 
         self._removed_count = 0
 
@@ -113,6 +114,21 @@ class RepoSyncConduit(RepoScratchPadMixin, ImporterScratchPadMixin, AddUnitMixin
         except Exception, e:
             logger.exception(_('Content unit unassociation failed'))
             raise ImporterConduitException(e), None, sys.exc_info()[2]
+
+    def associate_existing(self, unit_type_id, search_dicts):
+        """
+        Associates existing units with a repo
+
+        :param unit_type_id: unit type id
+        :type  unit_type_id: str
+        :param search_dicts: search dicts for units to associate with repo
+                             (example: list of unit key dicts)
+        :type  search_dicts: list of dicts
+        """
+        unit_ids = self._content_query_manager.get_content_unit_ids(unit_type_id, search_dicts)
+        self._association_manager.associate_all_by_ids(self.repo_id, unit_type_id, unit_ids,
+                                                       self.association_owner_type,
+                                                       self.association_owner_id)
 
     def build_success_report(self, summary, details):
         """

--- a/server/test/unit/plugins/util/test_publish_step.py
+++ b/server/test/unit/plugins/util/test_publish_step.py
@@ -8,17 +8,19 @@ import time
 import traceback
 import unittest
 
-import mock
-from mock import Mock, patch
+from mock import Mock, patch, MagicMock
 
-from pulp.common.plugins import reporting_constants
+from nectar.downloaders.local import LocalFileDownloader
+
+from pulp.common.plugins import reporting_constants, importer_constants
 from pulp.devel.unit.util import touch, compare_dict
 from pulp.plugins.config import PluginCallConfiguration
 from pulp.plugins.conduits.repo_publish import RepoPublishConduit
+from pulp.plugins.conduits.repo_sync import RepoSyncConduit
 from pulp.plugins.model import Repository
-from pulp.plugins.util.publish_step import Step, PublishStep, UnitPublishStep, \
 from pulp.plugins.util.publish_step import Step, PublishStep, UnitPublishStep, PluginStep, \
-    AtomicDirectoryPublishStep, SaveTarFilePublishStep, _post_order, CopyDirectoryStep
+    AtomicDirectoryPublishStep, SaveTarFilePublishStep, _post_order, CopyDirectoryStep, \
+    PluginStepIterativeProcessingMixin, DownloadStep
 
 
 class PublisherBase(unittest.TestCase):
@@ -30,9 +32,9 @@ class PublisherBase(unittest.TestCase):
 
         self.repo_id = 'publish-test-repo'
         self.repo = Repository(self.repo_id, working_dir=self.working_dir)
-        self.conduit = mock.Mock()
+        self.conduit = Mock()
         self.conduit = RepoPublishConduit(self.repo_id, 'test_distributor_id')
-        self.conduit.get_repo_scratchpad = mock.Mock(return_value={})
+        self.conduit.get_repo_scratchpad = Mock(return_value={})
 
         self.config = PluginCallConfiguration(None, None)
         self.publisher = PublishStep("base-step", self.repo, self.conduit, self.config,
@@ -46,7 +48,7 @@ class PluginBase(unittest.TestCase):
         self.repo_id = 'publish-test-repo'
         self.repo = Repository(self.repo_id, working_dir=self.working_dir)
         self.conduit = RepoPublishConduit(self.repo_id, 'test_plugin_id')
-        self.conduit.get_repo_scratchpad = mock.Mock(return_value={})
+        self.conduit.get_repo_scratchpad = Mock(return_value={})
 
         self.config = PluginCallConfiguration(None, None)
         self.pluginstep = PluginStep("base-step", self.repo, self.conduit, self.config,
@@ -120,7 +122,7 @@ class PluginStepTests(PluginBase):
     def test_get_repo_from_parent(self):
         step = PluginStep('foo_step')
         step.conduit = 'foo'
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.get_repo.return_value = 'foo'
         self.assertEquals('foo', step.get_repo())
 
@@ -136,7 +138,7 @@ class PluginStepTests(PluginBase):
     def test_get_plugin_type_from_parent(self):
         step = PluginStep('foo_step')
         step.conduit = 'foo'
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.get_plugin_type.return_value = 'foo'
         self.assertEquals('foo', step.get_plugin_type())
 
@@ -148,18 +150,18 @@ class PluginStepTests(PluginBase):
     def test_get_conduit_from_parent(self):
         step = PluginStep('foo_step')
         step.conduit = 'foo'
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.get_conduit.return_value = 'foo'
         self.assertEquals('foo', step.get_conduit())
 
-    @mock.patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
-    @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
+    @patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
+    @patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_process_step_failure_reported_on_metadata_finalized(self, mock_get_units, mock_update):
         self.pluginstep.repo.content_unit_counts = {'FOO_TYPE': 1}
         mock_get_units.return_value = ['mock_unit']
         step = PluginStep('foo_step')
         step.parent = self.pluginstep
-        step.finalize = mock.Mock(side_effect=Exception())
+        step.finalize = Mock(side_effect=Exception())
         self.assertRaises(Exception, step.process)
         self.assertEquals(step.state, reporting_constants.STATE_FAILED)
         self.assertEquals(step.progress_successes, 1)
@@ -169,14 +171,14 @@ class PluginStepTests(PluginBase):
     def test_cancel_before_processing(self):
         self.pluginstep.repo.content_unit_counts = {'FOO_TYPE': 2}
         step = PluginStep('foo_step')
-        step.is_skipped = mock.Mock()
+        step.is_skipped = Mock()
         step.cancel()
         step.process()
         self.assertEquals(0, step.is_skipped.call_count)
 
     def test_report_progress(self):
         plugin_step = PluginStep('foo_step')
-        plugin_step.parent = mock.Mock()
+        plugin_step.parent = Mock()
         plugin_step.report_progress()
         plugin_step.parent.report_progress.assert_called_once_with(False)
 
@@ -304,7 +306,7 @@ class PublishStepTests(PublisherBase):
     def test_get_repo_from_parent(self):
         step = PublishStep('foo_step')
         step.conduit = 'foo'
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.get_repo.return_value = 'foo'
         self.assertEquals('foo', step.get_repo())
 
@@ -320,7 +322,7 @@ class PublishStepTests(PublisherBase):
     def test_get_distributor_type_from_parent(self):
         step = PublishStep('foo_step')
         step.conduit = 'foo'
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.get_plugin_type.return_value = 'foo'
         self.assertEquals('foo', step.get_distributor_type())
 
@@ -332,18 +334,18 @@ class PublishStepTests(PublisherBase):
     def test_get_conduit_from_parent(self):
         step = PublishStep('foo_step')
         step.conduit = 'foo'
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.get_conduit.return_value = 'foo'
         self.assertEquals('foo', step.get_conduit())
 
-    @mock.patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
-    @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
+    @patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
+    @patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_process_step_failure_reported_on_metadata_finalized(self, mock_get_units, mock_update):
         self.publisher.repo.content_unit_counts = {'FOO_TYPE': 1}
         mock_get_units.return_value = ['mock_unit']
         step = PublishStep('foo_step')
         step.parent = self.publisher
-        step.finalize = mock.Mock(side_effect=Exception())
+        step.finalize = Mock(side_effect=Exception())
         self.assertRaises(Exception, step.process)
         self.assertEquals(step.state, reporting_constants.STATE_FAILED)
         self.assertEquals(step.progress_successes, 1)
@@ -353,14 +355,14 @@ class PublishStepTests(PublisherBase):
     def test_cancel_before_processing(self):
         self.publisher.repo.content_unit_counts = {'FOO_TYPE': 2}
         step = PublishStep('foo_step')
-        step.is_skipped = mock.Mock()
+        step.is_skipped = Mock()
         step.cancel()
         step.process()
         self.assertEquals(0, step.is_skipped.call_count)
 
     def test_report_progress(self):
         publish_step = PublishStep('foo_step')
-        publish_step.parent = mock.Mock()
+        publish_step.parent = Mock()
         publish_step.report_progress()
         publish_step.parent.report_progress.assert_called_once_with(False)
 
@@ -651,7 +653,7 @@ class UnitPublishStepTests(PublisherBase):
             self.publisher.cancel()
 
 
-    @mock.patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
+    @patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
     def test_process_step_skip_units(self, mock_update):
         self.publisher.config = PluginCallConfiguration(None, {'skip': ['FOO']})
         step = UnitPublishStep('foo_step', 'FOO')
@@ -659,11 +661,11 @@ class UnitPublishStepTests(PublisherBase):
         step.process()
         self.assertEquals(step.state, reporting_constants.STATE_SKIPPED)
 
-    @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
-    @mock.patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
+    @patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
+    @patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
     def test_process_step_no_units(self, mock_update, mock_get_units):
         self.publisher.repo.content_unit_counts = {'FOO_TYPE': 0}
-        mock_method = mock.Mock()
+        mock_method = Mock()
         mock_get_units.return_value = []
         step = UnitPublishStep('foo_step', 'FOO_TYPE')
         step.parent = self.publisher
@@ -672,11 +674,11 @@ class UnitPublishStepTests(PublisherBase):
         self.assertEquals(step.state, reporting_constants.STATE_COMPLETE)
         self.assertFalse(mock_method.called)
 
-    @mock.patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
-    @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
+    @patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
+    @patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_process_step_single_unit(self, mock_get_units, mock_update):
         self.publisher.repo.content_unit_counts = {'FOO_TYPE': 1}
-        mock_method = mock.Mock()
+        mock_method = Mock()
         mock_get_units.return_value = ['mock_unit']
         step = UnitPublishStep('foo_step', 'FOO_TYPE')
         step.parent = self.publisher
@@ -689,11 +691,11 @@ class UnitPublishStepTests(PublisherBase):
         self.assertEquals(step.total_units, 1)
         mock_method.assert_called_once_with('mock_unit')
 
-    @mock.patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
-    @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
+    @patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
+    @patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_process_step_single_unit_exception(self, mock_get_units, mock_update):
         self.publisher.repo.content_unit_counts = {'FOO_TYPE': 1}
-        mock_method = mock.Mock(side_effect=Exception())
+        mock_method = Mock(side_effect=Exception())
         mock_get_units.return_value = ['mock_unit']
         step = UnitPublishStep('foo_step', 'FOO_TYPE')
         step.parent = self.publisher
@@ -706,8 +708,8 @@ class UnitPublishStepTests(PublisherBase):
         self.assertEquals(step.total_units, 1)
         mock_method.assert_called_once_with('mock_unit')
 
-    @mock.patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
-    @mock.patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
+    @patch('pulp.server.async.task_status_manager.TaskStatusManager.update_task_status')
+    @patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
     def test_process_step_cancelled_mid_unit_processing(self, mock_get_units, mock_update):
         self.publisher.repo.content_unit_counts = {'FOO_TYPE': 2}
         mock_get_units.return_value = ['cancel', 'bar_unit']
@@ -744,14 +746,14 @@ class UnitPublishStepTests(PublisherBase):
 
     def test_get_total(self):
         step = UnitPublishStep("foo", ['bar', 'baz'])
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.repo.content_unit_counts.get.return_value = 1
         total = step._get_total()
         self.assertEquals(2, total)
 
     def test_get_total_for_list(self):
         step = UnitPublishStep("foo", ['bar', 'baz'])
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.repo.content_unit_counts.get.return_value = 1
         total = step._get_total()
         self.assertEquals(2, total)
@@ -773,14 +775,14 @@ class UnitPublishStepTests(PublisherBase):
     def test_get_total_ignore_filter(self):
         step = UnitPublishStep("foo", ['bar', 'baz'])
         step.association_filters = {'foo': 'bar'}
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.repo.content_unit_counts.get.return_value = 1
         total = step._get_total(ignore_filter=True)
         self.assertEquals(2, total)
 
     def test_get_total_for_none(self):
         step = UnitPublishStep("foo", ['bar', 'baz'])
-        step.parent = mock.Mock()
+        step.parent = Mock()
         step.parent.repo.content_unit_counts.get.return_value = 0
         total = step._get_total()
         self.assertEquals(0, total)
@@ -928,3 +930,264 @@ class TestCopyDirectoryStep(unittest.TestCase):
         step.process_main()
 
         self.assertTrue(os.path.exists(target_file))
+
+class TestPluginStepIterativeProcessingMixin(unittest.TestCase):
+
+    class DummyStep(PluginStepIterativeProcessingMixin):
+        """
+        A dummy class that provides some stuff that the mixin uses
+        """
+        def __init__(self):
+            self.canceled = False
+            self.progress_successes = 0
+            self.process_item = Mock()
+            self.report_progress = Mock()
+
+        def get_generator(self):
+            return (n for n in [1,2])
+
+    class DummyCanceledStep(PluginStepIterativeProcessingMixin):
+        """
+        A dummy class that provides some stuff that the mixin uses
+        """
+        def __init__(self):
+            self.canceled = True
+            self.progress_successes = 0
+            self.process_item = Mock()
+            self.report_progress = Mock()
+
+        def get_generator(self):
+            return (n for n in [1,2])
+
+    def test_get_generator(self):
+        mixin = PluginStepIterativeProcessingMixin()
+        try:
+            mixin.get_generator()
+            self.assertTrue(False, "no exception thrown")
+        except NotImplementedError:
+            pass
+        except:
+            self.assertTrue(False, "wrong exception thrown")
+
+    def test_process_block(self):
+        dummystep = self.DummyStep()
+        dummystep._process_block()
+        dummystep.process_item.assert_called()
+        dummystep.report_progress.assert_called()
+        self.assertEquals(dummystep.progress_successes, 2)
+
+    def test_process_block_canceled_item(self):
+        dummystep = self.DummyCanceledStep()
+        dummystep._process_block()
+        dummystep.process_item.assert_called()
+        dummystep.report_progress.assert_called()
+        # step is canceled!
+        self.assertEquals(dummystep.progress_successes, 0)
+
+
+class DownloadStepTests(unittest.TestCase):
+
+    TYPE_ID_FOO = 'foo' 
+
+    def get_basic_config(*arg, **kwargs):
+        plugin_config = {"num_retries":0, "retry_delay":0}
+        repo_plugin_config = {}
+        for key in kwargs:
+            repo_plugin_config[key] = kwargs[key]
+        config = PluginCallConfiguration(plugin_config,
+                repo_plugin_config=repo_plugin_config)
+        return config
+
+    def get_sync_conduit(type_id=None, existing_units=None, pkg_dir=None):
+        def build_failure_report(summary, details):
+            return SyncReport(False, sync_conduit._added_count, sync_conduit._updated_count,
+                              sync_conduit._removed_count, summary, details)
+
+        def build_success_report(summary, details):
+            return SyncReport(True, sync_conduit._added_count, sync_conduit._updated_count,
+                              sync_conduit._removed_count, summary, details)
+
+        def side_effect(type_id, key, metadata, rel_path):
+            if rel_path and pkg_dir:
+                rel_path = os.path.join(pkg_dir, rel_path)
+                if not os.path.exists(os.path.dirname(rel_path)):
+                    os.makedirs(os.path.dirname(rel_path))
+            unit = Unit(type_id, key, metadata, rel_path)
+            return unit
+
+        def get_units(criteria=None):
+            ret_val = []
+            if existing_units:
+                for u in existing_units:
+                    if criteria:
+                        if u.type_id in criteria.type_ids:
+                            ret_val.append(u)
+                    else:
+                        ret_val.append(u)
+            return ret_val
+
+        def search_all_units(type_id, criteria):
+            ret_val = []
+            if existing_units:
+                for u in existing_units:
+                    if u.type_id == type_id:
+                        if u.unit_key['id'] == criteria['filters']['id']:
+                            ret_val.append(u)
+            return ret_val
+
+        sync_conduit = Mock(spec=RepoSyncConduit)
+        sync_conduit._added_count = sync_conduit._updated_count = sync_conduit._removed_count = 0
+        sync_conduit.init_unit.side_effect = side_effect
+        sync_conduit.get_units.side_effect = get_units
+        sync_conduit.save_unit = Mock()
+        sync_conduit.search_all_units.side_effect = search_all_units
+        sync_conduit.build_failure_report = MagicMock(side_effect=build_failure_report)
+        sync_conduit.build_success_report = MagicMock(side_effect=build_success_report)
+        sync_conduit.set_progress = MagicMock()
+
+        return sync_conduit
+
+    def setUp(self):
+
+        conf_dict = {
+            importer_constants.KEY_FEED: 'http://fake.com/file_feed/',
+            importer_constants.KEY_MAX_SPEED: 500.0,
+            importer_constants.KEY_MAX_DOWNLOADS: 5,
+            importer_constants.KEY_SSL_VALIDATION: False,
+            importer_constants.KEY_SSL_CLIENT_CERT: "Trust me, I'm who I say I am.",
+            importer_constants.KEY_SSL_CLIENT_KEY: "Secret Key",
+            importer_constants.KEY_SSL_CA_CERT: "Uh, I guess that's the right server.",
+            importer_constants.KEY_PROXY_HOST: 'proxy.com',
+            importer_constants.KEY_PROXY_PORT: 1234,
+            importer_constants.KEY_PROXY_USER: "the_dude",
+            importer_constants.KEY_PROXY_PASS: 'bowling',
+            importer_constants.KEY_VALIDATE: False,
+        }
+        self.real_config = self.get_basic_config(**conf_dict)
+        self.real_conduit = self.get_sync_conduit()
+
+
+        self.mock_repo = Mock()
+        self.mock_conduit = Mock()
+        self.mock_config = Mock()
+        self.mock_working_dir = Mock()
+        self.dlstep = DownloadStep("fake_download", repo=self.mock_repo, conduit=self.mock_conduit,
+                                   config=self.mock_config, working_dir=self.mock_working_dir,
+                                   plugin_type="fake plugin")
+
+    def test_init(self):
+        self.assertEquals(self.dlstep.get_repo(), self.mock_repo)
+        self.assertEquals(self.dlstep.get_conduit(), self.mock_conduit)
+        self.assertEquals(self.dlstep.get_config(), self.mock_config)
+        self.assertEquals(self.dlstep.get_working_dir(), self.mock_working_dir)
+        self.assertEquals(self.dlstep.get_plugin_type(), "fake plugin")
+
+    def test_initalize(self):
+        # override mock config with real config dict
+        self.dlstep.config = self.real_config
+        self.dlstep.conduit = self.get_sync_conduit()
+
+        self.dlstep.initialize()
+
+        # Now let's assert that all the right things happened during initialization
+        self.assertEqual(self.dlstep._repo_url, 'http://fake.com/file_feed/')
+        # Validation of downloads should be disabled by default
+        self.assertEqual(self.dlstep._validate_downloads, False)
+
+        # Inspect the downloader
+        downloader = self.dlstep.downloader
+        # The dlstep should be the event listener for the downloader
+        self.assertEqual(downloader.event_listener, self.dlstep)
+        # Inspect the downloader config
+        expected_downloader_config = {
+            'max_speed': 500.0,
+            'max_concurrent': 5,
+            'ssl_client_cert': "Trust me, I'm who I say I am.",
+            'ssl_client_key': 'Secret Key',
+            'ssl_ca_cert': "Uh, I guess that's the right server.",
+            'ssl_validation': False,
+            'proxy_url': 'proxy.com',
+            'proxy_port': 1234,
+            'proxy_username': 'the_dude',
+            'proxy_password': 'bowling'}
+        for key, value in expected_downloader_config.items():
+            self.assertEquals(getattr(downloader.config, key), value)
+
+    def test__init___with_feed_lacking_trailing_slash(self):
+        """
+        tests https://bugzilla.redhat.com/show_bug.cgi?id=949004
+        """
+        slash_config = self.get_basic_config(
+                       **{importer_constants.KEY_FEED: 'http://fake.com/no_trailing_slash'})
+
+        # override mock config with real config dict
+        self.dlstep.config = slash_config
+        self.dlstep.initialize()
+        # Humorously enough, the _repo_url attribute named no_trailing_slash
+        # should now have a trailing slash
+        self.assertEqual(self.dlstep._repo_url, 'http://fake.com/no_trailing_slash/')
+
+    def test__init___file_downloader(self):
+        slash_config = self.get_basic_config(
+                       **{importer_constants.KEY_FEED: 'file:///some/path/'})
+        # override mock config with real config dict
+        self.dlstep.config = slash_config
+        self.dlstep.initialize()
+        self.assertTrue(isinstance(self.dlstep.downloader, LocalFileDownloader))
+
+    def test__init___ssl_validation(self):
+        """
+        Make sure the SSL validation is on by default.
+        """
+        # It should default to True
+        self.dlstep.config = self.get_basic_config(
+                              **{importer_constants.KEY_FEED: 'http://fake.com/iso_feed/'})
+        self.dlstep.initialize()
+        self.assertEqual(self.dlstep.downloader.config.ssl_validation, True)
+
+        # It should be possible to explicitly set it to False
+        self.dlstep.config = self.get_basic_config(
+                               **{importer_constants.KEY_FEED: 'http://fake.com/iso_feed/',
+                               importer_constants.KEY_SSL_VALIDATION: False})
+        self.dlstep.initialize()
+        self.assertEqual(self.dlstep.downloader.config.ssl_validation, False)
+
+        # It should be possible to explicitly set it to True
+        self.dlstep.config = self.get_basic_config(
+                               **{importer_constants.KEY_FEED: 'http://fake.com/iso_feed/',
+                               importer_constants.KEY_SSL_VALIDATION: True})
+        self.dlstep.initialize()
+        self.assertEqual(self.dlstep.downloader.config.ssl_validation, True)
+
+    def test__get_total(self):
+        mock_downloads = ['fake', 'downloads']
+        dlstep = DownloadStep('fake-step', downloads=mock_downloads)
+        self.assertEquals(dlstep._get_total(), 2)
+
+    def test__process_block(self):
+        mock_downloader = Mock()
+        mock_downloads = ['fake', 'downloads']
+        dlstep = DownloadStep('fake-step', downloads=mock_downloads)
+        dlstep.downloader = mock_downloader
+        dlstep._process_block()
+        mock_downloader.download.assert_called_once_with(['fake', 'downloads'])
+
+    def test_download_succeeded(self):
+        dlstep = DownloadStep('fake-step')
+        mock_report = Mock()
+        mock_report_progress = Mock()
+        dlstep.report_progress = mock_report_progress
+        dlstep.download_succeeded(mock_report)
+        self.assertEquals(dlstep.progress_successes, 1)
+        # assert report_progress was called with no args
+        mock_report_progress.assert_called_once_with()
+
+    def test_download_failed(self):
+        dlstep = DownloadStep('fake-step')
+        mock_report = Mock()
+        mock_report_progress = Mock()
+        dlstep.report_progress = mock_report_progress
+        dlstep.download_failed(mock_report)
+        self.assertEquals(dlstep.progress_failures, 1)
+        # assert report_progress was called with no args
+        mock_report_progress.assert_called_once_with()

--- a/server/test/unit/test_repo_sync_conduit.py
+++ b/server/test/unit/test_repo_sync_conduit.py
@@ -153,3 +153,14 @@ class RepoSyncConduitTests(base.PulpServerTests):
 
         # Test
         self.assertRaises(ImporterConduitException, self.conduit.remove_unit, None)
+
+    def test_associate_existing(self):
+        mock_am = mock.Mock()
+        self.conduit._association_manager = mock_am
+        self.conduit._content_query_manager = mock.Mock()
+        mock_unit_key = {'some_key': 123}
+        mock_id = mock.Mock()
+        self.conduit._content_query_manager.get_content_unit_ids.return_value = [mock_id]
+        self.conduit.associate_existing('fake-type', [mock_unit_key])
+        mock_am.associate_all_by_ids.assert_called_once_with('repo-1', 'fake-type', [mock_id],
+                                                             'importer', 'importer-id')


### PR DESCRIPTION
Adds step-based syncing to platform

The DownloadStep works by creating a list of DownloadRequests in a previous step and then passing the previous step into DownloadStep. The previous step needs to subclass from DownloadStepMixin in order to ensure get_downloads() is there. I am not sure if it's possible to get DownloadMixin's **init**() to be called via super() without an explicit call. http://tinyurl.com/mgjzr3y indicates it is possible but I wasn't able to get it working without an explicit call.

Additionally, some of the unit processing steps after downloading still happen in the plugin. I'd like to get these into platform, any ideas are welcome!
