### PR TITLE
1124589 - allow both PLAIN and ANONYMOUS sasl mechanisms for connections

### DIFF
--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.15
-Release:        12.pulp%{?dist}
+Release:        13.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages

--- a/deps/python-kombu/qpid_transport.patch
+++ b/deps/python-kombu/qpid_transport.patch
@@ -194,10 +194,10 @@ index 85b8f5e..acd1713 100644
      :keyword userid: Default user name if not provided in the URL.
 diff --git a/kombu/tests/transport/test_qpid.py b/kombu/tests/transport/test_qpid.py
 new file mode 100644
-index 0000000..e929daa
+index 0000000..6cea6b9
 --- /dev/null
 +++ b/kombu/tests/transport/test_qpid.py
-@@ -0,0 +1,1767 @@
+@@ -0,0 +1,1756 @@
 +from __future__ import absolute_import
 +
 +import datetime
@@ -210,21 +210,15 @@ index 0000000..e929daa
 +
 +from itertools import count
 +
-+QPID_NOT_AVAILABLE = False
-+try:
-+    import qpid.messaging.exceptions
-+    import qpidtoollibs     # noqa
-+except ImportError:
-+    QPID_NOT_AVAILABLE = True
-+
 +import kombu.five
 +from kombu.transport.qpid import AuthenticationFailure, QoS, Message
 +from kombu.transport.qpid import QpidMessagingExceptionHandler, Channel
 +from kombu.transport.qpid import Connection, ReceiversMonitor, Transport
++from kombu.transport.qpid import ConnectionError
 +from kombu.transport.virtual import Base64
 +from kombu.utils.compat import OrderedDict
-+from kombu.tests.case import Case, Mock, SkipTest
-+from kombu.tests.case import patch, skip_if_not_module
++from kombu.tests.case import Case, Mock
++from kombu.tests.case import patch
 +from mock import call
 +
 +
@@ -256,6 +250,14 @@ index 0000000..e929daa
 +            self.assertTrue(a[key] == b[key])
 +
 +
++class MockException(Exception):
++    pass
++
++
++class BreakOutException(Exception):
++    pass
++
++
 +class TestQpidMessagingExceptionHandler(Case):
 +
 +    allowed_string = 'object in use'
@@ -263,8 +265,6 @@ index 0000000..e929daa
 +
 +    def setUp(self):
 +        """Create a mock ExceptionHandler for testing by this object."""
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.handler = QpidMessagingExceptionHandler(self.allowed_string)
 +
 +    def test_string_stored(self):
