### PR TITLE
1129858 - Adds task state cleanup for celery workers who restart unexpectedly

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -6,6 +6,7 @@ import signal
 from celery import task, Task as CeleryTask, current_task
 from celery.app import control, defaults
 from celery.result import AsyncResult
+from celery.signals import worker_init
 
 from pulp.common import constants, dateutils
 from pulp.common.error_codes import PLP0023
@@ -41,8 +42,7 @@ def _delete_worker(name, normal_shutdown=False):
     """
     worker_list = list(resources.filter_workers(Criteria(filters={'_id': name})))
     if len(worker_list) == 0:
-        # Potentially _delete_worker() may be called with the database not containing any entries.
-        # https://bugzilla.redhat.com/show_bug.cgi?id=1091922
+        # If no workers are found then there is nothing to do.
         return
     worker = worker_list[0]
 
@@ -460,3 +460,25 @@ def register_sigterm_handler(f, handler):
             signal.signal(signal.SIGTERM, old_signal)
 
     return wrap_f
+
+
+@worker_init.connect
+def cleanup_old_worker(*args, **kwargs):
+    """
+    Cleans up old state if this worker was previously running, but died unexpectedly.
+
+    In those cases, any Pulp tasks that were running or waiting on this worker will show incorrect
+    state. Any reserved_resource reservations associated with the previous worker will also be
+    removed along with the worker entry in the database itself. This is called early in the worker
+    start process, and later when its fully online pulp_celerybeat will discover the worker as
+    usual to allow new work to arrive at this worker.
+
+    If there is no previous work to cleanup this method still runs, but has not effect on the
+    database.
+
+    :param args: For positional arguments; and not used otherwise
+    :param kwargs: For keyword arguments, and expected to have one named 'sender'
+    :return: None
+    """
+    name = kwargs['sender'].hostname
+    _delete_worker(name, normal_shutdown=True)

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -740,3 +740,12 @@ class TestGetCurrentTaskId(unittest.TestCase):
 
     def test_get_task_id_not_in_task(self):
         self.assertEquals(None, tasks.get_current_task_id())
+
+
+class TestCleanupOldWorker (unittest.TestCase):
+
+    @mock.patch('pulp.server.async.tasks._delete_worker')
+    def test_assert_calls__delete_worker_synchronously(self, mock__delete_worker):
+        sender = mock.Mock()
+        tasks.cleanup_old_worker(sender=sender)
+        mock__delete_worker.assert_called_once_with(sender.hostname, normal_shutdown=True)


### PR DESCRIPTION
This code will also run when the resource manager runs, but since the first check is to find the worker and the resource_manager is never in the workers table it will have no effect. This signal is not called with the celerybeat component starts.

normal_shutdown only impacts logging. I could also imagine that we want this kind of cleanup to be logged, but since it's cleaning up after the fact I have it cleanup silently.
