### PR TITLE
1102269 - Added task_type to the tasks executed by pulp agent

### DIFF
--- a/server/pulp/server/managers/consumer/agent.py
+++ b/server/pulp/server/managers/consumer/agent.py
@@ -26,9 +26,9 @@ from pulp.plugins.model import Consumer as ProfiledConsumer
 from pulp.plugins.profiler import Profiler, InvalidUnitsRequested
 from pulp.server.agent import PulpAgent
 from pulp.server.db.model.consumer import Bind
+from pulp.server.db.model.dispatch import TaskStatus
 from pulp.server.exceptions import PulpExecutionException, PulpDataException, MissingResource
 from pulp.server.managers import factory as managers
-from pulp.server.async.task_status_manager import TaskStatusManager
 from pulp.server.agent import Context
 
 
@@ -68,10 +68,10 @@ class AgentManager(object):
         :type distributor_id: str
         :param options: The options are handler specific.
         :type options: dict
-        :return: The task created by the bind
-        :rtype: dict
+        :return: The task status created by the bind
+        :rtype: TaskStatus
         """
-        # track agent operations using a pseudo task
+        # track agent operations using a TaskStatus
         task_id = str(uuid4())
         task_tags = [
             tags.resource_tag(tags.RESOURCE_CONSUMER_TYPE, consumer_id),
@@ -79,7 +79,9 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_REPOSITORY_DISTRIBUTOR_TYPE, distributor_id),
             tags.action_tag(tags.ACTION_AGENT_BIND)
         ]
-        task = TaskStatusManager.create_task_status(task_id, 'agent', tags=task_tags)
+        task_name = 'pulp.agent.gofer.pulpplugin.consumer.bind'
+        task_status = TaskStatus(task_id=task_id, task_type=task_name,
+                                 state=constants.CALL_WAITING_STATE, tags=task_tags)
 
         # agent request
         consumer_manager = managers.consumer_manager()
@@ -106,7 +108,7 @@ class AgentManager(object):
             Bind.Action.BIND,
             task_id)
 
-        return task
+        return task_status
 
     @staticmethod
     def unbind(consumer_id, repo_id, distributor_id, options):
@@ -120,8 +122,8 @@ class AgentManager(object):
         :type distributor_id: str
         :param options: The options are handler specific.
         :type options: dict
-        :return: A task ID that may be used to track the agent request.
-        :rtype: str
+        :return: A task status used to track the agent request.
+        :rtype: TaskStatus
         """
         # track agent operations using a pseudo task
         task_id = str(uuid4())
@@ -131,7 +133,9 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_REPOSITORY_DISTRIBUTOR_TYPE, distributor_id),
             tags.action_tag(tags.ACTION_AGENT_UNBIND)
         ]
-        task = TaskStatusManager.create_task_status(task_id, 'agent', tags=task_tags)
+        task_name = 'pulp.agent.gofer.pulpplugin.consumer.unbind'
+        task_status = TaskStatus(task_id=task_id, task_type=task_name,
+                                 state=constants.CALL_WAITING_STATE, tags=task_tags)
 
         # agent request
         manager = managers.consumer_manager()
@@ -157,7 +161,7 @@ class AgentManager(object):
             Bind.Action.UNBIND,
             task_id)
 
-        return task
+        return task_status
 
     @staticmethod
     def install_content(consumer_id, units, options):
@@ -170,8 +174,8 @@ class AgentManager(object):
             { type_id:<str>, unit_key:<dict> }
         :param options: Install options; based on unit type.
         :type options: dict
