### PR TITLE
1124589 - python-kombu does not work with Qpid unless the user adjusts qqpidd.conf

### DIFF
--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.15
-Release:        12.pulp%{?dist}
+Release:        13.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages

--- a/deps/python-kombu/qpid_transport.patch
+++ b/deps/python-kombu/qpid_transport.patch
@@ -194,10 +194,10 @@ index 85b8f5e..acd1713 100644
      :keyword userid: Default user name if not provided in the URL.
 diff --git a/kombu/tests/transport/test_qpid.py b/kombu/tests/transport/test_qpid.py
 new file mode 100644
-index 0000000..e929daa
+index 0000000..b449559
 --- /dev/null
 +++ b/kombu/tests/transport/test_qpid.py
-@@ -0,0 +1,1767 @@
+@@ -0,0 +1,1800 @@
 +from __future__ import absolute_import
 +
 +import datetime
@@ -210,21 +210,15 @@ index 0000000..e929daa
 +
 +from itertools import count
 +
-+QPID_NOT_AVAILABLE = False
-+try:
-+    import qpid.messaging.exceptions
-+    import qpidtoollibs     # noqa
-+except ImportError:
-+    QPID_NOT_AVAILABLE = True
-+
 +import kombu.five
 +from kombu.transport.qpid import AuthenticationFailure, QoS, Message
 +from kombu.transport.qpid import QpidMessagingExceptionHandler, Channel
 +from kombu.transport.qpid import Connection, ReceiversMonitor, Transport
++from kombu.transport.qpid import ConnectionError
 +from kombu.transport.virtual import Base64
 +from kombu.utils.compat import OrderedDict
-+from kombu.tests.case import Case, Mock, SkipTest
-+from kombu.tests.case import patch, skip_if_not_module
++from kombu.tests.case import Case, Mock
++from kombu.tests.case import patch
 +from mock import call
 +
 +
@@ -256,6 +250,14 @@ index 0000000..e929daa
 +            self.assertTrue(a[key] == b[key])
 +
 +
++class MockException(Exception):
++    pass
++
++
++class BreakOutException(Exception):
++    pass
++
++
 +class TestQpidMessagingExceptionHandler(Case):
 +
 +    allowed_string = 'object in use'
@@ -263,8 +265,6 @@ index 0000000..e929daa
 +
 +    def setUp(self):
 +        """Create a mock ExceptionHandler for testing by this object."""
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.handler = QpidMessagingExceptionHandler(self.allowed_string)
 +
 +    def test_string_stored(self):
@@ -302,8 +302,6 @@ index 0000000..e929daa
 +class TestQoS__init__(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos = QoS(self.mock_session)
 +
@@ -343,8 +341,6 @@ index 0000000..e929daa
 +class TestQoSCanConsumeMaxEstimate(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos = QoS(self.mock_session)
 +
@@ -361,8 +357,6 @@ index 0000000..e929daa
 +class TestQoSAck(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos = QoS(self.mock_session)
 +
@@ -383,11 +377,17 @@ index 0000000..e929daa
 +class TestQoSReject(Case):
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.mock_message = Mock()
 +        self.qos = QoS(self.mock_session)
++        self.patch_qpid = patch(QPID_MODULE + '.qpid')
++        self.mock_qpid = self.patch_qpid.start()
++        self.mock_Disposition = self.mock_qpid.messaging.Disposition
++        self.mock_RELEASED = self.mock_qpid.messaging.RELEASED
++        self.mock_REJECTED = self.mock_qpid.messaging.REJECTED
++
++    def tearDown(self):
++        self.patch_qpid.stop()
 +
 +    def test_reject_pops__not_yet_acked(self):
 +        self.qos.append(self.mock_message, 1)
@@ -395,25 +395,21 @@ index 0000000..e929daa
 +        self.qos.reject(1)
 +        self.assertTrue(1 not in self.qos._not_yet_acked)
 +
-+    @patch('qpid.messaging.Disposition')
-+    @patch('qpid.messaging.RELEASED')
-+    def test_reject_requeue_true(self, mock_RELEASED, mock_QpidDisposition):
++    def test_reject_requeue_true(self):
 +        self.qos.append(self.mock_message, 1)
 +        self.qos.reject(1, requeue=True)
-+        mock_QpidDisposition.assert_called_with(mock_RELEASED)
++        self.mock_Disposition.assert_called_with(self.mock_RELEASED)
 +        self.qos.session.acknowledge.assert_called_with(
 +            message=self.mock_message,
-+            disposition=mock_QpidDisposition.return_value)
++            disposition=self.mock_Disposition.return_value)
 +
-+    @patch('qpid.messaging.Disposition')
-+    @patch('qpid.messaging.REJECTED')
-+    def test_reject_requeue_false(self, mock_REJECTED, mock_QpidDisposition):
++    def test_reject_requeue_false(self):
 +        message = Mock()
 +        self.qos.append(message, 1)
 +        self.qos.reject(1, requeue=False)
-+        mock_QpidDisposition.assert_called_with(mock_REJECTED)
++        self.mock_Disposition.assert_called_with(self.mock_REJECTED)
 +        self.qos.session.acknowledge.assert_called_with(
-+            message=message, disposition=mock_QpidDisposition.return_value)
++            message=message, disposition=self.mock_Disposition.return_value)
 +
 +
 +class TestQoS(Case):
@@ -439,8 +435,6 @@ index 0000000..e929daa
 +        qos.append(m, m_delivery_tag)
 +
 +    def setUp(self):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_session = Mock()
 +        self.qos_no_limit = QoS(self.mock_session)
 +        self.qos_limit_2 = QoS(self.mock_session, prefetch_count=2)
@@ -479,25 +473,27 @@ index 0000000..e929daa
 +
 +class ConnectionTestBase(Case):
 +
-+    @patch('qpid.messaging.Connection')
-+    def setUp(self, QpidConnection):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
++    @patch(QPID_MODULE + '.qpid')
++    def setUp(self, mock_qpid):
 +        self.connection_options = {'host': 'localhost',
 +                                   'port': 5672,
 +                                   'username': 'guest',
-+                                   'password': 'guest',
++                                   'password': '',
 +                                   'transport': 'tcp',
 +                                   'timeout': 10,
-+                                   'sasl_mechanisms': 'PLAIN'}
-+        self.mock_qpid_connection = QpidConnection
++                                   'sasl_mechanisms': 'ANONYMOUS PLAIN'}
++        self.mock_qpid_connection = mock_qpid.messaging.Connection
 +        self.conn = Connection(**self.connection_options)
 +
 +
 +class TestConnectionInit(ExtraAssertionsMixin, ConnectionTestBase):
 +
 +    def test_connection__init__stores_connection_options(self):
