### PR TITLE
1131509 - remove quotes from ca_path

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -24,7 +24,7 @@
 # port: 443
 # api_prefix: /pulp/api
 # verify_ssl: True
-# ca_path: '/etc/pki/tls/certs/ca-bundle.crt'
+# ca_path: /etc/pki/tls/certs/ca-bundle.crt
 # upload_chunk_size: 1048576
 
 


### PR DESCRIPTION
The 'ca_path' config directive had quotes in the documented example. This is
incorrect. The CA path should not have quotes.