-        :return: A task used to track the agent request.
-        :rtype: dict
+        :return: A task status used to track the agent request.
+        :rtype: TaskStatus
         """
         # track agent operations using a pseudo task
         task_id = str(uuid4())
@@ -179,7 +183,9 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_CONSUMER_TYPE, consumer_id),
             tags.action_tag(tags.ACTION_AGENT_UNIT_INSTALL)
         ]
-        task = TaskStatusManager.create_task_status(task_id, 'agent', tags=task_tags)
+        task_name = 'pulp.agent.gofer.pulpplugin.content.install_content'
+        task_status = TaskStatus(task_id=task_id, task_type=task_name,
+                                 state=constants.CALL_WAITING_STATE, tags=task_tags)
 
         # agent request
         manager = managers.consumer_manager()
@@ -201,7 +207,7 @@ class AgentManager(object):
         context = Context(consumer, task_id=task_id, consumer_id=consumer_id)
         agent = PulpAgent()
         agent.content.install(context, units, options)
-        return task
+        return task_status
 
     @staticmethod
     def update_content(consumer_id, units, options):
@@ -214,8 +220,8 @@ class AgentManager(object):
             { type_id:<str>, unit_key:<dict> }
         :param options: Update options; based on unit type.
         :type options: dict
-        :return: A task used to track the agent request.
-        :rtype: dict
+        :return: A task status used to track the agent request.
+        :rtype: TaskStatus
         """
         # track agent operations using a pseudo task
         task_id = str(uuid4())
@@ -223,7 +229,9 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_CONSUMER_TYPE, consumer_id),
             tags.action_tag(tags.ACTION_AGENT_UNIT_UPDATE)
         ]
-        task = TaskStatusManager.create_task_status(task_id, 'agent', tags=task_tags)
+        task_name = 'pulp.agent.gofer.pulpplugin.content.update_content'
+        task_status = TaskStatus(task_id=task_id, task_type=task_name,
+                                 state=constants.CALL_WAITING_STATE, tags=task_tags)
 
         # agent request
         manager = managers.consumer_manager()
@@ -245,7 +253,7 @@ class AgentManager(object):
         context = Context(consumer, task_id=task_id, consumer_id=consumer_id)
         agent = PulpAgent()
         agent.content.update(context, units, options)
-        return task
+        return task_status
 
     @staticmethod
     def uninstall_content(consumer_id, units, options):
@@ -258,8 +266,8 @@ class AgentManager(object):
             { type_id:<str>, type_id:<dict> }
         :param options: Uninstall options; based on unit type.
         :type options: dict
-        :return: A task ID that may be used to track the agent request.
-        :rtype: dict
+        :return: A task status used to track the agent request.
+        :rtype: TaskStatus
         """
         # track agent operations using a pseudo task
         task_id = str(uuid4())
@@ -267,7 +275,9 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_CONSUMER_TYPE, consumer_id),
             tags.action_tag(tags.ACTION_AGENT_UNIT_UNINSTALL)
         ]
-        task = TaskStatusManager.create_task_status(task_id, 'agent', tags=task_tags)
+        task_name = 'pulp.agent.gofer.pulpplugin.content.uninstall_content'
+        task_status = TaskStatus(task_id=task_id, task_type=task_name,
+                                 state=constants.CALL_WAITING_STATE, tags=task_tags)
 
         # agent request
         manager = managers.consumer_manager()
@@ -289,7 +299,7 @@ class AgentManager(object):
         context = Context(consumer, task_id=task_id, consumer_id=consumer_id)
         agent = PulpAgent()
         agent.content.uninstall(context, units, options)
-        return task
+        return task_status
 
     def cancel_request(self, consumer_id, task_id):
         """

--- a/server/test/unit/server/managers/consumer/test_agent_manager.py
+++ b/server/test/unit/server/managers/consumer/test_agent_manager.py
@@ -50,7 +50,6 @@ class TestAgentManager(TestCase):
         mock_agent.unregistered.assert_called_with(mock_context.return_value)
 
     @patch('pulp.server.managers.consumer.agent.uuid4')
-    @patch('pulp.server.managers.consumer.agent.TaskStatusManager')
     @patch('pulp.server.managers.consumer.agent.AgentManager._bindings')
     @patch('pulp.server.managers.consumer.agent.managers')
     @patch('pulp.server.managers.consumer.agent.Context')
@@ -61,8 +60,7 @@ class TestAgentManager(TestCase):
         mock_context = mocks[1]
         mock_factory = mocks[2]
         mock_bindings = mocks[3]
-        mock_task_status_manager = mocks[4]
-        mock_uuid = mocks[5]
+        mock_uuid = mocks[4]
 
         consumer = {'id': '1234'}
         mock_consumer_manager = Mock()
