### PR TITLE
Updates docs to use new Qpid groupinstall definitions

### DIFF
--- a/docs/sphinx/user-guide/installation.rst
+++ b/docs/sphinx/user-guide/installation.rst
@@ -140,7 +140,9 @@ Server
    For Pulp to operate with the Qpid broker, either broker authentication needs to be disabled, or
    authentication needs to be configured. To disable authentication add ``auth=no`` to the
    ``qpidd.conf`` file. Qpid 0.24 and higher places the config file is at ``/etc/qpid/qpidd.conf``,
-   and earlier Qpid versions place the config file at ``/etc/qpidd.conf``.
+   and earlier Qpid versions place the config file at ``/etc/qpidd.conf``. Changes made to
+   ``qpidd.conf`` go into effect the next time Qpid starts; if Qpid is already running prior to
+   making a change to ``qpidd.conf`` then restart the Qpid.
 
    To leave broker authentication enabled, you will need to configure SASL with a
    username/password, and then configure Pulp to use that username/password. Refer to the Qpid docs

--- a/docs/sphinx/user-guide/release-notes/2.4.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.4.x.rst
@@ -208,6 +208,19 @@ After all Pulp servers and nodes have been upgraded, all consumers need to be re
 each registered consumer, run ``pulp-consumer update --keys`` to exchange RSA keys needed for
 message authentication.
 
+The Pulp 2.4.0 release includes an updated Admin Client which introduces new settings to the
+``/etc/pulp/admin/admin.conf`` file. Install the updated Admin Client RPMs using the following
+command on any machine that already had the Admin Client installed:
+
+::
+
+    $ sudo yum upgrade
+
+The RPM install places the new admin.conf at ``/etc/pulp/admin/admin.conf.rpmnew`` so it won't
+overwrite the old one at install time. The contents of ``/etc/pulp/admin/admin.conf.rpmnew`` need
+to be manually merged into ``/etc/pulp/admin/admin.conf`` before the Admin Client can be used to
+connect to a 2.4.0 Pulp server or node.
+
 
 Rest API Changes
 ----------------


### PR DESCRIPTION
This PR updates the docs to use the new groupinstall definitions pulp-server-qpid and pulp-consumer-qpid. Here is a recap of the changes:

Installation doc changes:
1) Clarifies the durability package qpid-cpp-server-store, and recommends the user install it side-by-side with qpid-cpp-server
2) Clarifies the Qpid authentication changes required by the user
3) Recommends pulp-server-qpid and pulp-consumer-qpid groupinstalls along with their agnostic counterparts as a note.
4) Points the user to other docs for more information on sections of server.conf
5) Makes the use of semicolons more consistent

Release Notes (Upgrade) changes:
1) The most substantive change is the upgrade no longer upgrades all packages on a machine when you just want to upgrade Pulp. The yum upgrade is replaced with yum groupupdate pulp-server-qpid.
2) Makes the use of semicolons more consistent
