### PR TITLE
Adds queue attribute to docs for Task Report

### DIFF
--- a/docs/sphinx/dev-guide/integration/rest-api/dispatch/task.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/dispatch/task.rst
@@ -27,7 +27,8 @@ task.
 * **finish_time** *(null or string)* - the time the call stopped executing
 * **tags** *(array)* - arbitrary tags useful for looking up the call report
 * **spawned_tasks** *(array)* - List of objects containing the uri and task id for any tasks that were spawned by this task.
-* **worker_name** *(string)* - The worker associated with the task
+* **worker_name** *(string)* - The worker associated with the task. This field is empty if a worker is not yet assigned.
+* **queue** *(string)* - The queue associated with the task. This field is empty if a queue is not yet assigned.
 * **error** *(null or object)* - Any, errors that occurred that did not cause the overall call to fail.  See :ref:`error_details`.
 
 .. note::


### PR DESCRIPTION
This was forgotten from earlier, and I realized it when I went to add the note that it can also be None. I am glad I decided to do this!
