### PR TITLE
Support defaults when loading nodes.conf.

### DIFF
--- a/nodes/common/bin/pulp-gen-nodes-certificate
+++ b/nodes/common/bin/pulp-gen-nodes-certificate
@@ -23,8 +23,8 @@ END
 
 READ_NODE_CONF=\
 $(cat << END
-from pulp_node import resources
-node_conf = resources.node_configuration()
+from pulp_node.config import read_config
+node_conf = read_config()
 print node_conf.main.node_certificate
 END
 )

--- a/nodes/common/etc/pulp/nodes.conf
+++ b/nodes/common/etc/pulp/nodes.conf
@@ -22,16 +22,16 @@
 #                             trusted authority on the web server that serves Pulp.
 
 [main]
-ca_path: /etc/pki/tls/certs/ca-bundle.crt
-node_certificate: /etc/pki/pulp/nodes/node.crt
-verify_ssl: True
+# ca_path: /etc/pki/tls/certs/ca-bundle.crt
+# node_certificate: /etc/pki/pulp/nodes/node.crt
+# verify_ssl: True
 
 
 # The oauth configuration used to authenticate to this node
 # user_id - The pulp user ID
 
 [oauth]
-user_id: admin
+# user_id: admin
 
 
 # The oauth configuration used to authenticate to the parent node
@@ -40,6 +40,6 @@ user_id: admin
 # user_id - The pulp user ID
 
 [parent_oauth]
-key:
-secret:
-user_id: admin
+# key:
+# secret:
+# user_id: admin

--- a/nodes/common/pulp_node/config.py
+++ b/nodes/common/pulp_node/config.py
@@ -1,0 +1,58 @@
+from pulp.common.config import ANY, BOOL, Config, REQUIRED
+
+
+NODE_CONFIGURATION_PATH = '/etc/pulp/nodes.conf'
+
+DEFAULT = {
+    'main': {
+        'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+        'node_certificate': '/etc/pki/pulp/nodes/node.crt',
+        'verify_ssl': 'true',
+    },
+    'oauth': {
+        'user_id': 'admin',
+    },
+    'parent_oauth': {
+        'key': '',
+        'secret': '',
+        'user_id': 'admin',
+    },
+}
+
+SCHEMA = (
+    ('main', REQUIRED,
+        (
+            ('ca_path', REQUIRED, ANY),
+            ('node_certificate', REQUIRED, ANY),
+            ('verify_ssl', REQUIRED, BOOL),
+        )
+    ),
+    ('oauth', REQUIRED,
+        (
+            ('user_id', REQUIRED, ANY),
+        )
+    ),
+    ('parent_oauth', REQUIRED,
+        (
+            ('key', REQUIRED, ANY),
+            ('secret', REQUIRED, ANY),
+            ('user_id', REQUIRED, ANY),
+        )
+    ),
+)
+
+
+def read_config(path=NODE_CONFIGURATION_PATH, validate=True):
+    """
+    Get the node configuration object.
+    The node configuration is overridden using values from the pulp
+    consumer.conf and defaulted using server.conf as appropriate.
+    :param path: The optional path to the configuration.
+    :return: The configuration object.
+    :rtype: pulp.common.config.Graph
+    """
+    config = Config(DEFAULT)
+    config.update(Config(path))
+    if validate:
+        config.validate(SCHEMA)
+    return config.graph()

--- a/nodes/common/pulp_node/resources.py
+++ b/nodes/common/pulp_node/resources.py
@@ -1,47 +1,9 @@
-from pulp.common.config import ANY, BOOL, Config, REQUIRED, parse_bool
+from pulp.common.config import parse_bool
 from pulp.server.config import config as pulp_conf
 from pulp.bindings.server import PulpConnection
 from pulp.bindings.bindings import Bindings
 
-
-NODE_CONFIGURATION_PATH = '/etc/pulp/nodes.conf'
-CONSUMER_CONFIGURATION_PATH = '/etc/pulp/consumer/consumer.conf'
-
-NODE_SCHEMA = (
-    ('main', REQUIRED,
-        (
-            ('ca_path', REQUIRED, ANY),
-            ('node_certificate', REQUIRED, ANY),
-            ('verify_ssl', REQUIRED, BOOL),
-        )
-    ),
-    ('oauth', REQUIRED,
-        (
-            ('user_id', REQUIRED, ANY),
-        )
-    ),
-    ('parent_oauth', REQUIRED,
-        (
-            ('key', REQUIRED, ANY),
-            ('secret', REQUIRED, ANY),
-            ('user_id', REQUIRED, ANY),
-        )
-    ),
-)
-
-
-def node_configuration(path=NODE_CONFIGURATION_PATH):
-    """
-    Get the node configuration object.
-    The node configuration is overridden using values from the pulp
-    consumer.conf and defaulted using server.conf as appropriate.
-    :param path: The optional path to the configuration.
-    :return: The configuration object.
-    :rtype: pulp.common.config.Graph
-    """
-    cfg = Config(path)
-    cfg.validate(NODE_SCHEMA)
-    return cfg.graph()
+from pulp_node.config import read_config
 
 
 def parent_bindings(host, port=443):
