### PR TITLE
1146680 - Stop pulp_workers services with SIGQUIT.

### DIFF
--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -249,12 +249,12 @@ dryrun () {
 
 
 stop_workers () {
-    _chuid stopwait $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
+    _chuid stopwait $CELERYD_NODES -QUIT --pidfile="$CELERYD_PID_FILE"
 }
 
 
 restart_workers () {
-    _chuid restart $CELERYD_NODES $DAEMON_OPTS      \
+    _chuid restart $CELERYD_NODES -QUIT $DAEMON_OPTS      \
                    --pidfile="$CELERYD_PID_FILE"    \
                    --logfile="$CELERYD_LOG_FILE"    \
                    --loglevel="$CELERYD_LOG_LEVEL"  \

--- a/server/usr/lib/systemd/system/pulp_workers.service
+++ b/server/usr/lib/systemd/system/pulp_workers.service
@@ -7,6 +7,7 @@ Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/libexec/pulp-manage-workers start
 ExecStop=/usr/libexec/pulp-manage-workers stop
+KillSignal=SIGQUIT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This will cause our workers to cancel their current tasks when the service is stopped or restarted.

https://bugzilla.redhat.com/show_bug.cgi?id=1146680
