### PR TITLE
1131260 - Shell out to for certificate validation.

### DIFF
--- a/server/pulp/server/common/openssl.py
+++ b/server/pulp/server/common/openssl.py
@@ -26,7 +26,7 @@ class Certificate(object):
         that it is signed by at least one of the CAs in the ca_chain. It will return True if it is
         valid, and False otherwise.
 
-        :param ca_chain: A list of CA certificates.
+        :param ca_chain: A list of CA certificates. Each should be a Certificate object.
         :type  ca_chain: iterable
         :return:         True if verified.
         :rtype:          bool
@@ -50,6 +50,7 @@ class Certificate(object):
 
             # Write the CAs to a tempfile
             ca = tempfile.NamedTemporaryFile(mode='w', dir=self._tempdir, delete=False)
+            ca_chain = [c._cert for c in ca_chain]
             ca.write('\n'.join(ca_chain))
             ca.close()
 

--- a/server/test/unit/server/common/test_openssl.py
+++ b/server/test/unit/server/common/test_openssl.py
@@ -106,7 +106,7 @@ class TestCertificate(unittest.TestCase):
         check_call.side_effect = fake_check_call
 
         cert_data = "I'm trying to trick you with an expired certificate!"
-        ca_chain = ['A CA', 'Another CA']
+        ca_chain = [openssl.Certificate(c) for c in ['A CA', 'Another CA']]
         cert = openssl.Certificate(cert_data)
 
         valid = cert.verify(ca_chain)
@@ -171,7 +171,7 @@ class TestCertificate(unittest.TestCase):
         mkdtemp.return_value = a_tempdir
 
         cert_data = "I am a real cert!"
-        ca_chain = ['A CA']
+        ca_chain = [openssl.Certificate('A CA')]
         cert = openssl.Certificate(cert_data)
 
         valid = cert.verify(ca_chain)


### PR DESCRIPTION
Due to difficulty in finding an easily supportable method for
certificate validation in Python, this commit replaces our use of
libcrypto with a subprocess call to openssl. The libcrypto attempt was
clean but had thread safety issues. Pulp does not work without threading
at the moment.

https://bugzilla.redhat.com/show_bug.cgi?id=1131260
