### PR TITLE
1099954 - Adds cyrus-sasl-plain note for SASL config to user guide

### DIFF
--- a/docs/sphinx/user-guide/broker-settings.rst
+++ b/docs/sphinx/user-guide/broker-settings.rst
@@ -128,10 +128,19 @@ Qpid with Username and Password Authentication
 The Pulp Server <--> Pulp Consumer Agent only support certificate based authentication, however the
 Pulp Server <--> Pulp Worker communication does allow for username and password based auth.
 
-To use Pulp with Qpid and username and password authentication, you'll need to configure the
-usernames and passwords on the Qpid broker, and then configure Pulp. Refer to the Qpid
-documentation for how to configure the broker. This section explains how to configure Pulp to use a
-username and password configured in Qpid.
+Pulp can authenticate using a username and password with Qpid using SASL. Refer to the Qpid docs
+on how to configure Qpid for SASL, but here are a few helpful pointers:
+
+1. Ensure the Qpid machine has the ``cyrus-sasl-plain`` package installed. After installing it,
+   restart Qpid to ensure it has taken effect.
+
+2. Configure the username and password in the SASL database. Refer to Qpid docs for the specifics
+   of this.
+
+3. Ensure the qpidd user has read access to the SASL database.
+
+After configuring the broker for SASL, then configure Pulp. This section explains how to configure
+Pulp to use a username and password configured in Qpid.
 
 Assuming Qpid has the user ``foo`` and the password ``bar`` configured, enable Pulp to use them by
 uncommenting the ``broker_url`` setting in ``[tasks]`` and setting it as follows:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1099954

It took me a while to test this, but I've determine that cyrus-sasl-plain only needs to be installed on the broker and NOT on the pulp server. As such there was only one place to update it.

Personally I feel this is redundant with the Qpid docs, but we spend time with users helping them resolve these issues so I've documented the process from a high level here anyway.
