### PR TITLE
Revises release note for queue attribute fix

### DIFF
--- a/docs/sphinx/user-guide/release-notes/2.5.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.5.x.rst
@@ -17,9 +17,10 @@ New Features
 Rest API Changes
 ----------------
 
-* The `Task Report` attribute `queue` is duplicated as the attribute `worker_name`. This is a
-  backwards compatible change. The `queue` attribute will be removed from the `Task Report` in
-  Pulp 3.0.0.
+* A new `Task Report` attribute named `worker_name` is introduced that holds the name of the worker
+  a task is associated with. Previously the worker name was stored in a `Task Report` attribute
+  named `queue`. The `queue` attribute now correctly records the queue a task is put in. The
+  `queue` attribute is deprecated and will be removed from the `Task Report` in Pulp 3.0.0.
 
 .. _2.5.0_upgrade_to_2.5.1:
 


### PR DESCRIPTION
When this release note was written, the queue and worker_name were a simple duplication. Then we went back and made the queue return the correct queue name, but we never updated the release note. This updates the release note to be correct and a little more verbose.
