### PR TITLE
1148919 - 148915 - remove traceback from log if user enters incorrect password

### DIFF
--- a/client_admin/pulp/client/admin/exception_handler.py
+++ b/client_admin/pulp/client/admin/exception_handler.py
@@ -10,10 +10,14 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+import logging
 from gettext import gettext as _
 
 from pulp.client.extensions.exceptions import ExceptionHandler, CODE_PERMISSIONS_EXCEPTION
 from pulp.common import auth_utils
+
+
+_logger = logging.getLogger(__name__)
 
 
 class AdminExceptionHandler(ExceptionHandler):
@@ -42,7 +46,7 @@ class AdminExceptionHandler(ExceptionHandler):
         :return: appropriate exit code for this error
         """
 
-        self._log_client_exception(e)
+        _logger.error(e)
 
         handlers = {
             auth_utils.CODE_FAILED : self._handle_authentication_failed,

--- a/client_consumer/pulp/client/consumer/exception_handler.py
+++ b/client_consumer/pulp/client/consumer/exception_handler.py
@@ -10,9 +10,13 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+import logging
 from gettext import gettext as _
 
 from pulp.client.extensions.exceptions import ExceptionHandler, CODE_PERMISSIONS_EXCEPTION
+
+
+_logger = logging.getLogger(__name__)
 
 
 class ConsumerExceptionHandler(ExceptionHandler):
@@ -24,13 +28,13 @@ class ConsumerExceptionHandler(ExceptionHandler):
         the displayed error message to that behavior.
         """
 
-        self._log_client_exception(e)
-
         msg = _('Authentication Failed')
 
         desc = _('A valid Pulp user is required to register a new consumer. '
                  'Please double check the username and password and attempt the '
                  'request again.')
+
+        _logger.error("%(msg)s - %(desc)s" % {'msg': msg, 'desc': desc})
 
         self.prompt.render_failure_message(msg)
         self.prompt.render_paragraph(desc)

--- a/client_lib/pulp/client/extensions/exceptions.py
+++ b/client_lib/pulp/client/extensions/exceptions.py
@@ -241,7 +241,7 @@ class ExceptionHandler:
         :return: appropriate exit code for this error
         """
 
-        self._log_client_exception(e)
+        _logger.error(e)
 
         msg = _('The specified user does not have permission to execute '
                 'the given command')


### PR DESCRIPTION
By logging an error rather than an exception, the traceback is left out of the logs. Fixes [BZ-1148919](https://bugzilla.redhat.com/show_bug.cgi?id=1148919) and [BZ-1148915](https://bugzilla.redhat.com/show_bug.cgi?id=1148915)
