### PR TITLE
setting a max DB connect timeout of 1 second for pulp-manage-db

### DIFF
--- a/server/pulp/server/db/manage.py
+++ b/server/pulp/server/db/manage.py
@@ -103,7 +103,7 @@ def main():
     try:
         options = parse_args()
         _start_logging()
-        connection.initialize()
+        connection.initialize(max_timeout=1)
         _auto_manage_db(options)
     except DataError, e:
         logger.critical(str(e))

--- a/server/test/unit/server/db/test_manage.py
+++ b/server/test/unit/server/db/test_manage.py
@@ -151,6 +151,14 @@ class TestManageDB(MigrationTest):
         # Also, make sure the factory was initialized
         factory.initialize.assert_called_once_with()
 
+    @patch('sys.argv', ["pulp-manage-db"])
+    @patch('pulp.server.db.connection.initialize')
+    @patch('pulp.server.db.manage._auto_manage_db')
+    def test_set_connection_timeout(self, mock_auto_manage_db, mock_initialize):
+        manage.main()
+
+        mock_initialize.assert_called_once_with(max_timeout=1)
+
     @patch('sys.stderr')
     @patch('os.getuid', return_value=0)
     def test_wont_run_as_root(self, mock_getuid, mock_stderr):


### PR DESCRIPTION
If a user runs pulp-manage-db while mongo is not listening for connections,
that user does not want the usual retry back-off. They want pulp-manage-db to
keep trying about once per second until a connection is established.

I can't find any tests for the `initialize` function, and I don't want to block this tiny improvement on having to write a whole set of tests. This area is going to get re-worked this sprint anyway when mongoengine is dropped in.
