### PR TITLE
Adds qpid-tools as a build dep for all environments

### DIFF
--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.15
-Release:        11.pulp%{?dist}
+Release:        12.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages
@@ -27,7 +27,6 @@ BuildRequires:  python2-devel
 %if 0%{?rhel} == 6
 BuildRequires:  python-ordereddict
 BuildRequires:  python-importlib
-BuildRequires:  qpid-tools
 %endif
 %if 0%{?with_python3}
 BuildRequires:  python3-devel
@@ -54,6 +53,7 @@ BuildRequires: python-mock
 BuildRequires: python-msgpack
 BuildRequires: python-qpid
 BuildRequires: python-qpid-qmf
+BuildRequires: qpid-tools
 BuildRequires: python-simplejson
 BuildRequires: python-unittest2
 BuildRequires: PyYAML


### PR DESCRIPTION
Moves the qpid-tools from being just an EL6 dependency to being a build dependency for all environments. This shouldn't cause any problems, but it will allow builders with Qpid 0.22 or earlier to build this package also.
