### PR TITLE
1064150 - Creates a troubleshooting page that includes trailing slash inconsistency

### DIFF
--- a/docs/sphinx/dev-guide/index.rst
+++ b/docs/sphinx/dev-guide/index.rst
@@ -11,3 +11,4 @@ Pulp Developer Guide
    newtypesupport/index
    integration/index
    glossary
+   troubleshooting

--- a/docs/sphinx/dev-guide/troubleshooting.rst
+++ b/docs/sphinx/dev-guide/troubleshooting.rst
@@ -1,0 +1,9 @@
+Troubleshooting
+===============
+
+.. _trailing_slashes:
+
+Trailing Slashes
+----------------
+
+The REST API for Pulp is inconsistent with the use of trailing slashes in REST calls. If you are having trouble, try adding or removing the trailing slash.


### PR DESCRIPTION
Closes [BZ-1064150](https://bugzilla.redhat.com/show_bug.cgi?id=1064150)