@@ -80,7 +78,6 @@ class TestAgentManager(TestCase):
 
         task_id = '2345'
         mock_task = {'task_id': task_id}
-        mock_task_status_manager.create_task_status = Mock(return_value=mock_task)
 
         mock_context.return_value = {}
 
@@ -115,14 +112,12 @@ class TestAgentManager(TestCase):
             repo_id=repo_id,
             distributor_id=distributor_id)
 
-        self.assertEqual(task, mock_task)
-        mock_task_status_manager.create_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
+        self.assertEqual(task.task_type, 'pulp.agent.gofer.pulpplugin.consumer.bind')
         mock_agent.bind.assert_called_with(mock_context.return_value, agent_bindings, options)
         mock_bind_manager.action_pending.assert_called_with(
             consumer['id'], repo_id, distributor_id, Bind.Action.BIND, task_id)
 
     @patch('pulp.server.managers.consumer.agent.uuid4')
-    @patch('pulp.server.managers.consumer.agent.TaskStatusManager')
     @patch('pulp.server.managers.consumer.agent.AgentManager._unbindings')
     @patch('pulp.server.managers.consumer.agent.managers')
     @patch('pulp.server.managers.consumer.agent.Context')
@@ -132,8 +127,7 @@ class TestAgentManager(TestCase):
         mock_context = mocks[1]
         mock_factory = mocks[2]
         mock_unbindings = mocks[3]
-        mock_task_status_manager = mocks[4]
-        mock_uuid = mocks[5]
+        mock_uuid = mocks[4]
 
         consumer = {'id': '1234'}
         mock_consumer_manager = Mock()
@@ -152,7 +146,6 @@ class TestAgentManager(TestCase):
 
         task_id = '2345'
         mock_task = {'task_id': task_id}
-        mock_task_status_manager.create_task_status = Mock(return_value=mock_task)
 
         mock_context.return_value = {}
 
@@ -184,14 +177,12 @@ class TestAgentManager(TestCase):
             repo_id=repo_id,
             distributor_id=distributor_id)
 
-        self.assertEqual(task, mock_task)
-        mock_task_status_manager.create_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
+        self.assertEqual(task.task_type, 'pulp.agent.gofer.pulpplugin.consumer.unbind')
         mock_agent.unbind.assert_called_with(mock_context.return_value, agent_bindings, options)
         mock_bind_manager.action_pending.assert_called_with(
             consumer['id'], repo_id, distributor_id, Bind.Action.UNBIND, task_id)
 
     @patch('pulp.server.managers.consumer.agent.uuid4')
-    @patch('pulp.server.managers.consumer.agent.TaskStatusManager')
     @patch('pulp.server.managers.consumer.agent.AgentManager._profiled_consumer')
     @patch('pulp.server.managers.consumer.agent.AgentManager._profiler')
     @patch('pulp.server.managers.consumer.agent.managers')
@@ -203,8 +194,7 @@ class TestAgentManager(TestCase):
         mock_factory = mocks[2]
         mock_get_profiler = mocks[3]
         mock_get_profiled_consumer = mocks[4]
-        mock_task_status_manager = mocks[5]
-        mock_uuid = mocks[6]
+        mock_uuid = mocks[5]
 
         unit = {'type_id': 'xyz', 'unit_key': {}}
 
@@ -221,7 +211,6 @@ class TestAgentManager(TestCase):
 
         task_id = '2345'
         mock_task = {'task_id': task_id}
-        mock_task_status_manager.create_task_status = Mock(return_value=mock_task)
 
         mock_context.return_value = {}
 
@@ -240,15 +229,13 @@ class TestAgentManager(TestCase):
             tags.action_tag(tags.ACTION_AGENT_UNIT_INSTALL)
         ]
 
-        self.assertEqual(task, mock_task)
+        self.assertEqual(task.task_type, 'pulp.agent.gofer.pulpplugin.content.install_content')
         mock_consumer_manager.get_consumer.assert_called_with(consumer['id'])
         mock_context.assert_called_with(consumer, task_id=task_id, consumer_id=consumer['id'])
