### PR TITLE
1130119 - do not add full task info to spawned_tasks

### DIFF
--- a/docs/sphinx/user-guide/release-notes/2.4.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.4.x.rst
@@ -2,6 +2,17 @@
 Pulp 2.4 Release Notes
 ======================
 
+Pulp 2.4.2
+==========
+
+Rest API Changes
+----------------
+
+* Certain API calls under ``/consumers/`` related to repo binding would
+  `erroneously return full task information <https://bugzilla.redhat.com/show_bug.cgi?id=1130119>`_.
+  This has been corrected; these calls now only return the task's ID.
+
+
 Pulp 2.4.1
 ==========
 

--- a/server/pulp/server/tasks/consumer.py
+++ b/server/pulp/server/tasks/consumer.py
@@ -50,7 +50,8 @@ def bind(consumer_id, repo_id, distributor_id, notify_agent, binding_config, age
     if notify_agent:
         agent_manager = managers.consumer_agent_manager()
         task = agent_manager.bind(consumer_id, repo_id, distributor_id, agent_options)
-        response.spawned_tasks.append(task)
+        # we only want the task's ID, not the full task
+        response.spawned_tasks.append({'task_id': task.get('task_id')})
 
     return response
 
@@ -88,7 +89,8 @@ def unbind(consumer_id, repo_id, distributor_id, options):
         # The agent notification handler will delete the binding from the server
         agent_manager = managers.consumer_agent_manager()
         task = agent_manager.unbind(consumer_id, repo_id, distributor_id, options)
-        response.spawned_tasks.append(task)
+        # we only want the task's ID, not the full task
+        response.spawned_tasks.append({'task_id': task.get('task_id')})
     else:
         # Since there was no agent notification, perform the delete immediately
         bind_manager.delete(consumer_id, repo_id, distributor_id, True)
@@ -128,7 +130,8 @@ def force_unbind(consumer_id, repo_id, distributor_id, options):
     if binding['notify_agent']:
         agent_manager = managers.consumer_agent_manager()
         task = agent_manager.unbind(consumer_id, repo_id, distributor_id, options)
-        response.spawned_tasks.append(task)
+        # we only want the task's ID, not the full task
+        response.spawned_tasks.append({'task_id': task.get('task_id')})
 
     return response
 

--- a/server/test/unit/server/tasks/test_consumer.py
+++ b/server/test/unit/server/tasks/test_consumer.py
@@ -45,7 +45,7 @@ class TestBind(unittest.TestCase):
         binding_config = {'binding': 'foo'}
         agent_options = {'bar': 'baz'}
         mock_bind_manager.consumer_agent_manager.return_value.bind.return_value = \
-            {'task_id': 'foo-request-id'}
+            {'task_id': 'foo-request-id', 'other_task_detail': 'abc123'}
         result = consumer.bind('foo_consumer_id', 'foo_repo_id', 'foo_distributor_id',
                                True, binding_config, agent_options)
         mock_bind_manager.consumer_agent_manager.return_value.bind.assert_called_once_with(
@@ -84,7 +84,7 @@ class TestUnbind(unittest.TestCase):
         agent_options = {'bar': 'baz'}
         mock_bind_manager.consumer_bind_manager.return_value.get_bind.return_value = binding_config
         mock_bind_manager.consumer_agent_manager.return_value.unbind.return_value = \
-            {'task_id': 'foo-request-id'}
+            {'task_id': 'foo-request-id', 'other_task_detail': 'abc123'}
         result = consumer.unbind('foo_consumer_id', 'foo_repo_id', 'foo_distributor_id',
                                  agent_options)
         mock_bind_manager.consumer_bind_manager.return_value.unbind.assert_called_once_with(
@@ -120,7 +120,7 @@ class TestForceUnbind(unittest.TestCase):
         agent_options = {'bar': 'baz'}
         mock_bind_manager.consumer_bind_manager.return_value.get_bind.return_value = binding_config
         mock_bind_manager.consumer_agent_manager.return_value.unbind.return_value = \
-            {'task_id': 'foo-request-id'}
+            {'task_id': 'foo-request-id', 'other_task_detail': 'abc123'}
         result = consumer.force_unbind('foo_consumer_id', 'foo_repo_id', 'foo_distributor_id',
                                        agent_options)
         mock_bind_manager.consumer_agent_manager.return_value.unbind.assert_called_once_with(


### PR DESCRIPTION
Previously, the entire task object was being added to spawned task results in
certain cases when a consumer agent notification was occuring.  Instead, it
should just be the task_id.