@@ -54,7 +16,7 @@ def parent_bindings(host, port=443):
     :return: A pulp bindings object.
     :rtype: Bindings
     """
-    node_conf = node_configuration()
+    node_conf = read_config()
     oauth = node_conf.parent_oauth
     verify_ssl = parse_bool(node_conf.main.verify_ssl)
     ca_path = node_conf.main.ca_path
@@ -78,9 +40,9 @@ def pulp_bindings():
     :return: A pulp bindings object.
     :rtype: Bindings
     """
-    node_conf = node_configuration()
+    node_conf = read_config()
     oauth = node_conf.oauth
-    verify_ssl = False if node_conf.main.verify_ssl.lower() == 'false' else True
+    verify_ssl = parse_bool(node_conf.main.verify_ssl)
     ca_path = node_conf.main.ca_path
     host = pulp_conf.get('server', 'server_name')
     key = pulp_conf.get('oauth', 'oauth_key')

--- a/nodes/parent/pulp_node/profilers/nodes.py
+++ b/nodes/parent/pulp_node/profilers/nodes.py
@@ -15,7 +15,7 @@ from pulp.plugins.profiler import Profiler
 from pulp.server.config import config as pulp_conf
 
 from pulp_node import constants
-from pulp_node import resources
+from pulp_node.config import read_config
 
 
 # --- plugin loading ---------------------------------------------------------
