### PR TITLE
1148475 - Adds rpm_exec to all systemd systems

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -71,10 +71,11 @@ sysnet_read_config(celery_t)
 
 ######################################
 #
-# I'm not sure that this rule is needed or why on EL7 anymore
+# rpm_exec is needed with the startup of pulp_workers and pulp_resource_manager on systemd based
+# systems
 #
 
-ifdef(`distro_rhel7', `
+ifndef(`distro_rhel6', `
     rpm_exec(celery_t)
 ')
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1148475

See [this comment on the bug](https://bugzilla.redhat.com/show_bug.cgi?id=1148475#c3) for some explanation.

I was able to produce the avc denials using the same version reported in the bug. I rebuilt the policy with this PR and the workers start properly in enforcing mode now.
