### PR TITLE
Raise the python-rhsm release for builder.py.

### DIFF
--- a/deps/python-rhsm/python-rhsm.spec
+++ b/deps/python-rhsm/python-rhsm.spec
@@ -6,7 +6,7 @@
 
 Name: python-rhsm
 Version: 1.8.0
-Release: 1.pulp%{?dist}
+Release: 2.pulp%{?dist}
 
 Summary: A Python library to communicate with a Red Hat Unified Entitlement Platform
 Group: Development/Libraries


### PR DESCRIPTION
We have some tag conflicts in our repository, so we need to raise the
release on python-rhsm to get the tags sorted out so we can build
python-rhsm for EL 7.
