### PR TITLE
1111228 - Removed jdob from the event listener sample return

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/event/crud.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/event/crud.rst
@@ -162,7 +162,7 @@ overwritten.
     ],
     "id": "4ff73d598a905b777d000014",
     "notifier_config": {
-      "url": "https://localhost/pulp/api/jdob/"
+      "url": "https://localhost/pulp/api"
     },
     "notifier_type_id": "http"
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1111228

The second typo referenced in the BZ is fixed in https://github.com/pulp/pulp/pull/1090
