### PR TITLE
1142304 - remove extraneous errors during unit test runs

### DIFF
--- a/nodes/common/pulp_node/manifest.py
+++ b/nodes/common/pulp_node/manifest.py
@@ -368,10 +368,6 @@ class UnitWriter(object):
         self.close()
         return False
 
-    def __del__(self):
-        # just in case the writer is not properly closed.
-        self.close()
-
 
 class UnitIterator:
     """

--- a/server/pulp/server/common/openssl.py
+++ b/server/pulp/server/common/openssl.py
@@ -66,12 +66,6 @@ class Certificate(object):
             return True
         finally:
             # Make sure we always clean up
-            self.__del__()
-
-    def __del__(self):
-        """
-        Remove the temporary files if they still exist.
-        """
-        if self._tempdir:
-            shutil.rmtree(self._tempdir)
-            self._tempdir = None
+            if self._tempdir:
+                shutil.rmtree(self._tempdir)
+                self._tempdir = None


### PR DESCRIPTION
A few areas of the Pulp code used  `__del__` to ensure some cleanup tasks were
completed. However, `__del__` can be called during garbage collection [while
cPython is doing cleanup](https://docs.python.org/2/reference/datamodel.html#object.__del__), which results in error messages being
printed to stderr. These messages are ultimately harmless since they occur
during instance teardown. However, we can remove these calls to `__del__` and
rely on other mechanisms instead.

In the _UnitWriter_ class, the `__exit__` method will always invoked since the
class is only called by a `with` statement. This is performing the same cleanup
function as the `__del__` method.

In the _Certificate_ class, we can do temp dir cleanup directly inside the
`finally` block.

This patch removes the `__del__` methods in these classes and relies on the
aforementioned methods along with regular garbage collection to do cleanup.
When I ran GC stats after making these changes, I didn't see any unaccounted
references.