-        mock_task_status_manager.create_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
         mock_profiler.install_units.assert_called_with(consumer, [unit], options, {}, ANY)
         mock_agent.install.assert_called_with(mock_context.return_value, [unit], options)
 
     @patch('pulp.server.managers.consumer.agent.uuid4')
-    @patch('pulp.server.managers.consumer.agent.TaskStatusManager')
     @patch('pulp.server.managers.consumer.agent.AgentManager._profiled_consumer')
     @patch('pulp.server.managers.consumer.agent.AgentManager._profiler')
     @patch('pulp.server.managers.consumer.agent.managers')
@@ -260,8 +247,7 @@ class TestAgentManager(TestCase):
         mock_factory = mocks[2]
         mock_get_profiler = mocks[3]
         mock_get_profiled_consumer = mocks[4]
-        mock_task_status_manager = mocks[5]
-        mock_uuid = mocks[6]
+        mock_uuid = mocks[5]
 
         unit = {'type_id': 'xyz', 'unit_key': {}}
 
@@ -278,7 +264,6 @@ class TestAgentManager(TestCase):
 
         task_id = '2345'
         mock_task = {'task_id': task_id}
-        mock_task_status_manager.create_task_status = Mock(return_value=mock_task)
 
         mock_context.return_value = {}
 
@@ -297,15 +282,13 @@ class TestAgentManager(TestCase):
             tags.action_tag(tags.ACTION_AGENT_UNIT_UPDATE)
         ]
 
-        self.assertEqual(task, mock_task)
+        self.assertEqual(task.task_type, 'pulp.agent.gofer.pulpplugin.content.update_content')
         mock_consumer_manager.get_consumer.assert_called_with(consumer['id'])
         mock_context.assert_called_with(consumer, task_id=task_id, consumer_id=consumer['id'])
-        mock_task_status_manager.create_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
         mock_profiler.update_units.assert_called_with(consumer, [unit], options, {}, ANY)
         mock_agent.update.assert_called_with(mock_context.return_value, [unit], options)
 
     @patch('pulp.server.managers.consumer.agent.uuid4')
-    @patch('pulp.server.managers.consumer.agent.TaskStatusManager')
     @patch('pulp.server.managers.consumer.agent.AgentManager._profiled_consumer')
     @patch('pulp.server.managers.consumer.agent.AgentManager._profiler')
     @patch('pulp.server.managers.consumer.agent.managers')
@@ -317,8 +300,7 @@ class TestAgentManager(TestCase):
         mock_factory = mocks[2]
         mock_get_profiler = mocks[3]
         mock_get_profiled_consumer = mocks[4]
-        mock_task_status_manager = mocks[5]
-        mock_uuid = mocks[6]
+        mock_uuid = mocks[5]
 
         unit = {'type_id': 'xyz', 'unit_key': {}}
 
@@ -335,7 +317,6 @@ class TestAgentManager(TestCase):
 
         task_id = '2345'
         mock_task = {'task_id': task_id}
-        mock_task_status_manager.create_task_status = Mock(return_value=mock_task)
 
         mock_context.return_value = {}
 
@@ -354,10 +335,9 @@ class TestAgentManager(TestCase):
             tags.action_tag(tags.ACTION_AGENT_UNIT_UNINSTALL)
         ]
 
-        self.assertEqual(task, mock_task)
+        self.assertEqual(task.task_type, 'pulp.agent.gofer.pulpplugin.content.uninstall_content')
         mock_consumer_manager.get_consumer.assert_called_with(consumer['id'])
         mock_context.assert_called_with(consumer, task_id=task_id, consumer_id=consumer['id'])
-        mock_task_status_manager.create_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
         mock_profiler.uninstall_units.assert_called_with(consumer, [unit], options, {}, ANY)
         mock_agent.uninstall.assert_called_with(mock_context.return_value, [unit], options)
 


### PR DESCRIPTION
Bind, unbind, content.install, content.update, content.uninstall tasks
did not record a task_type in the TaskStatus collection.  This patch
fixes this problem.
