### PR TITLE
1133953 - check Mongo version during startup

### DIFF
--- a/server/test/unit/test_database.py
+++ b/server/test/unit/test_database.py
@@ -12,23 +12,57 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-import logging
-
 import base
+import unittest
+
+from mock import patch
 
 from pulp.server.db import connection
 
-logging.root.setLevel(logging.ERROR)
-qpid = logging.getLogger('qpid.messaging')
-qpid.setLevel(logging.ERROR)
-
-log = logging.getLogger('pulp.test.testdatabase')
 
 class TestDatabase(base.PulpServerTests):
 
     def setUp(self):
         base.PulpServerTests.setUp(self)
-        logging.root.setLevel(logging.ERROR)
 
     def test_database_name(self):
         self.assertEquals(connection._DATABASE.name, self.config.get("database", "name"))
+
+
+class TestDatabaseVersion(unittest.TestCase):
+    """
+    test DB version parsing. Info on expected versions is at
+    https://github.com/mongodb/mongo/blob/master/src/mongo/util/version.cpp#L39-45
+    """
+    @patch("pymongo.MongoClient")
+    @patch("pulp.server.db.connection._end_request_decorator")
+    def _test_initialize(self, version_str, mock_end, mock_mongoclient):
+        mock_mongoclient_instance = mock_mongoclient.return_value
+        mock_mongoclient_instance.server_info.return_value = {"version": version_str}
+        connection.initialize()
+
+    def test_database_version_bad_version(self):
+        try:
+            self._test_initialize('1.2.3')
+            self.fail("RuntimeError not raised")
+        except RuntimeError:
+            pass  # expected exception
+
+    def test_database_version_good_version(self):
+        # the version check succeeded if no exception was raised
+        self._test_initialize('2.6.0')
+
+    def test_database_version_good_equal_version(self):
+        # the version check succeeded if no exception was raised
+        self._test_initialize('2.4.0')
+
+    def test_database_version_good_rc_version(self):
+        # the version check succeeded if no exception was raised
+        self._test_initialize('2.8.0-rc1')
+
+    def test_database_version_bad_rc_version(self):
+        try:
+            self._test_initialize('2.3.0-rc1')
+            self.fail("RuntimeError not raised")
+        except RuntimeError:
+            pass  # expected exception


### PR DESCRIPTION
Previous versions of Pulp would not check the version of the Mongo database
during startup. If the version of Mongo was older than what Pulp expected,
issues would arise during runtime that could be difficult to debug.

Instead, check the Mongo version at startup and fail immediately if it's not
compatible with Pulp.

https://github.com/mongodb/mongo/blob/master/src/mongo/util/version.cpp
contains information about how Mongo versioning works.
