### PR TITLE
Moving a generator pagination feature over from pulp_rpm

### DIFF
--- a/server/pulp/plugins/util/misc.py
+++ b/server/pulp/plugins/util/misc.py
@@ -1,0 +1,29 @@
+import itertools
+
+
+DEFAULT_PAGE_SIZE = 1000
+
+
+def paginate(iterable, page_size=DEFAULT_PAGE_SIZE):
+    """
+    Takes any kind of iterable and chops it up into tuples of size "page_size".
+    A generator is returned, so this can be an efficient way to chunk items from
+    some other generator.
+
+    :param iterable:    any iterable such as a list, tuple, or generator
+    :type  iterable:    iterable
+    :param page_size:   how many items should be in each returned tuple
+    :type  page_size:   int
+
+    :return:    generator of tuples, each including "page_size" number of items
+                from "iterable", except the last tuple, which may contain
+                fewer.
+    :rtype:     generator
+    """
+    # this won't work properly if we give islice something that isn't a generator
+    generator = (x for x in iterable)
+    while True:
+        page = tuple(itertools.islice(generator, 0, page_size))
+        if not page:
+            return
+        yield page

--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -495,7 +495,7 @@ class UnitPublishStep(PublishStep):
         the unit_type defaults to none since some steps are not used for processing units.
 
         :param step_type: The id of the step this processes
-        :typstep_typeid: str
+        :type step_type: str
         :param unit_type: The type of unit this step processes
         :type unit_type: str or list of str
         """

--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -145,8 +145,8 @@ class RepoUnitAssociationManager(object):
         @param unit_type_id: identifies the type of unit being added
         @type  unit_type_id: str
 
-        @param unit_id_list: list of unique identifiers for units within the given type
-        @type  unit_id_list: list of str
+        @param unit_id_list: list or generator of unique identifiers for units within the given type
+        @type  unit_id_list: list or generator of str
 
         @param owner_type: category of the caller making the association;
                            must be one of the OWNER_* variables in this module
@@ -155,6 +155,9 @@ class RepoUnitAssociationManager(object):
         @param owner_id: identifies the caller making the association, either
                          the importer ID or user login
         @type  owner_id: str
+
+        :return:    number of new units added to the repo
+        :rtype:     int
 
         @raise InvalidType: if the given owner type is not of the valid enumeration
         """
@@ -173,6 +176,7 @@ class RepoUnitAssociationManager(object):
         if unique_count:
             manager_factory.repo_manager().update_unit_count(
                 repo_id, unit_type_id, unique_count)
+        return unique_count
 
     @staticmethod
     def associate_from_repo(source_repo_id, dest_repo_id, criteria=None,

--- a/server/test/unit/plugins/util/test_misc.py
+++ b/server/test/unit/plugins/util/test_misc.py
@@ -1,0 +1,75 @@
+import inspect
+import unittest
+
+from pulp.plugins.util import misc
+
+
+class TestPaginate(unittest.TestCase):
+    def test_list(self):
+        iterable = list(range(10))
+        ret = misc.paginate(iterable, 3)
+
+        self.assertTrue(inspect.isgenerator(ret))
+
+        pieces = list(ret)
+
+        self.assertEqual(pieces, [(0,1,2), (3,4,5), (6,7,8), (9,)])
+
+    def test_list_one_page(self):
+        iterable = list(range(10))
+        ret = misc.paginate(iterable, 100)
+
+        self.assertTrue(inspect.isgenerator(ret))
+
+        pieces = list(ret)
+
+        self.assertEqual(pieces, [tuple(range(10))])
+
+    def test_empty_list(self):
+        ret = misc.paginate([], 3)
+
+        self.assertTrue(inspect.isgenerator(ret))
+
+        pieces = list(ret)
+
+        self.assertEqual(pieces, [])
+
+    def test_tuple(self):
+        iterable = tuple(range(10))
+        ret = misc.paginate(iterable, 3)
+
+        self.assertTrue(inspect.isgenerator(ret))
+
+        pieces = list(ret)
+
+        self.assertEqual(pieces, [(0,1,2), (3,4,5), (6,7,8), (9,)])
+
+    def test_tuple_one_page(self):
+        iterable = tuple(range(10))
+        ret = misc.paginate(iterable, 100)
+
+        self.assertTrue(inspect.isgenerator(ret))
+
+        pieces = list(ret)
+
+        self.assertEqual(pieces, [tuple(range(10))])
+
+    def test_generator(self):
+        iterable = (x for x in range(10))
+        ret = misc.paginate(iterable, 3)
+
+        self.assertTrue(inspect.isgenerator(ret))
+
+        pieces = list(ret)
+
+        self.assertEqual(pieces, [(0,1,2), (3,4,5), (6,7,8), (9,)])
+
+    def test_generator_one_page(self):
+        iterable = (x for x in range(10))
+        ret = misc.paginate(iterable, 100)
+
+        self.assertTrue(inspect.isgenerator(ret))
+
+        pieces = list(ret)
+
+        self.assertEqual(pieces, [tuple(range(10))])

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -138,11 +138,13 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
 
         # Test
         ids = ['foo', 'bar', 'baz']
-        self.manager.associate_all_by_ids(self.repo_id, 'type-1', ids, OWNER_TYPE_USER, 'admin')
+        ret = self.manager.associate_all_by_ids(self.repo_id, 'type-1', ids, OWNER_TYPE_USER, 'admin')
 
         # Verify
         repo_units = list(RepoContentUnit.get_collection().find({'repo_id' : self.repo_id}))
         self.assertEqual(len(ids), len(repo_units))
+        # return value should be the number of units that were associated
+        self.assertEqual(ret, len(repo_units))
         for unit in repo_units:
             self.assertTrue(unit['unit_id'] in ids)
 


### PR DESCRIPTION
Improving an unused manager method to turn an iterable of unit keys into a generator of unit IDs
