### PR TITLE
Added three new groupinstall definitions to include Qpid bits

### DIFF
--- a/comps.xml
+++ b/comps.xml
@@ -102,16 +102,4 @@
       <packagereq type="mandatory">pulp-agent</packagereq>
     </packagelist>
   </group>
-  <group>
-    <id>pulp-qpid-cpp-server</id>
-    <name>Qpid Server for Pulp</name>
-    <description>
-      Qpid message broker daemon including durability packages.
-    </description>
-    <uservisible>true</uservisible>
-    <packagelist>
-      <packagereq type="mandatory">qpid-cpp-server</packagereq>
-      <packagereq type="mandatory">qpid-cpp-server-store</packagereq>
-    </packagelist>
-  </group>
 </comps>


### PR DESCRIPTION
The new descriptions are very similar to the existing ones. I read up on inheritance of group install definitions, but it seems that is not allowed. This introduces qpid specific groupinstall definitions: one for pulp-server, one for pulp-consumer, and one for qpid-cpp-server that includes the durability packages.