@@ -55,7 +55,7 @@ class NodeProfiler(Profiler):
         """
         port = 443
         host = pulp_conf.get('server', 'server_name')
-        node_conf = resources.node_configuration()
+        node_conf = read_config()
         path = node_conf.main.node_certificate
         with open(path) as fp:
             node_certificate = fp.read()

--- a/nodes/test/unit/test_config.py
+++ b/nodes/test/unit/test_config.py
@@ -1,0 +1,82 @@
+
+from unittest import TestCase
+
+from mock import patch
+
+from pulp_node.config import read_config, SCHEMA, DEFAULT, NODE_CONFIGURATION_PATH
+
+
+class TestConfig(TestCase):
+
+    @staticmethod
+    def schema_has_section(section):
+        for _section in [s[0] for s in SCHEMA]:
+            if _section == section:
+                return True
+        return False
+
+    @staticmethod
+    def schema_has_property(section, key):
+        for _section in SCHEMA:
+            if _section[0] != section:
+                continue
+            for _key in [p[0] for p in _section[2]]:
+                if _key == key:
+                    return True
+        return False
+
+    def test_default(self):
+        # Everything in the schema has a default.
+        for section in SCHEMA:
+            for key in [p[0] for p in section[2]]:
+                msg = '[%s] not found in schema' % key
+                self.assertTrue(key in DEFAULT[section[0]], msg=msg)
+        # Everything in the default is defined in the schema.
+        for section in DEFAULT:
+            self.assertTrue(self.schema_has_section(section))
+            for key in DEFAULT[section]:
+                msg = '[%s].%s has not default' % (section, key)
+                self.assertTrue(self.schema_has_property(section, key), msg=msg)
+
+    @patch('pulp_node.config.Config')
+    def test_read(self, fake_config):
+        # test
+        cfg = read_config()
+
+        # validation
+        calls = fake_config.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0][0], DEFAULT)
+        self.assertEqual(calls[1][0][0], NODE_CONFIGURATION_PATH)
+        fake_config().validate.assert_called_with(SCHEMA)
+        self.assertEqual(cfg, fake_config().graph())
+
+    @patch('pulp_node.config.Config')
+    def test_read_path(self, fake_config):
+        path = '/tmp/abc'
+
+        # test
+        cfg = read_config(path=path)
+
+        # validation
+        calls = fake_config.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0][0], DEFAULT)
+        self.assertEqual(calls[1][0][0], path)
+        fake_config().validate.assert_called_with(SCHEMA)
+        self.assertEqual(cfg, fake_config().graph())
+
+    @patch('pulp_node.config.Config')
+    def test_read_no_validation(self, fake_config):
+        path = '/tmp/abc'
+
+        # test
+        cfg = read_config(path=path, validate=False)
+
+        # validation
+        calls = fake_config.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0][0], DEFAULT)
+        self.assertEqual(calls[1][0][0], path)
+        self.assertFalse(fake_config().validate.called)
+        self.assertEqual(cfg, fake_config().graph())

--- a/nodes/test/unit/test_plugins.py
+++ b/nodes/test/unit/test_plugins.py
@@ -327,10 +327,10 @@ class TestProfiler(PluginTestBase):
         plugin = _class()
         self.assertTrue(isinstance(plugin, NodeProfiler))
 
-    @patch('pulp_node.resources.node_configuration')
-    def test_update_units(self, mock_get_node_conf):
+    @patch('pulp_node.profilers.nodes.read_config')
+    def test_update_units(self, mock_read_config):
         # Setup
-        mock_get_node_conf.return_value = self.node_configuration()
+        mock_read_config.return_value = self.node_configuration()
         # Test
         host = 'abc'
         port = 443

--- a/nodes/test/unit/test_resources.py
+++ b/nodes/test/unit/test_resources.py
@@ -13,8 +13,8 @@ class TestParentBindings(unittest.TestCase):
     """
     This class contains tests for the parent_bindings() function.
     """
-    @mock.patch('pulp_node.resources.node_configuration')
-    def test_verify_ssl_false(self, node_configuration):
+    @mock.patch('pulp_node.resources.read_config')
+    def test_verify_ssl_false(self, read_config):
         """
         Make sure that verify_ssl is passed correctly when it is false.
         """
@@ -22,15 +22,15 @@ class TestParentBindings(unittest.TestCase):
         node_config = {'parent_oauth': {'key': 'some_key', 'secret': 'ssssh!', 'user_id': 'bgates'},
                        'main': {'verify_ssl': 'fAlsE', 'ca_path': ca_path}}
         node_config = config.Config(node_config).graph()
-        node_configuration.return_value = node_config
+        read_config.return_value = node_config
 
         bindings = resources.parent_bindings('host')
 
         self.assertEqual(bindings.bindings.server.ca_path, ca_path)
         self.assertEqual(bindings.bindings.server.verify_ssl, False)
 
-    @mock.patch('pulp_node.resources.node_configuration')
-    def test_verify_ssl_true(self, node_configuration):
+    @mock.patch('pulp_node.resources.read_config')
+    def test_verify_ssl_true(self, read_config):
         """
         Make sure that verify_ssl is passed correctly when it is true.
         """
@@ -38,7 +38,7 @@ class TestParentBindings(unittest.TestCase):
         node_config = {'parent_oauth': {'key': 'some_key', 'secret': 'ssssh!', 'user_id': 'bgates'},
                        'main': {'verify_ssl': 'tRue', 'ca_path': ca_path}}
         node_config = config.Config(node_config).graph()
-        node_configuration.return_value = node_config
+        read_config.return_value = node_config
 
         bindings = resources.parent_bindings('host')
 
@@ -50,8 +50,8 @@ class TestPulpBindings(unittest.TestCase):
     """
     This class contains tests for the pulp_bindings() function.
     """
-    @mock.patch('pulp_node.resources.node_configuration')
-    def test_verify_ssl_false(self, node_configuration):
+    @mock.patch('pulp_node.resources.read_config')
+    def test_verify_ssl_false(self, read_config):
         """
         Make sure that verify_ssl is passed correctly when it is false.
         """
@@ -59,15 +59,15 @@ class TestPulpBindings(unittest.TestCase):
         node_config = {'parent_oauth': {'key': 'some_key', 'secret': 'ssssh!', 'user_id': 'bgates'},
                        'main': {'verify_ssl': 'fAlsE', 'ca_path': ca_path}}
         node_config = config.Config(node_config).graph()
-        node_configuration.return_value = node_config
+        read_config.return_value = node_config
 
         bindings = resources.pulp_bindings()
 
         self.assertEqual(bindings.bindings.server.ca_path, ca_path)
         self.assertEqual(bindings.bindings.server.verify_ssl, False)
 
-    @mock.patch('pulp_node.resources.node_configuration')
-    def test_verify_ssl_true(self, node_configuration):
+    @mock.patch('pulp_node.resources.read_config')
+    def test_verify_ssl_true(self, read_config):
         """
         Make sure that verify_ssl is passed correctly when it is true.
         """
@@ -75,7 +75,7 @@ class TestPulpBindings(unittest.TestCase):
         node_config = {'parent_oauth': {'key': 'some_key', 'secret': 'ssssh!', 'user_id': 'bgates'},
                        'main': {'verify_ssl': 'True', 'ca_path': ca_path}}
         node_config = config.Config(node_config).graph()
-        node_configuration.return_value = node_config
+        read_config.return_value = node_config
 
         bindings = resources.pulp_bindings()
 


### PR DESCRIPTION
Basically bring reading the nodes.conf in line with how the consumer.conf and admin.conf are read and validated.  It was pretty close to start with.  Mainly needed to add support for defaults.