-+        self.assertDictEqual(self.connection_options,
++        # ensure that only one mech was passed into connection. The other
++        # options should all be passed through as-is
++        modified_conn_opts = self.connection_options
++        modified_conn_opts['sasl_mechanisms'] = 'PLAIN'
++        self.assertDictEqual(modified_conn_opts,
 +                             self.conn.connection_options)
 +
 +    def test_connection__init__variables(self):
@@ -505,67 +501,87 @@ index 0000000..e929daa
 +        self.assertTrue(isinstance(self.conn._callbacks, dict))
 +
 +    def test_connection__init__establishes_connection(self):
-+        self.mock_qpid_connection.establish.assert_called_with(
-+            **self.connection_options)
++        modified_conn_opts = self.connection_options
++        modified_conn_opts['sasl_mechanisms'] = 'PLAIN'
++        self.mock_qpid_connection.establish.assert_called_with(**modified_conn_opts)
 +
 +    def test_connection__init__saves_established_connection(self):
 +        created_conn = self.mock_qpid_connection.establish.return_value
 +        self.assertTrue(self.conn._qpid_conn is created_conn)
 +
++    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
 +    @patch(QPID_MODULE + '.sys.exc_info')
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__mutates_ConnError_by_message(self, qpid_conn,
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__mutates_ConnError_by_message(self, mock_qpid,
 +                                                            mock_exc_info):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++        my_conn_error = MockException()
 +        my_conn_error.text = 'connection-forced: Authentication failed(320)'
-+        qpid_conn.establish.side_effect = my_conn_error
++        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
 +        mock_exc_info.return_value = ('a', 'b', None)
 +        try:
 +            self.conn = Connection(**self.connection_options)
 +        except AuthenticationFailure as error:
 +            exc_info = sys.exc_info()
-+            self.assertTrue(not isinstance(error, ConnectionError))
++            self.assertTrue(not isinstance(error, MockException))
 +            self.assertTrue(exc_info[1] is 'b')
 +            self.assertTrue(exc_info[2] is None)
 +        else:
 +            self.fail('ConnectionError type was not mutated correctly')
 +
++    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
 +    @patch(QPID_MODULE + '.sys.exc_info')
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__mutates_ConnError_by_code(self, qpid_conn,
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__mutates_ConnError_by_code(self, mock_qpid,
 +                                                         mock_exc_info):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++        my_conn_error = MockException()
 +        my_conn_error.code = 320
 +        my_conn_error.text = 'someothertext'
-+        qpid_conn.establish.side_effect = my_conn_error
++        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
 +        mock_exc_info.return_value = ('a', 'b', None)
 +        try:
 +            self.conn = Connection(**self.connection_options)
 +        except AuthenticationFailure as error:
 +            exc_info = sys.exc_info()
-+            self.assertTrue(not isinstance(error, ConnectionError))
++            self.assertTrue(not isinstance(error, MockException))
 +            self.assertTrue(exc_info[1] is 'b')
 +            self.assertTrue(exc_info[2] is None)
 +        else:
 +            self.fail('ConnectionError type was not mutated correctly')
 +
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__non_auth_Conn_Error_raises(self, qpid_conn):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
++    @patch(QPID_MODULE + '.sys.exc_info')
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__unknown_connection_error(self, mock_qpid, mock_exc_info):
++        # If we get a connection error that we don't understand, bubble it up as-is
++        my_conn_error = MockException()
++        my_conn_error.code = 999
++        my_conn_error.text = 'someothertext'
++        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
++        mock_exc_info.return_value = ('a', 'b', None)
++        try:
++            self.conn = Connection(**self.connection_options)
++        except Exception as error:
++            self.assertTrue(error.code == 999)
++        else:
++            self.fail("Connection should have thrown an exception")
++
++    @patch.object(Transport, 'channel_errors', new=(MockException, ))
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__non_auth_Conn_Error_raises(self, mock_qpid):
++        mock_Qpid_Connection = mock_qpid.messaging.Connection
++        my_conn_error = MockException()
 +        my_conn_error.text = 'some non auth related error message'
-+        qpid_conn.establish.side_effect = my_conn_error
-+        self.assertRaises(ConnectionError, Connection,
++        mock_Qpid_Connection.establish.side_effect = my_conn_error
++        self.assertRaises(MockException, Connection,
 +                          **self.connection_options)
 +
-+    @patch('qpid.messaging.Connection')
-+    def test_connection__init__non_qpid_exception_raises(self, qpid_conn):
-+        ConnectionError = qpid.messaging.exceptions.ConnectionError
-+        my_conn_error = ConnectionError()
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__non_qpid_exception_raises(self, mock_qpid):
++        mock_Qpid_Connection = mock_qpid.messaging.Connection
++        mock_ConnectionError = mock_qpid.messaging.exceptions.ConnectionError
++        my_conn_error = mock_ConnectionError()
 +        my_conn_error.text = 'some non auth related error message'
-+        qpid_conn.establish.side_effect = IOError()
++        mock_Qpid_Connection.establish.side_effect = IOError()
 +        self.assertRaises(IOError, Connection, **self.connection_options)
 +
 +
@@ -612,8 +628,9 @@ index 0000000..e929daa
 +class ChannelTestBase(Case):
 +
 +    def setUp(self):
-+        self.patch_qpidtoollibs = patch(QPID_MODULE + '.qpidtoollibs.BrokerAgent')
-+        self.mock_broker_agent = self.patch_qpidtoollibs.start()
++        self.patch_qpidtoollibs = patch(QPID_MODULE + '.qpidtoollibs')
++        self.mock_qpidtoollibs = self.patch_qpidtoollibs.start()
++        self.mock_broker_agent = self.mock_qpidtoollibs.BrokerAgent
 +        self.conn = Mock()
 +        self.transport = Mock()
 +        self.channel = Channel(self.conn, self.transport)
@@ -657,10 +674,11 @@ index 0000000..e929daa
 +
 +class TestChannelPut(ChannelTestBase):
 +
-+    @patch('qpid.messaging.Message')
-+    def test_channel__put_onto_queue(self, mock_Message_cls):
++    @patch(QPID_MODULE + '.qpid')
++    def test_channel__put_onto_queue(self, mock_qpid):
 +        routing_key = 'routingkey'
 +        mock_message = Mock()
++        mock_Message_cls = mock_qpid.messaging.Message
 +
 +        self.channel._put(routing_key, mock_message)
 +
@@ -674,11 +692,12 @@ index 0000000..e929daa
 +                                            sync=True)
 +        mock_sender.close.assert_called_with()
 +
-+    @patch('qpid.messaging.Message')
-+    def test_channel__put_onto_exchange(self, mock_Message_cls):
++    @patch(QPID_MODULE + '.qpid')
++    def test_channel__put_onto_exchange(self, mock_qpid):
 +        mock_routing_key = 'routingkey'
 +        mock_exchange_name = 'myexchange'
 +        mock_message = Mock()
++        mock_Message_cls = mock_qpid.messaging.Message
 +
 +        self.channel._put(mock_routing_key, mock_message, mock_exchange_name)
 +
@@ -998,11 +1017,8 @@ index 0000000..e929daa
 +
 +class TestChannel(ExtraAssertionsMixin, Case):
 +
-+    @skip_if_not_module('qpidtoollibs')
-+    @patch('qpidtoollibs.BrokerAgent')
-+    def setUp(self, mock_BrokerAgent):
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
++    @patch(QPID_MODULE + '.qpidtoollibs')
++    def setUp(self, mock_qpidtoollibs):
 +        self.mock_connection = Mock()
 +        self.mock_qpid_connection = Mock()
 +        self.mock_qpid_session = Mock()
@@ -1013,8 +1029,8 @@ index 0000000..e929daa
 +        self.mock_transport = Mock()
 +        self.mock_broker = Mock()
 +        self.mock_Message = Mock()
-+        self.mock_BrokerAgent = mock_BrokerAgent
-+        mock_BrokerAgent.return_value = self.mock_broker
++        self.mock_BrokerAgent = mock_qpidtoollibs.BrokerAgent
++        self.mock_BrokerAgent.return_value = self.mock_broker
 +        self.my_channel = Channel(self.mock_connection,
 +                                  self.mock_transport)
 +        self.my_channel.Message = self.mock_Message
@@ -1460,10 +1476,6 @@ index 0000000..e929daa
 +        self.mock_w = Mock()
 +        self.monitor = ReceiversMonitor(self.mock_session, self.mock_w)
 +
-+        class BreakOutException(Exception):
-+            pass
-+        self.BreakOutException = BreakOutException
-+
 +
 +class TestReceiversMonitorType(ReceiversMonitorTestBase):
 +
@@ -1498,10 +1510,11 @@ index 0000000..e929daa
 +    @patch(QPID_MODULE + '.time.sleep')
 +    def test_receivers_monitor_run_calls_monitor_receivers(
 +            self, mock_sleep, mock_monitor_receivers):
-+        mock_sleep.side_effect = self.BreakOutException()
-+        self.assertRaises(self.BreakOutException, self.monitor.run)
++        mock_sleep.side_effect = BreakOutException()
++        self.assertRaises(BreakOutException, self.monitor.run)
 +        mock_monitor_receivers.assert_called_once_with()
 +
++    @patch.object(Transport, 'connection_errors', new=(BreakOutException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1509,8 +1522,8 @@ index 0000000..e929daa
 +            self, mock_logger, mock_sleep, mock_monitor_receivers):
 +        exc_to_raise = IOError()
 +        mock_monitor_receivers.side_effect = exc_to_raise
-+        mock_sleep.side_effect = self.BreakOutException()
-+        self.assertRaises(self.BreakOutException, self.monitor.run)
++        mock_sleep.side_effect = BreakOutException()
++        self.assertRaises(BreakOutException, self.monitor.run)
 +        mock_logger.error.assert_called_once_with(exc_to_raise)
 +        mock_sleep.assert_called_once_with(10)
 +
@@ -1519,12 +1532,13 @@ index 0000000..e929daa
 +    def test_receivers_monitor_run_loops_when_exception_is_raised(
 +            self, mock_sleep, mock_monitor_receivers):
 +        def return_once_raise_on_second_call(*args):
-+            mock_sleep.side_effect = self.BreakOutException()
++            mock_sleep.side_effect = BreakOutException()
 +            return None
 +        mock_sleep.side_effect = return_once_raise_on_second_call
-+        self.assertRaises(self.BreakOutException, self.monitor.run)
++        self.assertRaises(BreakOutException, self.monitor.run)
 +        mock_monitor_receivers.has_calls([call(), call()])
 +
++    @patch.object(Transport, 'connection_errors', new=(MockException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1533,9 +1547,8 @@ index 0000000..e929daa
 +    def test_receivers_monitor_exits_when_recoverable_exception_raised(
 +            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
 +            mock_monitor_receivers):
-+        recoverable_error = Transport.connection_errors[0]
-+        mock_monitor_receivers.side_effect = recoverable_error()
-+        mock_sleep.side_effect = self.BreakOutException()
++        mock_monitor_receivers.side_effect = MockException()
++        mock_sleep.side_effect = BreakOutException()
 +        try:
 +            self.monitor.run()
 +        except Exception:
@@ -1543,6 +1556,7 @@ index 0000000..e929daa
 +                      'recoverable error is caught')
 +        self.assertTrue(not mock_logger.error.called)
 +
++    @patch.object(Transport, 'connection_errors', new=(MockException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1551,9 +1565,8 @@ index 0000000..e929daa
 +    def test_receivers_monitor_saves_traceback_when_recoverable_exc_raised(
 +            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
 +            mock_monitor_receivers):
-+        recoverable_error = Transport.connection_errors[0]
-+        mock_monitor_receivers.side_effect = recoverable_error()
-+        mock_sleep.side_effect = self.BreakOutException()
++        mock_monitor_receivers.side_effect = MockException()
++        mock_sleep.side_effect = BreakOutException()
 +        try:
 +            self.monitor.run()
 +        except Exception:
@@ -1562,6 +1575,7 @@ index 0000000..e929daa
 +        self.assertTrue(
 +            self.mock_session.exc_info is mock_sys_exc_info.return_value)
 +
++    @patch.object(Transport, 'connection_errors', new=(MockException, ))
 +    @patch.object(ReceiversMonitor, 'monitor_receivers')
 +    @patch(QPID_MODULE + '.time.sleep')
 +    @patch(QPID_MODULE + '.logger')
@@ -1570,9 +1584,8 @@ index 0000000..e929daa
 +    def test_receivers_monitor_writes_e_to_pipe_when_recoverable_exc_raised(
 +            self, mock_sys_exc_info, mock_os_write, mock_logger, mock_sleep,
 +            mock_monitor_receivers):
-+        recoverable_error = Transport.connection_errors[0]
-+        mock_monitor_receivers.side_effect = recoverable_error()
-+        mock_sleep.side_effect = self.BreakOutException()
++        mock_monitor_receivers.side_effect = MockException()
++        mock_sleep.side_effect = BreakOutException()
 +        try:
 +            self.monitor.run()
 +        except Exception:
@@ -1584,15 +1597,15 @@ index 0000000..e929daa
 +class TestReceiversMonitorMonitorReceivers(ReceiversMonitorTestBase):
 +
 +    def test_receivers_monitor_monitor_receivers_calls_next_receivers(self):
-+        self.mock_session.next_receiver.side_effect = self.BreakOutException()
-+        self.assertRaises(self.BreakOutException,
++        self.mock_session.next_receiver.side_effect = BreakOutException()
++        self.assertRaises(BreakOutException,
 +                          self.monitor.monitor_receivers)
 +        self.mock_session.next_receiver.assert_called_once_with()
 +
 +    def test_receivers_monitor_monitor_receivers_writes_to_fd(self):
 +        with patch(QPID_MODULE + '.os.write') as mock_os_write:
-+            mock_os_write.side_effect = self.BreakOutException()
-+            self.assertRaises(self.BreakOutException,
++            mock_os_write.side_effect = BreakOutException()
++            self.assertRaises(BreakOutException,
 +                              self.monitor.monitor_receivers)
 +            mock_os_write.assert_called_once_with(self.mock_w, '0')
 +
@@ -1655,9 +1668,10 @@ index 0000000..e929daa
 +        return mock_receiver
 +
 +    def test_socket_timeout_raised_when_all_receivers_empty(self):
-+        qpid_Empty = qpid.messaging.exceptions.Empty
-+        self.transport.session.next_receiver.side_effect = qpid_Empty()
-+        self.assertRaises(socket.timeout, self.transport.drain_events, Mock())
++        with patch(QPID_MODULE + '.QpidEmpty', new=MockException) as mock_qpid_empty:
++            self.transport.session.next_receiver.side_effect = MockException()
++            self.assertRaises(socket.timeout, self.transport.drain_events,
++                              Mock())
 +
 +    def test_socket_timeout_raised_when_by_timeout(self):
 +        self.transport.session.next_receiver = self.mock_next_receiver
@@ -1730,20 +1744,31 @@ index 0000000..e929daa
 +        self.client.userid = new_userid_string
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username=new_userid_string,
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
-+                                               password='guest',
++                                               password='',
++                                               port=5672,
++                                               transport='tcp')
++
++    def test_transport_establish_conn_sasl_mech_sorting(self):
++        self.client.sasl_mechanisms = 'MECH1 MECH2'
++        self.transport.establish_connection()
++        self.mock_conn.assert_called_once_with(username='guest',
++                                               sasl_mechanisms='MECH1 MECH2',
++                                               host='127.0.0.1',
++                                               timeout=4,
++                                               password='',
 +                                               port=5672,
 +                                               transport='tcp')
 +
 +    def test_transport_establish_conn_empty_client_is_default(self):
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
-+                                               password='guest',
++                                               password='',
 +                                               port=5672,
 +                                               transport='tcp')
 +
@@ -1752,11 +1777,11 @@ index 0000000..e929daa
 +        self.client.transport_options['new_param'] = new_param_value
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
 +                                               new_param=new_param_value,
-+                                               password='guest',
++                                               password='',
 +                                               port=5672,
 +                                               transport='tcp')
 +
@@ -1764,10 +1789,21 @@ index 0000000..e929daa
 +        self.client.hostname = 'localhost'
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
-+                                               password='guest',
++                                               password='',
++                                               port=5672,
++                                               transport='tcp')
++
++    def test_transport_establish_conn_set_password(self):
++        self.client.password = 'somepass'
++        self.transport.establish_connection()
++        self.mock_conn.assert_called_once_with(username='guest',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
++                                               host='127.0.0.1',
++                                               timeout=4,
++                                               password='somepass',
 +                                               port=5672,
 +                                               transport='tcp')
 +
@@ -1775,10 +1811,10 @@ index 0000000..e929daa
 +        self.client.ssl = False
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               timeout=4,
-+                                               password='guest',
++                                               password='',
 +                                               port=5672,
 +                                               transport='tcp')
 +
@@ -1793,10 +1829,10 @@ index 0000000..e929daa
 +                                               ssl_trustfile='my_cacerts',
 +                                               timeout=4,
 +                                               ssl_skip_hostname_check=False,
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               ssl_keyfile='my_keyfile',
-+                                               password='guest',
++                                               password='',
 +                                               port=5672, transport='ssl')
 +
 +    def test_transport_establish_conn_with_ssl_skip_hostname_check(self):
@@ -1810,10 +1846,10 @@ index 0000000..e929daa
 +                                               ssl_trustfile='my_cacerts',
 +                                               timeout=4,
 +                                               ssl_skip_hostname_check=True,
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='127.0.0.1',
 +                                               ssl_keyfile='my_keyfile',
-+                                               password='guest',
++                                               password='',
 +                                               port=5672, transport='ssl')
 +
 +    def test_transport_establish_conn_sets_client_on_connection_object(self):
@@ -1848,9 +1884,9 @@ index 0000000..e929daa
 +        self.client.hostname = 'some_other_hostname'
 +        self.transport.establish_connection()
 +        self.mock_conn.assert_called_once_with(username='guest',
-+                                               sasl_mechanisms='PLAIN',
++                                               sasl_mechanisms='PLAIN ANONYMOUS',
 +                                               host='some_other_hostname',
-+                                               timeout=4, password='guest',
++                                               timeout=4, password='',
 +                                               port=5672, transport='tcp')
 +
 +
@@ -1873,8 +1909,7 @@ index 0000000..e929daa
 +        self.assertEqual('qpid', Transport.driver_name)
 +
 +    def test_transport_channel_error_contains_qpid_ConnectionError(self):
-+        self.assertTrue(qpid.messaging.exceptions.ConnectionError in
-+                        Transport.connection_errors)
++        self.assertTrue(ConnectionError in Transport.connection_errors)
 +
 +    def test_transport_channel_error_contains_socket_error(self):
 +        self.assertTrue(select.error in Transport.connection_errors)
@@ -1939,8 +1974,6 @@ index 0000000..e929daa
 +
 +    def setUp(self):
 +        """Creates a mock_client to be used in testing."""
-+        if QPID_NOT_AVAILABLE:
-+            raise SkipTest('qpid.messaging not installed')
 +        self.mock_client = Mock()
 +
 +    def test_close_connection(self):
@@ -1958,10 +1991,10 @@ index 0000000..e929daa
 +
 +    def test_default_connection_params(self):
 +        """Test that the default_connection_params are correct"""
-+        correct_params = {'userid': 'guest', 'password': 'guest',
++        correct_params = {'userid': 'guest', 'password': '',
 +                          'port': 5672, 'virtual_host': '',
 +                          'hostname': 'localhost',
-+                          'sasl_mechanisms': 'PLAIN'}
++                          'sasl_mechanisms': 'PLAIN ANONYMOUS'}
 +        my_transport = Transport(self.mock_client)
 +        result_params = my_transport.default_connection_params
 +        self.assertDictEqual(correct_params, result_params)
@@ -1979,10 +2012,10 @@ index 10d62e9..c1d6868 100644
  _transport_cache = {}
 diff --git a/kombu/transport/qpid.py b/kombu/transport/qpid.py
 new file mode 100644
-index 0000000..bed0a94
+index 0000000..38ec306
 --- /dev/null
 +++ b/kombu/transport/qpid.py
-@@ -0,0 +1,1759 @@
+@@ -0,0 +1,1652 @@
 +"""
 +kombu.transport.qpid
 +=======================
@@ -2023,6 +2056,19 @@ index 0000000..bed0a94
 +except ImportError:  # pragma: no cover
 +    qpidtoollibs = None     # noqa
 +
++try:
++    from qpid.messaging.exceptions import ConnectionError
++    from qpid.messaging.exceptions import Empty as QpidEmpty
++except ImportError:  # pragma: no cover
++    ConnectionError = None
++    QpidEmpty = None
++
++try:
++    import qpid
++except ImportError:  # pragma: no cover
++    qpid = None
++
++
 +from kombu.five import Empty, items
 +from kombu.log import get_logger
 +from kombu.transport.virtual import Base64, Message
@@ -2032,169 +2078,9 @@ index 0000000..bed0a94
 +
 +logger = get_logger(__name__)
 +
-+
-+##### Start Monkey Patching #####
-+
-+# This section applies two patches to qpid.messaging that are required for
-+# correct operation. Each patch fixes a bug. See links to the bugs below:
-+# https://issues.apache.org/jira/browse/QPID-5637
-+# https://issues.apache.org/jira/browse/QPID-5557
-+
-+### Begin Monkey Patch 1 ###
-+# https://issues.apache.org/jira/browse/QPID-5637
-+
-+#############################################################################
-+#  _   _  ___ _____ _____
-+# | \ | |/ _ \_   _| ____|
-+# |  \| | | | || | |  _|
-+# | |\  | |_| || | | |___
-+# |_| \_|\___/ |_| |_____|
-+#
-+# If you have code that also uses qpid.messaging and imports kombu,
-+# or causes this file to be imported, then you need to make sure that this
-+# import occurs first.
-+#
-+# Failure to do this will cause the following exception:
-+# AttributeError: 'Selector' object has no attribute '_current_pid'
-+#
-+# Fix this by importing this module prior to using qpid.messaging in other
-+# code that also uses this module.
-+#############################################################################
-+
-+
-+# Imports for Monkey Patch 1
-+try:
-+    from qpid.selector import Selector
-+except ImportError:  # pragma: no cover
-+    Selector = None     # noqa
-+import atexit
-+
-+
-+# Prepare for Monkey Patch 1
-+def default_monkey():  # pragma: no cover
-+    Selector.lock.acquire()
-+    try:
-+        if Selector.DEFAULT is None:
-+            sel = Selector()
-+            atexit.register(sel.stop)
-+            sel.start()
-+            Selector.DEFAULT = sel
-+            Selector._current_pid = os.getpid()
-+        elif Selector._current_pid != os.getpid():
-+            sel = Selector()
-+            atexit.register(sel.stop)
-+            sel.start()
-+            Selector.DEFAULT = sel
-+            Selector._current_pid = os.getpid()
-+        return Selector.DEFAULT
-+    finally:
-+        Selector.lock.release()
-+
-+# Apply Monkey Patch 1
-+
-+try:
-+    import qpid.selector
-+    qpid.selector.Selector.default = staticmethod(default_monkey)
-+except ImportError:  # pragma: no cover
-+    pass
-+
-+### End Monkey Patch 1 ###
-+
-+### Begin Monkey Patch 2 ###
-+# https://issues.apache.org/jira/browse/QPID-5557
-+
-+# Imports for Monkey Patch 2
-+try:
-+    from qpid.ops import ExchangeQuery, QueueQuery
-+except ImportError:  # pragma: no cover
-+    ExchangeQuery = None
-+    QueueQuery = None
-+
-+try:
-+    from qpid.messaging.exceptions import NotFound, AssertionFailed
-+except ImportError:  # pragma: no cover
-+    NotFound = None
-+    AssertionFailed = None
-+
-+
-+# Prepare for Monkey Patch 2
-+def resolve_declare_monkey(self, sst, lnk, dir, action):  # pragma: no cover
-+    declare = lnk.options.get("create") in ("always", dir)
-+    assrt = lnk.options.get("assert") in ("always", dir)
-+    requested_type = lnk.options.get("node", {}).get("type")
-+
-+    def do_resolved(type, subtype):
-+        err = None
-+        if type is None:
-+            if declare:
-+                err = self.declare(sst, lnk, action)
-+            else:
-+                err = NotFound(text="no such queue: %s" % lnk.name)
-+        else:
-+            if assrt:
-+                expected = lnk.options.get("node", {}).get("type")
-+                if expected and type != expected:
-+                    err = AssertionFailed(
-+                        text="expected %s, got %s" % (expected, type))
-+            if err is None:
-+                action(type, subtype)
-+        if err:
-+            tgt = lnk.target
-+            tgt.error = err
-+            del self._attachments[tgt]
-+            tgt.closed = True
-+            return
-+
-+    self.resolve(sst, lnk.name, do_resolved, node_type=requested_type,
-+                 force=declare)
-+
-+
-+def resolve_monkey(self, sst, name, action, force=False,
-+                   node_type=None):  # pragma: no cover
-+    if not force and not node_type:
-+        try:
-+            type, subtype = self.address_cache[name]
-+            action(type, subtype)
-+            return
-+        except KeyError:
-+            pass
-+    args = []
-+
-+    def do_result(r):
-+        args.append(r)
-+
-+    def do_action(r):
-+        do_result(r)
-+        er, qr = args
-+        if node_type == "topic" and not er.not_found:
-+            type, subtype = "topic", er.type
-+        elif node_type == "queue" and qr.queue:
-+            type, subtype = "queue", None
-+        elif er.not_found and not qr.queue:
-+            type, subtype = None, None
-+        elif qr.queue:
-+            type, subtype = "queue", None
-+        else:
-+            type, subtype = "topic", er.type
-+        if type is not None:
-+            self.address_cache[name] = (type, subtype)
-+        action(type, subtype)
-+
-+    sst.write_query(ExchangeQuery(name), do_result)
-+    sst.write_query(QueueQuery(name), do_action)
-+
-+
-+# Apply monkey patch 2
-+try:
-+    import qpid.messaging.driver
-+    qpid.messaging.driver.Engine.resolve_declare = resolve_declare_monkey
-+    qpid.messaging.driver.Engine.resolve = resolve_monkey
-+except ImportError:  # pragma: no cover
-+    pass
-+
-+### End Monkey Patch 2 ###
-+
-+##### End Monkey Patching #####
++## The Following Import Applies Monkey Patches at Import Time ##
++import kombu.transport.qpid_patches
++################################################################
 +
 +
 +DEFAULT_PORT = 5672
@@ -3311,6 +3197,7 @@ index 0000000..bed0a94
 +
 +    # A class reference to the :class:`Channel` object
 +    Channel = Channel
++    SASL_ANONYMOUS_MECH = 'ANONYMOUS'
 +
 +    def __init__(self, **connection_options):
 +        """Instantiate a Connection object.
@@ -3345,16 +3232,49 @@ index 0000000..bed0a94
 +        self.connection_options = connection_options
 +        self.channels = []
 +        self._callbacks = {}
++        self._qpid_conn = None
 +        establish = qpid.messaging.Connection.establish
-+        try:
-+            self._qpid_conn = establish(**self.connection_options)
-+        except qpid.messaging.exceptions.ConnectionError as conn_exc:
-+            coded_as_auth_failure = getattr(conn_exc, 'code', None) == 320
-+            contains_auth_fail_text = 'Authentication failed' in conn_exc.text
-+            if coded_as_auth_failure or contains_auth_fail_text:
-+                exc = sys.exc_info()
-+                raise AuthenticationFailure, exc[1], exc[2]  # flake8: noqa
-+            raise
++        # There is a behavior difference in qpid.messaging's sasl_mechanism
++        # selection method and cyrus-sasl's. The former will put PLAIN before
++        # ANONYMOUS if a username and password is given, but the latter will
++        # simply take whichever mech is listed first. Thus, if we had
++        # "ANONYMOUS PLAIN" as the default, the user would never be able to
++        # select PLAIN if cyrus-sasl was installed.
++
++        # The following code will put ANONYMOUS last in the mech list, and then
++        # try sasl mechs one by one. This should still result in secure
++        # behavior since it will select the first suitable mech. Unsuitable
++        # mechs will be rejected by the server.
++
++        sasl_mechanisms = [x for x in connection_options['sasl_mechanisms'].split() \
++                           if x != self.SASL_ANONYMOUS_MECH]
++        if self.SASL_ANONYMOUS_MECH in connection_options['sasl_mechanisms'].split():
++            sasl_mechanisms.append(self.SASL_ANONYMOUS_MECH)
++
++        for sasl_mech in sasl_mechanisms:
++            try:
++                logger.debug("Attempting to connect to qpid with SASL mechanism %s" % sasl_mech)
++                modified_conn_opts = self.connection_options
++                modified_conn_opts['sasl_mechanisms'] = sasl_mech
++                self._qpid_conn = establish(**modified_conn_opts)
++                # connection was successful if we got this far
++                logger.info("Connected to qpid with SASL mechanism %s" % sasl_mech)
++                break
++            except ConnectionError as conn_exc:
++                coded_as_auth_failure = getattr(conn_exc, 'code', None) == 320
++                contains_auth_fail_text = 'Authentication failed' in conn_exc.text
++                contains_mech_fail_text = 'sasl negotiation failed: no mechanism agreed'\
++                                          in conn_exc.text
++                if coded_as_auth_failure or contains_auth_fail_text or contains_mech_fail_text:
++                    logger.debug("Unable to connect to qpid with SASL mechanism %s" % sasl_mech)
++                    continue
++                raise
++
++        if not self.get_qpid_connection():
++            exc = sys.exc_info()
++            logger.error("Unable to authenticate to qpid using the following mechanisms: %s" %
++                         sasl_mechanisms)
++            raise AuthenticationFailure, exc[1], exc[2] # flake8: noqa
 +
 +    def get_qpid_connection(self):
 +        """Return the existing connection (singleton).
@@ -3506,7 +3426,7 @@ index 0000000..bed0a94
 +    driver_name = 'qpid'
 +
 +    connection_errors = (
-+        qpid.messaging.exceptions.ConnectionError,
++        ConnectionError,
 +        select.error
 +    )
 +
@@ -3704,7 +3624,7 @@ index 0000000..bed0a94
 +                receiver = self.session.next_receiver(timeout=timeout)
 +                message = receiver.fetch()
 +                queue = receiver.source
-+            except qpid.messaging.exceptions.Empty:
++            except QpidEmpty:
 +                raise socket.timeout()
 +            else:
 +                connection._callbacks[queue](message)
@@ -3736,12 +3656,190 @@ index 0000000..bed0a94
 +        These connection parameters will be used whenever the creator of
 +        Transport does not specify a required parameter.
 +
++        NOTE: password is set to '' by default instead of None so the a
++        connection is attempted[1]. An empty password is considered valid for
++        qpidd if "auth=no" is set on the server.
++
++        [1] https://issues.apache.org/jira/browse/QPID-6109
++
 +        :return: A dict containing the default parameters.
 +        :rtype: dict
 +        """
-+        return {'userid': 'guest', 'password': 'guest',
++        return {'userid': 'guest', 'password': '',
 +                'port': self.default_port, 'virtual_host': '',
-+                'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN'}
++                'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN ANONYMOUS'}
+diff --git a/kombu/transport/qpid_patches.py b/kombu/transport/qpid_patches.py
+new file mode 100644
+index 0000000..7bb4e1c
+--- /dev/null
++++ b/kombu/transport/qpid_patches.py
+@@ -0,0 +1,166 @@
++# This module applies two patches to qpid.messaging that are required for
++# correct operation. Each patch fixes a bug. See links to the bugs below:
++# https://issues.apache.org/jira/browse/QPID-5637
++# https://issues.apache.org/jira/browse/QPID-5557
++
++### Begin Monkey Patch 1 ###
++# https://issues.apache.org/jira/browse/QPID-5637
++
++#############################################################################
++#  _   _  ___ _____ _____
++# | \ | |/ _ \_   _| ____|
++# |  \| | | | || | |  _|
++# | |\  | |_| || | | |___
++# |_| \_|\___/ |_| |_____|
++#
++# If you have code that also uses qpid.messaging and imports kombu,
++# or causes this file to be imported, then you need to make sure that this
++# import occurs first.
++#
++# Failure to do this will cause the following exception:
++# AttributeError: 'Selector' object has no attribute '_current_pid'
++#
++# Fix this by importing this module prior to using qpid.messaging in other
++# code that also uses this module.
++#############################################################################
++
++
++# this import is needed for Python 2.6. Without it, qpid.py will "mask" the
++# system's qpid lib
++from __future__ import absolute_import
++
++import os
++
++
++# Imports for Monkey Patch 1
++try:
++    from qpid.selector import Selector
++except ImportError:  # pragma: no cover
++    Selector = None     # noqa
++import atexit
++
++
++# Prepare for Monkey Patch 1
++def default_monkey():  # pragma: no cover
++    Selector.lock.acquire()
++    try:
++        if Selector.DEFAULT is None:
++            sel = Selector()
++            atexit.register(sel.stop)
++            sel.start()
++            Selector.DEFAULT = sel
++            Selector._current_pid = os.getpid()
++        elif Selector._current_pid != os.getpid():
++            sel = Selector()
++            atexit.register(sel.stop)
++            sel.start()
++            Selector.DEFAULT = sel
++            Selector._current_pid = os.getpid()
++        return Selector.DEFAULT
++    finally:
++        Selector.lock.release()
++
++# Apply Monkey Patch 1
++
++try:
++    import qpid.selector
++    qpid.selector.Selector.default = staticmethod(default_monkey)
++except ImportError:  # pragma: no cover
++    pass
++
++### End Monkey Patch 1 ###
++
++### Begin Monkey Patch 2 ###
++# https://issues.apache.org/jira/browse/QPID-5557
++
++# Imports for Monkey Patch 2
++try:
++    from qpid.ops import ExchangeQuery, QueueQuery
++except ImportError:  # pragma: no cover
++    ExchangeQuery = None
++    QueueQuery = None
++
++try:
++    from qpid.messaging.exceptions import NotFound, AssertionFailed, ConnectionError
++except ImportError:  # pragma: no cover
++    NotFound = None
++    AssertionFailed = None
++    ConnectionError = None
++
++
++# Prepare for Monkey Patch 2
++def resolve_declare_monkey(self, sst, lnk, dir, action):  # pragma: no cover
++    declare = lnk.options.get("create") in ("always", dir)
++    assrt = lnk.options.get("assert") in ("always", dir)
++    requested_type = lnk.options.get("node", {}).get("type")
++
++    def do_resolved(type, subtype):
++        err = None
++        if type is None:
++            if declare:
++                err = self.declare(sst, lnk, action)
++            else:
++                err = NotFound(text="no such queue: %s" % lnk.name)
++        else:
++            if assrt:
++                expected = lnk.options.get("node", {}).get("type")
++                if expected and type != expected:
++                    err = AssertionFailed(
++                        text="expected %s, got %s" % (expected, type))
++            if err is None:
++                action(type, subtype)
++        if err:
++            tgt = lnk.target
++            tgt.error = err
++            del self._attachments[tgt]
++            tgt.closed = True
++            return
++
++    self.resolve(sst, lnk.name, do_resolved, node_type=requested_type,
++                 force=declare)
++
++
++def resolve_monkey(self, sst, name, action, force=False,
++                   node_type=None):  # pragma: no cover
++    if not force and not node_type:
++        try:
++            type, subtype = self.address_cache[name]
++            action(type, subtype)
++            return
++        except KeyError:
++            pass
++    args = []
++
++    def do_result(r):
++        args.append(r)
++
++    def do_action(r):
++        do_result(r)
++        er, qr = args
++        if node_type == "topic" and not er.not_found:
++            type, subtype = "topic", er.type
++        elif node_type == "queue" and qr.queue:
++            type, subtype = "queue", None
++        elif er.not_found and not qr.queue:
++            type, subtype = None, None
++        elif qr.queue:
++            type, subtype = "queue", None
++        else:
++            type, subtype = "topic", er.type
++        if type is not None:
++            self.address_cache[name] = (type, subtype)
++        action(type, subtype)
++
++    sst.write_query(ExchangeQuery(name), do_result)
++    sst.write_query(QueueQuery(name), do_action)
++
++
++# Apply monkey patch 2
++try:
++    import qpid.messaging.driver
++    qpid.messaging.driver.Engine.resolve_declare = resolve_declare_monkey
++    qpid.messaging.driver.Engine.resolve = resolve_monkey
++except ImportError:  # pragma: no cover
++    pass
++
++### End Monkey Patch 2 ###
 diff --git a/requirements/extras/qpid.txt b/requirements/extras/qpid.txt
 new file mode 100644
 index 0000000..61b8c8c

--- a/docs/sphinx/user-guide/installation.rst
+++ b/docs/sphinx/user-guide/installation.rst
@@ -135,17 +135,12 @@ Server
       ``qpid-cpp-server-linearstore`` instead for improved broker performance. After installing
       this package, you will need to restart the Qpid broker to enable the durability feature.
 
-   For Pulp to operate with the Qpid broker, either broker authentication needs to be disabled, or
-   authentication needs to be configured. To disable authentication add ``auth=no`` to the
-   ``qpidd.conf`` file. Qpid 0.24 and higher places the config file is at ``/etc/qpid/qpidd.conf``,
-   and earlier Qpid versions place the config file at ``/etc/qpidd.conf``. Changes made to
-   ``qpidd.conf`` go into effect the next time Qpid starts; if Qpid is already running prior to
-   making a change to ``qpidd.conf`` then restart the Qpid.
-
-   To leave broker authentication enabled, you will need to configure SASL with a
-   username/password, and then configure Pulp to use that username/password. Refer to the Qpid docs
-   on how to configure username/password authentication using SASL. Once the broker is configured,
-   update Pulp according to the :ref:`Pulp Broker Settings Guide <pulp-broker-settings>`.
+   Pulp uses the ``ANONYMOUS`` Qpid authentication mechanism by default. To
+   enable username/password-based ``PLAIN`` broker authentication, you will need
+   to configure SASL with a username/password, and then configure Pulp to use that
+   username/password. Refer to the Qpid docs on how to configure username/password
+   authentication using SASL. Once the broker is configured, update Pulp according
+   to the :ref:`Pulp Broker Settings Guide <pulp-broker-settings>`.
 
    The server can be *optionally* configured so that it will connect to the broker using SSL by following the steps
    defined in the :ref:`Qpid SSL Configuration Guide <qpid-ssl-configuration>`. By default, Pulp

--- a/docs/sphinx/user-guide/release-notes/2.5.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.5.x.rst
@@ -2,6 +2,17 @@
 Pulp 2.5 Release Notes
 =========================
 
+Pulp 2.5.1
+===========
+
+New Features
+------------
+
+- Pulp no longer requires additional configuration of Qpid after installation.
+  It now works with the ANONYMOUS authentication mechanism. Users can still use a
+  username/password however if they set up a SASL database as described in the
+  installation document.
+
 Pulp 2.5.0
 ===========
 


### PR DESCRIPTION
This update to pulp's python-kombu allows use of the ANONYMOUS sasl_mechanism,
which works "out of the box" with qpidd. Users will no longer have to edit
their `qpidd.conf` file as one of the installation steps.

Note that some other kombu refactoring updates are included with this patch.
However there should be no difference in functionality aside from the
aforementioned sasl_mechanism change.
