### PR TITLE
1149894 - Adds a get_parent_directory that gets it right with a trailing slash

### DIFF
--- a/server/pulp/plugins/util/misc.py
+++ b/server/pulp/plugins/util/misc.py
@@ -38,7 +38,7 @@ def get_parent_directory(path):
     that contains the item specified by path. Using this method avoids issues introduced when
     os.path.dirname() is used with paths that include trailing slashes.
 
-    The returned parent directory path does not include a trailing slash . The existence of the
+    The returned parent directory path does not include a trailing slash. The existence of the
     directory does not affect this functions behavior.
 
     :param path: file or directory path

--- a/server/test/unit/plugins/util/test_misc.py
+++ b/server/test/unit/plugins/util/test_misc.py
@@ -92,7 +92,7 @@ class TestGetParentDirectory(unittest.TestCase):
         self.assertEqual(result, parent_dir)
 
     def test_absolute_path_ends_in_slash(self):
-        path = '/an/absolute/path'
+        path = '/an/absolute/path/'
         parent_dir = '/an/absolute'
         result = misc.get_parent_directory(path)
         self.assertEqual(result, parent_dir)


### PR DESCRIPTION
This change is the platform portion of the bugfix for 1149894. pulp_puppet [PR 138](https://github.com/pulp/pulp_puppet/pull/138) uses this new function. They need to be merged together.

https://bugzilla.redhat.com/show_bug.cgi?id=1149894
