### PR TITLE
1130153 - Fixed regression with consumer binding retrieval.

### DIFF
--- a/server/pulp/server/managers/consumer/bind.py
+++ b/server/pulp/server/managers/consumer/bind.py
@@ -149,7 +149,7 @@ class BindManager(object):
         :return: The Bind object
         :rtype:  SON
 
-        :raise MissingResource: if the consumer, repository, distributor, or binding do not exist
+        :raise MissingResource: if the binding does not exist
         """
         # Validate that the binding exists at all before continuing.
         # This will raise an exception if it it does not.
@@ -197,18 +197,19 @@ class BindManager(object):
         :return: A specific bind.
         :rtype:  SON
 
-        :raise MissingResource: if the consumer, repository, or distributor don't exist,
-        or if the binding doesn't exist
+        :raise MissingResource: if the binding doesn't exist
         """
-        missing_values = BindManager._validate_consumer_repo(consumer_id, repo_id, distributor_id)
-        if missing_values:
-            raise MissingResource(**missing_values)
-
         collection = Bind.get_collection()
         bind_id = BindManager.bind_id(consumer_id, repo_id, distributor_id)
         bind = collection.find_one(bind_id)
         if bind is None:
-            raise MissingResource(bind_id=bind_id)
+            # If the binding doesn't exist, report which values are not present
+            missing_values = BindManager._validate_consumer_repo(consumer_id, repo_id, distributor_id)
+            if missing_values:
+                raise MissingResource(**missing_values)
+            else:
+                # In this case, every resource is present, but the consumer isn't bound to that repo/distributor
+                raise MissingResource(bind_id=bind_id)
         return bind
 
     def find_all(self):

--- a/server/test/unit/test_bind_manager.py
+++ b/server/test/unit/test_bind_manager.py
@@ -148,6 +148,23 @@ class BindManagerTests(base.PulpServerTests):
         # Test
         self.assertRaises(MissingResource, manager.get_bind, 'A', 'B', 'C')
 
+    def test_get_bind_repo_gone(self):
+        """
+        Test that retrieving a consumer binding when the repo is gone is possible
+        """
+        # Setup
+        self.populate()
+        manager = factory.consumer_bind_manager()
+        manager.bind(self.CONSUMER_ID, self.REPO_ID, self.DISTRIBUTOR_ID,
+                     self.NOTIFY_AGENT, self.BINDING_CONFIG)
+        Repo.get_collection().remove({})
+
+        # Test
+        bind = manager.get_bind(self.CONSUMER_ID, self.REPO_ID, self.DISTRIBUTOR_ID)
+        self.assertEquals(bind['consumer_id'], self.CONSUMER_ID)
+        self.assertEquals(bind['repo_id'], self.REPO_ID)
+        self.assertEquals(bind['distributor_id'], self.DISTRIBUTOR_ID)
+
     def test_find_all(self):
         # Setup
         self.populate()


### PR DESCRIPTION
The regression made it impossible to retrieve a consumer's bindings
after a distributor it was bound to was deleted. This, in turn, made
it impossible for the distributor to remove the bindings after it was
removed. 

This PR fixes the following bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=1130153
https://bugzilla.redhat.com/show_bug.cgi?id=1130151