@@ -302,8 +302,6 @@ index 0000000..e929daa
 +class TestQoS__init__(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos = QoS(self.mock_session)
 +
@@ -343,8 +341,6 @@ index 0000000..e929daa
 +class TestQoSCanConsumeMaxEstimate(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos = QoS(self.mock_session)
 +
@@ -361,8 +357,6 @@ index 0000000..e929daa
 +class TestQoSAck(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos = QoS(self.mock_session)
 +
@@ -383,11 +377,17 @@ index 0000000..e929daa
 +class TestQoSReject(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.mock_message = Mock()
 +        self.qos = QoS(self.mock_session)
++        self.patch_qpid = patch(QPID_MODULE + '.qpid')
++        self.mock_qpid = self.patch_qpid.start()
++        self.mock_Disposition = self.mock_qpid.messaging.Disposition
++        self.mock_RELEASED = self.mock_qpid.messaging.RELEASED
++        self.mock_REJECTED = self.mock_qpid.messaging.REJECTED
++
++    def tearDown(self):
++        self.patch_qpid.stop()
 +
 +    def test_reject_pops__not_yet_acked(self):
 +        self.qos.append(self.mock_message, 1)
@@ -395,25 +395,21 @@ index 0000000..e929daa
 +        self.qos.reject(1)
 +        self.assertTrue(1 not in self.qos._not_yet_acked)
 +
-+    @patch('qpid.messaging.Disposition')
-+    @patch('qpid.messaging.RELEASED')
-+    def test_reject_requeue_true(self, mock_RELEASED, mock_QpidDisposition):
++    def test_reject_requeue_true(self):
 +        self.qos.append(self.mock_message, 1)
 +        self.qos.reject(1, requeue=True)
-+        mock_QpidDisposition.assert_called_with(mock_RELEASED)
++        self.mock_Disposition.assert_called_with(self.mock_RELEASED)
 +        self.qos.session.acknowledge.assert_called_with(
 +            message=self.mock_message,
-+            disposition=mock_QpidDisposition.return_value)
++            disposition=self.mock_Disposition.return_value)
 +
-+    @patch('qpid.messaging.Disposition')
-+    @patch('qpid.messaging.REJECTED')
-+    def test_reject_requeue_false(self, mock_REJECTED, mock_QpidDisposition):
++    def test_reject_requeue_false(self):
 +        message = Mock()
 +        self.qos.append(message, 1)
 +        self.qos.reject(1, requeue=False)
-+        mock_QpidDisposition.assert_called_with(mock_REJECTED)
++        self.mock_Disposition.assert_called_with(self.mock_REJECTED)
 +        self.qos.session.acknowledge.assert_called_with(
-+            message=message, disposition=mock_QpidDisposition.return_value)
++            message=message, disposition=self.mock_Disposition.return_value)
 +
 +
 +class TestQoS(Case):
@@ -439,8 +435,6 @@ index 0000000..e929daa
 +        qos.append(m, m_delivery_tag)
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos_no_limit = QoS(self.mock_session)
 +        self.qos_limit_2 = QoS(self.mock_session, prefetch_count=2)
@@ -479,10 +473,8 @@ index 0000000..e929daa
 +
 +class ConnectionTestBase(Case):
 +
-+    @patch('qpid.messaging.Connection')
-+    def setUp(self, QpidConnection):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
++    @patch(QPID_MODULE + '.qpid')
++    def setUp(self, mock_qpid):
 +        self.connection_options = {'host': 'localhost',
 +                                   'port': 5672,
 +                                   'username': 'guest',
@@ -490,7 +482,7 @@ index 0000000..e929daa
 +                                   'transport': 'tcp',
 +                                   'timeout': 10,
 +                                   'sasl_mechanisms': 'PLAIN'}
-+        self.mock_qpid_connection = QpidConnection
++        self.mock_qpid_connection = mock_qpid.messaging.Connection
 +        self.conn = Connection(**self.connection_options)
 +
 +
@@ -512,60 +504,62 @@ index 0000000..e929daa
 +        created_conn = self.mock_qpid_connection.establish.return_value
 +        self.assertTrue(self.conn._qpid_conn is created_conn)
 +
++    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
 +    @patch(QPID_MODULE + '.sys.exc_info')
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__mutates_ConnError_by_message(self, qpid_conn,
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__mutates_ConnError_by_message(self, mock_qpid,
 +                                                            mock_exc_info):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++        my_conn_error = MockException()
 +        my_conn_error.text = 'connection-forced: Authentication failed(320)'
-+        qpid_conn.establish.side_effect = my_conn_error
++        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
 +        mock_exc_info.return_value = ('a', 'b', None)
 +        try:
 +            self.conn = Connection(**self.connection_options)
 +        except AuthenticationFailure as error:
 +            exc_info = sys.exc_info()
-+            self.assertTrue(not isinstance(error, ConnectionError))
++            self.assertTrue(not isinstance(error, MockException))
 +            self.assertTrue(exc_info[1] is 'b')
 +            self.assertTrue(exc_info[2] is None)
 +        else:
 +            self.fail('ConnectionError type was not mutated correctly')
 +
++    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
 +    @patch(QPID_MODULE + '.sys.exc_info')
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__mutates_ConnError_by_code(self, qpid_conn,
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__mutates_ConnError_by_code(self, mock_qpid,
 +                                                         mock_exc_info):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++        my_conn_error = MockException()
 +        my_conn_error.code = 320
 +        my_conn_error.text = 'someothertext'
-+        qpid_conn.establish.side_effect = my_conn_error
++        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
 +        mock_exc_info.return_value = ('a', 'b', None)
 +        try:
 +            self.conn = Connection(**self.connection_options)
 +        except AuthenticationFailure as error:
 +            exc_info = sys.exc_info()
-+            self.assertTrue(not isinstance(error, ConnectionError))
++            self.assertTrue(not isinstance(error, MockException))
 +            self.assertTrue(exc_info[1] is 'b')
 +            self.assertTrue(exc_info[2] is None)
 +        else:
 +            self.fail('ConnectionError type was not mutated correctly')
 +
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__non_auth_Conn_Error_raises(self, qpid_conn):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++    @patch.object(Transport, 'channel_errors', new=(MockException, ))
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__non_auth_Conn_Error_raises(self, mock_qpid):
++        mock_Qpid_Connection = mock_qpid.messaging.Connection
++        my_conn_error = MockException()
 +        my_conn_error.text = 'some non auth related error message'
-+        qpid_conn.establish.side_effect = my_conn_error
-+        self.assertRaises(ConnectionError, Connection,
++        mock_Qpid_Connection.establish.side_effect = my_conn_error
++        self.assertRaises(MockException, Connection,
 +                          **self.connection_options)
 +
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__non_qpid_exception_raises(self, qpid_conn):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__non_qpid_exception_raises(self, mock_qpid):
++        mock_Qpid_Connection = mock_qpid.messaging.Connection
++        mock_ConnectionError = mock_qpid.messaging.exceptions.ConnectionError
++        my_conn_error = mock_ConnectionError()
 +        my_conn_error.text = 'some non auth related error message'
-+        qpid_conn.establish.side_effect = IOError()
++        mock_Qpid_Connection.establish.side_effect = IOError()
 +        self.assertRaises(IOError, Connection, **self.connection_options)
 +
 +
@@ -612,8 +606,9 @@ index 0000000..e929daa
 +class ChannelTestBase(Case):
 +
 +    def setUp(self):
-+        self.patch_qpidtoollibs = patch(QPID_MODULE + '.qpidtoollibs.BrokerAgent')
-+        self.mock_broker_agent = self.patch_qpidtoollibs.start()
++        self.patch_qpidtoollibs = patch(QPID_MODULE + '.qpidtoollibs')
++        self.mock_qpidtoollibs = self.patch_qpidtoollibs.start()
++        self.mock_broker_agent = self.mock_qpidtoollibs.BrokerAgent
 +        self.conn = Mock()
 +        self.transport = Mock()
 +        self.channel = Channel(self.conn, self.transport)
@@ -657,10 +652,11 @@ index 0000000..e929daa
 +
 +class TestChannelPut(ChannelTestBase):
 +
-+    @patch('qpid.messaging.Message')
-+    def test_channel__put_onto_queue(self, mock_Message_cls):
++    @patch(QPID_MODULE + '.qpid')
++    def test_channel__put_onto_queue(self, mock_qpid):
 +        routing_key = 'routingkey'
 +        mock_message = Mock()
++        mock_Message_cls = mock_qpid.messaging.Message
 +
 +        self.channel._put(routing_key, mock_message)
 +
@@ -674,11 +670,12 @@ index 0000000..e929daa
 +                                            sync=True)
 +        mock_sender.close.assert_called_with()
 +
-+    @patch('qpid.messaging.Message')
-+    def test_channel__put_onto_exchange(self, mock_Message_cls):
++    @patch(QPID_MODULE + '.qpid')
++    def test_channel__put_onto_exchange(self, mock_qpid):
 +        mock_routing_key = 'routingkey'
 +        mock_exchange_name = 'myexchange'
 +        mock_message = Mock()
++        mock_Message_cls = mock_qpid.messaging.Message
 +
 +        self.channel._put(mock_routing_key, mock_message, mock_exchange_name)
 +
@@ -998,11 +995,8 @@ index 0000000..e929daa
 +
 +class TestChannel(ExtraAssertionsMixin, Case):
 +
-+    @skip_if_not_module('qpidtoollibs')
-+    @patch('qpidtoollibs.BrokerAgent')
-+    def setUp(self, mock_BrokerAgent):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
++    @patch(QPID_MODULE + '.qpidtoollibs')
++    def setUp(self, mock_qpidtoollibs):
 +        self.mock_connection = Mock()
 +        self.mock_qpid_connection = Mock()
 +        self.mock_qpid_session = Mock()
@@ -1013,8 +1007,8 @@ index 0000000..e929daa
 +        self.mock_transport = Mock()
 +        self.mock_broker = Mock()
 +        self.mock_Message = Mock()
-+        self.mock_BrokerAgent = mock_BrokerAgent
-+        mock_BrokerAgent.return_value = self.mock_broker
++        self.mock_BrokerAgent = mock_qpidtoollibs.BrokerAgent
++        self.mock_BrokerAgent.return_value = self.mock_broker
 +        self.my_channel = Channel(self.mock_connection,
 +                                  self.mock_transport)
 +        self.my_channel.Message = self.mock_Message
@@ -1460,10 +1454,6 @@ index 0000000..e929daa
 +        self.mock_w = Mock()
 +        self.monitor = ReceiversMonitor(self.mock_session, self.mock_w)
 +
-+        class BreakOutException(Exception):
-+            pass
-+        self.BreakOutException = BreakOutException
-+
 +
 +class TestReceiversMonitorType(ReceiversMonitorTestBase):
 +
@@ -1498,10 +1488,11 @@ index 0000000..e929daa
 +    @patch(QPID_MODULE + '.time.sleep')
 +    def test_receivers_monitor_run_calls_monitor_receivers(
 +            self, mock_sleep, mock_monitor_receivers):
-+        mock_sleep.side_effect = self.BreakOutException()
-+        self.assertRaises(self.BreakOutException, self.monitor.run)
++        mock_sleep.side_effect = BreakOutException()
++        self.assertRaises(BreakOutException, self.monitor.run)
 +        mock_monitor_receivers.assert_called_once_with()
 +
++    @patch.object(Transport, 'connection_errors', new=(BreakOutException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1509,8 +1500,8 @@ index 0000000..e929daa
 +            self, mock_logger, mock_sleep, mock_monitor_receivers):
 +        exc_to_raise = IOError()
 +        mock_monitor_receivers.side_effect = exc_to_raise
-+        mock_sleep.side_effect = self.BreakOutException()
-+        self.assertRaises(self.BreakOutException, self.monitor.run)
++        mock_sleep.side_effect = BreakOutException()
++        self.assertRaises(BreakOutException, self.monitor.run)
 +        mock_logger.error.assert_called_once_with(exc_to_raise)
 +        mock_sleep.assert_called_once_with(10)
 +
@@ -1519,12 +1510,13 @@ index 0000000..e929daa
 +    def test_receivers_monitor_run_loops_when_exception_is_raised(
 +            self, mock_sleep, mock_monitor_receivers):
 +        def return_once_raise_on_second_call(*args):
-+            mock_sleep.side_effect = self.BreakOutException()
++            mock_sleep.side_effect = BreakOutException()
 +            return None
 +        mock_sleep.side_effect = return_once_raise_on_second_call
-+        self.assertRaises(self.BreakOutException, self.monitor.run)
++        self.assertRaises(BreakOutException, self.monitor.run)
 +        mock_monitor_receivers.has_calls([call(), call()])
 +
++    @patch.object(Transport, 'connection_errors', new=(MockException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1533,9 +1525,8 @@ index 0000000..e929daa
 +    def test_receivers_monitor_exits_when_recoverable_exception_raised(
 +            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
 +            mock_monitor_receivers):
-+        recoverable_error = Transport.connection_errors[0]
-+        mock_monitor_receivers.side_effect = recoverable_error()
-+        mock_sleep.side_effect = self.BreakOutException()
++        mock_monitor_receivers.side_effect = MockException()
++        mock_sleep.side_effect = BreakOutException()
 +        try:
 +            self.monitor.run()
 +        except Exception:
@@ -1543,6 +1534,7 @@ index 0000000..e929daa
 +                      'recoverable error is caught')
 +        self.assertTrue(not mock_logger.error.called)
 +
++    @patch.object(Transport, 'connection_errors', new=(MockException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1551,9 +1543,8 @@ index 0000000..e929daa
 +    def test_receivers_monitor_saves_traceback_when_recoverable_exc_raised(
 +            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
 +            mock_monitor_receivers):
-+        recoverable_error = Transport.connection_errors[0]
-+        mock_monitor_receivers.side_effect = recoverable_error()
-+        mock_sleep.side_effect = self.BreakOutException()
++        mock_monitor_receivers.side_effect = MockException()
++        mock_sleep.side_effect = BreakOutException()
 +        try:
 +            self.monitor.run()
 +        except Exception:
@@ -1562,6 +1553,7 @@ index 0000000..e929daa
 +        self.assertTrue(
 +            self.mock_session.exc_info is mock_sys_exc_info.return_value)
 +
++    @patch.object(Transport, 'connection_errors', new=(MockException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1570,9 +1562,8 @@ index 0000000..e929daa
 +    def test_receivers_monitor_writes_e_to_pipe_when_recoverable_exc_raised(
 +            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
 +            mock_monitor_receivers):
-+        recoverable_error = Transport.connection_errors[0]
-+        mock_monitor_receivers.side_effect = recoverable_error()
-+        mock_sleep.side_effect = self.BreakOutException()
++        mock_monitor_receivers.side_effect = MockException()
++        mock_sleep.side_effect = BreakOutException()
 +        try:
 +            self.monitor.run()
 +        except Exception:
@@ -1584,15 +1575,15 @@ index 0000000..e929daa
 +class TestReceiversMonitorMonitorReceivers(ReceiversMonitorTestBase):
 +
 +    def test_receivers_monitor_monitor_receivers_calls_next_receivers(self):
-+        self.mock_session.next_receiver.side_effect = self.BreakOutException()
-+        self.assertRaises(self.BreakOutException,
++        self.mock_session.next_receiver.side_effect = BreakOutException()
++        self.assertRaises(BreakOutException,
 +                          self.monitor.monitor_receivers)
 +        self.mock_session.next_receiver.assert_called_once_with()
 +
 +    def test_receivers_monitor_monitor_receivers_writes_to_fd(self):
 +        with patch(QPID_MODULE + '.os.write') as mock_os_write:
-+            mock_os_write.side_effect = self.BreakOutException()
-+            self.assertRaises(self.BreakOutException,
++            mock_os_write.side_effect = BreakOutException()
++            self.assertRaises(BreakOutException,
 +                              self.monitor.monitor_receivers)
 +            mock_os_write.assert_called_once_with(self.mock_w, '0')
 +
@@ -1655,9 +1646,10 @@ index 0000000..e929daa
 +        return mock_receiver
 +
 +    def test_socket_timeout_raised_when_all_receivers_empty(self):
-+        qpid_Empty = qpid.messaging.exceptions.Empty
-+        self.transport.session.next_receiver.side_effect = qpid_Empty()
-+        self.assertRaises(socket.timeout, self.transport.drain_events, Mock())
++        with patch(QPID_MODULE + '.QpidEmpty', new=MockException) as mock_qpid_empty:
++            self.transport.session.next_receiver.side_effect = MockException()
++            self.assertRaises(socket.timeout, self.transport.drain_events,
++                              Mock())
 +
 +    def test_socket_timeout_raised_when_by_timeout(self):
 +        self.transport.session.next_receiver = self.mock_next_receiver
@@ -1730,7 +1722,7 @@ index 0000000..e929daa
 +        self.client.userid = new_userid_string
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username=new_userid_string,
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
 +                                               password='guest',
@@ -1740,7 +1732,7 @@ index 0000000..e929daa
 +    def test_transport_establish_conn_empty_client_is_default(self):
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
 +                                               password='guest',
@@ -1752,7 +1744,7 @@ index 0000000..e929daa
 +        self.client.transport_options['new_param'] = new_param_value
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
 +                                               new_param=new_param_value,
@@ -1764,7 +1756,7 @@ index 0000000..e929daa
 +        self.client.hostname = 'localhost'
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
 +                                               password='guest',
@@ -1775,7 +1767,7 @@ index 0000000..e929daa
 +        self.client.ssl = False
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
 +                                               password='guest',
@@ -1793,7 +1785,7 @@ index 0000000..e929daa
 +                                               ssl_trustfile='my_cacerts',
 +                                               timeout=4,
 +                                               ssl_skip_hostname_check=False,
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               ssl_keyfile='my_keyfile',
 +                                               password='guest',
@@ -1810,7 +1802,7 @@ index 0000000..e929daa
 +                                               ssl_trustfile='my_cacerts',
 +                                               timeout=4,
 +                                               ssl_skip_hostname_check=True,
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               ssl_keyfile='my_keyfile',
 +                                               password='guest',
@@ -1848,7 +1840,7 @@ index 0000000..e929daa
 +        self.client.hostname = 'some_other_hostname'
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='some_other_hostname',
 +                                               timeout=4, password='guest',
 +                                               port=5672, transport='tcp')
@@ -1873,8 +1865,7 @@ index 0000000..e929daa
 +        self.assertEqual('qpid', Transport.driver_name)
 +
 +    def test_transport_channel_error_contains_qpid_ConnectionError(self):
-+        self.assertTrue(qpid.messaging.exceptions.ConnectionError in
-+                        Transport.connection_errors)
++        self.assertTrue(ConnectionError in Transport.connection_errors)
 +
 +    def test_transport_channel_error_contains_socket_error(self):
 +        self.assertTrue(select.error in Transport.connection_errors)
@@ -1939,8 +1930,6 @@ index 0000000..e929daa
 +
 +    def setUp(self):
 +        """Creates a mock_client to be used in testing."""
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_client = Mock()
 +
 +    def test_close_connection(self):
@@ -1961,7 +1950,7 @@ index 0000000..e929daa
 +        correct_params = {'userid': 'guest', 'password': 'guest',
 +                          'port': 5672, 'virtual_host': '',
 +                          'hostname': 'localhost',
-+                          'sasl_mechanisms': 'PLAIN'}
++                          'sasl_mechanisms': 'PLAIN ANONYMOUS'}
 +        my_transport = Transport(self.mock_client)
 +        result_params = my_transport.default_connection_params
 +        self.assertDictEqual(correct_params, result_params)
@@ -1979,10 +1968,10 @@ index 10d62e9..c1d6868 100644
  _transport_cache = {}
 diff --git a/kombu/transport/qpid.py b/kombu/transport/qpid.py
 new file mode 100644
-index 0000000..bed0a94
+index 0000000..ee277d4
 --- /dev/null
 +++ b/kombu/transport/qpid.py
-@@ -0,0 +1,1759 @@
+@@ -0,0 +1,1612 @@
 +"""
 +kombu.transport.qpid
 +=======================
@@ -2023,6 +2012,19 @@ index 0000000..bed0a94
 +except ImportError:  # pragma: no cover
 +    qpidtoollibs = None     # noqa
 +
++try:
++    from qpid.messaging.exceptions import ConnectionError
++    from qpid.messaging.exceptions import Empty as QpidEmpty
++except ImportError:  # pragma: no cover
++    ConnectionError = None
++    QpidEmpty = None
++
++try:
++    import qpid
++except ImportError:  # pragma: no cover
++    qpid = None
++
++
 +from kombu.five import Empty, items
 +from kombu.log import get_logger
 +from kombu.transport.virtual import Base64, Message
@@ -2032,169 +2034,9 @@ index 0000000..bed0a94
 +
 +logger = get_logger(__name__)
 +
-+
-+##### Start Monkey Patching #####
-+
-+# This section applies two patches to qpid.messaging that are required for
-+# correct operation. Each patch fixes a bug. See links to the bugs below:
-+# https://issues.apache.org/jira/browse/QPID-5637
-+# https://issues.apache.org/jira/browse/QPID-5557
-+
-+### Begin Monkey Patch 1 ###
-+# https://issues.apache.org/jira/browse/QPID-5637
-+
-+#############################################################################
-+#  _   _  ___ _____ _____
-+# | \ | |/ _ \_   _| ____|
-+# |  \| | | | || | |  _|
-+# | |\  | |_| || | | |___
-+# |_| \_|\___/ |_| |_____|
-+#
-+# If you have code that also uses qpid.messaging and imports kombu,
-+# or causes this file to be imported, then you need to make sure that this
-+# import occurs first.
-+#
-+# Failure to do this will cause the following exception:
-+# AttributeError: 'Selector' object has no attribute '_current_pid'
-+#
-+# Fix this by importing this module prior to using qpid.messaging in other
-+# code that also uses this module.
-+#############################################################################
-+
-+
-+# Imports for Monkey Patch 1
-+try:
-+    from qpid.selector import Selector
-+except ImportError:  # pragma: no cover
-+    Selector = None     # noqa
-+import atexit
-+
-+
-+# Prepare for Monkey Patch 1
-+def default_monkey():  # pragma: no cover
-+    Selector.lock.acquire()
-+    try:
-+        if Selector.DEFAULT is None:
-+            sel = Selector()
-+            atexit.register(sel.stop)
-+            sel.start()
-+            Selector.DEFAULT = sel
-+            Selector._current_pid = os.getpid()
-+        elif Selector._current_pid != os.getpid():
-+            sel = Selector()
-+            atexit.register(sel.stop)
-+            sel.start()
-+            Selector.DEFAULT = sel
-+            Selector._current_pid = os.getpid()
-+        return Selector.DEFAULT
-+    finally:
-+        Selector.lock.release()
-+
-+# Apply Monkey Patch 1
-+
-+try:
-+    import qpid.selector
-+    qpid.selector.Selector.default = staticmethod(default_monkey)
-+except ImportError:  # pragma: no cover
-+    pass
-+
-+### End Monkey Patch 1 ###
-+
-+### Begin Monkey Patch 2 ###
-+# https://issues.apache.org/jira/browse/QPID-5557
-+
-+# Imports for Monkey Patch 2
-+try:
-+    from qpid.ops import ExchangeQuery, QueueQuery
-+except ImportError:  # pragma: no cover
-+    ExchangeQuery = None
-+    QueueQuery = None
-+
-+try:
-+    from qpid.messaging.exceptions import NotFound, AssertionFailed
-+except ImportError:  # pragma: no cover
-+    NotFound = None
-+    AssertionFailed = None
-+
-+
-+# Prepare for Monkey Patch 2
-+def resolve_declare_monkey(self, sst, lnk, dir, action):  # pragma: no cover
-+    declare = lnk.options.get("create") in ("always", dir)
-+    assrt = lnk.options.get("assert") in ("always", dir)
-+    requested_type = lnk.options.get("node", {}).get("type")
-+
-+    def do_resolved(type, subtype):
-+        err = None
-+        if type is None:
-+            if declare:
-+                err = self.declare(sst, lnk, action)
-+            else:
-+                err = NotFound(text="no such queue: %s" % lnk.name)
-+        else:
-+            if assrt:
-+                expected = lnk.options.get("node", {}).get("type")
-+                if expected and type != expected:
-+                    err = AssertionFailed(
-+                        text="expected %s, got %s" % (expected, type))
-+            if err is None:
-+                action(type, subtype)
-+        if err:
-+            tgt = lnk.target
-+            tgt.error = err
-+            del self._attachments[tgt]
-+            tgt.closed = True
-+            return
-+
-+    self.resolve(sst, lnk.name, do_resolved, node_type=requested_type,
-+                 force=declare)
-+
-+
-+def resolve_monkey(self, sst, name, action, force=False,
-+                   node_type=None):  # pragma: no cover
-+    if not force and not node_type:
-+        try:
-+            type, subtype = self.address_cache[name]
-+            action(type, subtype)
-+            return
-+        except KeyError:
-+            pass
-+    args = []
-+
-+    def do_result(r):
-+        args.append(r)
-+
-+    def do_action(r):
-+        do_result(r)
-+        er, qr = args
-+        if node_type == "topic" and not er.not_found:
-+            type, subtype = "topic", er.type
-+        elif node_type == "queue" and qr.queue:
-+            type, subtype = "queue", None
-+        elif er.not_found and not qr.queue:
-+            type, subtype = None, None
-+        elif qr.queue:
-+            type, subtype = "queue", None
-+        else:
-+            type, subtype = "topic", er.type
-+        if type is not None:
-+            self.address_cache[name] = (type, subtype)
-+        action(type, subtype)
-+
-+    sst.write_query(ExchangeQuery(name), do_result)
-+    sst.write_query(QueueQuery(name), do_action)
-+
-+
-+# Apply monkey patch 2
-+try:
-+    import qpid.messaging.driver
-+    qpid.messaging.driver.Engine.resolve_declare = resolve_declare_monkey
-+    qpid.messaging.driver.Engine.resolve = resolve_monkey
-+except ImportError:  # pragma: no cover
-+    pass
-+
-+### End Monkey Patch 2 ###
-+
-+##### End Monkey Patching #####
++## The Following Import Applies Monkey Patches at Import Time ##
++import kombu.transport.qpid_patches
++################################################################
 +
 +
 +DEFAULT_PORT = 5672
@@ -3348,7 +3190,7 @@ index 0000000..bed0a94
 +        establish = qpid.messaging.Connection.establish
 +        try:
 +            self._qpid_conn = establish(**self.connection_options)
-+        except qpid.messaging.exceptions.ConnectionError as conn_exc:
++        except ConnectionError as conn_exc:
 +            coded_as_auth_failure = getattr(conn_exc, 'code', None) == 320
 +            contains_auth_fail_text = 'Authentication failed' in conn_exc.text
 +            if coded_as_auth_failure or contains_auth_fail_text:
@@ -3506,7 +3348,7 @@ index 0000000..bed0a94
 +    driver_name = 'qpid'
 +
 +    connection_errors = (
-+        qpid.messaging.exceptions.ConnectionError,
++        ConnectionError,
 +        select.error
 +    )
 +
@@ -3704,7 +3546,7 @@ index 0000000..bed0a94
 +                receiver = self.session.next_receiver(timeout=timeout)
 +                message = receiver.fetch()
 +                queue = receiver.source
-+            except qpid.messaging.exceptions.Empty:
++            except QpidEmpty:
 +                raise socket.timeout()
 +            else:
 +                connection._callbacks[queue](message)
@@ -3741,7 +3583,172 @@ index 0000000..bed0a94
 +        """
 +        return {'userid': 'guest', 'password': 'guest',
 +                'port': self.default_port, 'virtual_host': '',
-+                'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN'}
++                'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN ANONYMOUS'}
+diff --git a/kombu/transport/qpid_patches.py b/kombu/transport/qpid_patches.py
+new file mode 100644
+index 0000000..9a6d061
+--- /dev/null
++++ b/kombu/transport/qpid_patches.py
+@@ -0,0 +1,159 @@
++# This module applies two patches to qpid.messaging that are required for
++# correct operation. Each patch fixes a bug. See links to the bugs below:
++# https://issues.apache.org/jira/browse/QPID-5637
++# https://issues.apache.org/jira/browse/QPID-5557
++
++### Begin Monkey Patch 1 ###
++# https://issues.apache.org/jira/browse/QPID-5637
++
++#############################################################################
++#  _   _  ___ _____ _____
++# | \ | |/ _ \_   _| ____|
++# |  \| | | | || | |  _|
++# | |\  | |_| || | | |___
++# |_| \_|\___/ |_| |_____|
++#
++# If you have code that also uses qpid.messaging and imports kombu,
++# or causes this file to be imported, then you need to make sure that this
++# import occurs first.
++#
++# Failure to do this will cause the following exception:
++# AttributeError: 'Selector' object has no attribute '_current_pid'
++#
++# Fix this by importing this module prior to using qpid.messaging in other
++# code that also uses this module.
++#############################################################################
++
++
++# Imports for Monkey Patch 1
++try:
++    from qpid.selector import Selector
++except ImportError:  # pragma: no cover
++    Selector = None     # noqa
++import atexit
++
++
++# Prepare for Monkey Patch 1
++def default_monkey():  # pragma: no cover
++    Selector.lock.acquire()
++    try:
++        if Selector.DEFAULT is None:
++            sel = Selector()
++            atexit.register(sel.stop)
++            sel.start()
++            Selector.DEFAULT = sel
++            Selector._current_pid = os.getpid()
++        elif Selector._current_pid != os.getpid():
++            sel = Selector()
++            atexit.register(sel.stop)
++            sel.start()
++            Selector.DEFAULT = sel
++            Selector._current_pid = os.getpid()
++        return Selector.DEFAULT
++    finally:
++        Selector.lock.release()
++
++# Apply Monkey Patch 1
++
++try:
++    import qpid.selector
++    qpid.selector.Selector.default = staticmethod(default_monkey)
++except ImportError:  # pragma: no cover
++    pass
++
++### End Monkey Patch 1 ###
++
++### Begin Monkey Patch 2 ###
++# https://issues.apache.org/jira/browse/QPID-5557
++
++# Imports for Monkey Patch 2
++try:
++    from qpid.ops import ExchangeQuery, QueueQuery
++except ImportError:  # pragma: no cover
++    ExchangeQuery = None
++    QueueQuery = None
++
++try:
++    from qpid.messaging.exceptions import NotFound, AssertionFailed, ConnectionError
++except ImportError:  # pragma: no cover
++    NotFound = None
++    AssertionFailed = None
++    ConnectionError = None
++
++
++# Prepare for Monkey Patch 2
++def resolve_declare_monkey(self, sst, lnk, dir, action):  # pragma: no cover
++    declare = lnk.options.get("create") in ("always", dir)
++    assrt = lnk.options.get("assert") in ("always", dir)
++    requested_type = lnk.options.get("node", {}).get("type")
++
++    def do_resolved(type, subtype):
++        err = None
++        if type is None:
++            if declare:
++                err = self.declare(sst, lnk, action)
++            else:
++                err = NotFound(text="no such queue: %s" % lnk.name)
++        else:
++            if assrt:
++                expected = lnk.options.get("node", {}).get("type")
++                if expected and type != expected:
++                    err = AssertionFailed(
++                        text="expected %s, got %s" % (expected, type))
++            if err is None:
++                action(type, subtype)
++        if err:
++            tgt = lnk.target
++            tgt.error = err
++            del self._attachments[tgt]
++            tgt.closed = True
++            return
++
++    self.resolve(sst, lnk.name, do_resolved, node_type=requested_type,
++                 force=declare)
++
++
++def resolve_monkey(self, sst, name, action, force=False,
++                   node_type=None):  # pragma: no cover
++    if not force and not node_type:
++        try:
++            type, subtype = self.address_cache[name]
++            action(type, subtype)
++            return
++        except KeyError:
++            pass
++    args = []
++
++    def do_result(r):
++        args.append(r)
++
++    def do_action(r):
++        do_result(r)
++        er, qr = args
++        if node_type == "topic" and not er.not_found:
++            type, subtype = "topic", er.type
++        elif node_type == "queue" and qr.queue:
++            type, subtype = "queue", None
++        elif er.not_found and not qr.queue:
++            type, subtype = None, None
++        elif qr.queue:
++            type, subtype = "queue", None
++        else:
++            type, subtype = "topic", er.type
++        if type is not None:
++            self.address_cache[name] = (type, subtype)
++        action(type, subtype)
++
++    sst.write_query(ExchangeQuery(name), do_result)
++    sst.write_query(QueueQuery(name), do_action)
++
++
++# Apply monkey patch 2
++try:
++    import qpid.messaging.driver
++    qpid.messaging.driver.Engine.resolve_declare = resolve_declare_monkey
++    qpid.messaging.driver.Engine.resolve = resolve_monkey
++except ImportError:  # pragma: no cover
++    pass
++
++### End Monkey Patch 2 ###
 diff --git a/requirements/extras/qpid.txt b/requirements/extras/qpid.txt
 new file mode 100644
 index 0000000..61b8c8c


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/QPID-6091 and
https://github.com/pulp/kombu/pull/21 for more detail.

Note that this patch update includes some other fixes to tests from pulp/kombu
that are not part of this BZ.
