### PR TITLE
1142881 - Fixes SELinux policy to allow sqlite generation to occur

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -9,13 +9,13 @@ require {
         type var_run_t;
         type celery_t;
         type pulp_cert_t;
-        class process { signal signull };
+        class process { setsched signal signull };
         class tcp_socket { getopt create connect setopt getattr write read };
-        class file { write getattr read create unlink open };
+        class file { lock rename write setattr getattr read create unlink open };
         class netlink_route_socket { bind create getattr nlmsg_read write read };
         class unix_dgram_socket { create connect };
         class udp_socket { ioctl create getattr connect write read };
-        class dir { getattr search };
+        class dir { getattr search write remove_name create add_name rmdir };
 }
 
 #============= celery_t ==============
@@ -25,8 +25,28 @@ allow celery_t self:tcp_socket { getopt create connect setopt getattr write read
 allow celery_t self:udp_socket { ioctl getattr create connect write read };
 allow celery_t self:unix_dgram_socket { create connect };
 
+######################################
+#
+# pulp_rpm publish call to createrepo for generating sqlite files
+#
+
+allow celery_t self:process { setsched };
+allow celery_t tmp_t:dir { write remove_name create add_name rmdir };
+allow celery_t tmp_t:file { rename create unlink setattr write read getattr open lock };
+
+ifndef(`distro_rhel6', `
+    fs_getattr_xattr_fs(celery_t)
+')
+
+######################################
+#
+#
+#
+
 allow celery_t pulp_cert_t:dir { getattr search };
 allow celery_t pulp_cert_t:file { read write getattr open };
+
+######################################
 
 allow celery_t var_run_t:file { write getattr read create unlink open };
 apache_delete_sys_content_rw(celery_t)
@@ -49,7 +69,23 @@ miscfiles_read_localization(celery_t)
 miscfiles_manage_cert_dirs(celery_t)
 sysnet_read_config(celery_t)
 
+######################################
+#
+# I'm not sure that this rule is needed or why on EL7 anymore
+#
+
 ifdef(`distro_rhel7', `
-    auth_read_passwd(celery_t)
     rpm_exec(celery_t)
 ')
+
+######################################
+#
+# We can't include this reference policy statement in EL6 because it doesn't know this definition
+# I'm not sure why the allow statements provided by the auth_read_passwd are not needed on EL6
+#
+
+ifndef(`distro_rhel6', `
+    auth_read_passwd(celery_t)
+')
+
+######################################


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1142881

This PR does 3 things:
- allows for tmp file writing by celery_t processes, and call seetsched on process (sqlite generation support)
- makes auth_read_passwd available on both fedoras and rhel7. I believe this is needed for fedora which was never tested, but has been now.
- adds some documentation to start organizing the pulp-celery SELinux policy

This was tested on EL6, EL7, FC19, and FC20 with Enforcing enabled. I tested a create->sync->publish->delete of a repo, and then a consumer register->bind->update->unbind->unregister on each.
