### PR TITLE
1099954 - Link installation docs to using Pulp with SASL and Qpid docs

### DIFF
--- a/docs/sphinx/user-guide/broker-settings.rst
+++ b/docs/sphinx/user-guide/broker-settings.rst
@@ -122,6 +122,8 @@ To use Qpid on a different host for Pulp Sever <--> Pulp Worker communication, u
     ``broker_url: qpid://guest@someotherhost.com/``
 
 
+.. _pulp-broker-qpid-with-username-password:
+
 Qpid with Username and Password Authentication
 ----------------------------------------------
 

--- a/docs/sphinx/user-guide/installation.rst
+++ b/docs/sphinx/user-guide/installation.rst
@@ -138,8 +138,9 @@ Server
    enable username/password-based ``PLAIN`` broker authentication, you will need
    to configure SASL with a username/password, and then configure Pulp to use that
    username/password. Refer to the Qpid docs on how to configure username/password
-   authentication using SASL. Once the broker is configured, update Pulp according
-   to the :ref:`Pulp Broker Settings Guide <pulp-broker-settings>`.
+   authentication using SASL. Once the broker is configured, configure Pulp according
+   to the docs on using
+   :ref:`Pulp with Qpid and username/password authentication <pulp-broker-qpid-with-username-password>`.
 
    The server can be *optionally* configured so that it will connect to the broker using SSL by following the steps
    defined in the :ref:`Qpid SSL Configuration Guide <qpid-ssl-configuration>`. By default, Pulp


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1099954

This PR is the second PR for this BZ. The first PR [1204](https://github.com/pulp/pulp/pull/1204) is against 2.5-testing. These changes are in a separate PR because the docs I wanted to edit weren't introduced until 2.5-dev.
