### PR TITLE
remove traceback from log if user enters incorrect password

### DIFF
--- a/client_admin/pulp/client/admin/exception_handler.py
+++ b/client_admin/pulp/client/admin/exception_handler.py
@@ -42,7 +42,7 @@ class AdminExceptionHandler(ExceptionHandler):
         :return: appropriate exit code for this error
         """
 
-        self._log_client_exception(e)
+        self._log_client_error(e)
 
         handlers = {
             auth_utils.CODE_FAILED : self._handle_authentication_failed,

--- a/client_consumer/pulp/client/consumer/exception_handler.py
+++ b/client_consumer/pulp/client/consumer/exception_handler.py
@@ -24,14 +24,13 @@ class ConsumerExceptionHandler(ExceptionHandler):
         the displayed error message to that behavior.
         """
 
-        self._log_client_exception(e)
-
         msg = _('Authentication Failed')
 
         desc = _('A valid Pulp user is required to register a new consumer. '
                  'Please double check the username and password and attempt the '
                  'request again.')
 
+        self._log_client_error("%(msg)s - %(desc)s" % {'msg': msg, 'desc': desc})
         self.prompt.render_failure_message(msg)
         self.prompt.render_paragraph(desc)
 

--- a/client_lib/pulp/client/extensions/exceptions.py
+++ b/client_lib/pulp/client/extensions/exceptions.py
@@ -241,7 +241,7 @@ class ExceptionHandler:
         :return: appropriate exit code for this error
         """
 
-        self._log_client_exception(e)
+        self._log_client_error(e)
 
         msg = _('The specified user does not have permission to execute '
                 'the given command')
@@ -455,6 +455,13 @@ class ExceptionHandler:
                 'd' : e.extra_data}
 
         _logger.error(template % data)
+
+    def _log_client_error(self, e):
+        """
+        Logs a client-side error to the log.
+        :param e: Error to be logged.
+        """
+        _logger.error(e)
 
     def _log_client_exception(self, e):
         """


### PR DESCRIPTION
By logging an error rather than an exception, the traceback is left out of the logs. Fixes [BZ-1148919](https://bugzilla.redhat.com/show_bug.cgi?id=1148919) and [BZ-1148915](https://bugzilla.redhat.com/show_bug.cgi?id=1148915)
