### PR TITLE
Add a dev-setup.sh script

### DIFF
--- a/docs/sphinx/dev-guide/contributing/dev_setup.rst
+++ b/docs/sphinx/dev-guide/contributing/dev_setup.rst
@@ -1,6 +1,24 @@
 Developer Setup
 ===============
 
+For the Impatient
+^^^^^^^^^^^^^^^^^
+
+* Start a Fedora 20 x86_64 instance that will be dedicated for development with
+  at least 2GB of memory and 10GB of disk space. More disk space is needed if
+  you plan on syncing larger repos for test purposes.
+
+* If one does not already exist, create a non-root user with sudo access.
+
+* As that user, ``wget https://raw.githubusercontent.com/pulp/pulp/master/playpen/dev-setup.sh``.
+  Note that this installs RPMs and makes system modifications that you wouldn't
+  want to apply on a VM that was not dedicated to Pulp development.
+
+* As that user, ``bash dev-setup.sh``.
+
+* While it runs, read the rest of this document!
+
+
 Source Code
 ^^^^^^^^^^^
 
@@ -35,7 +53,9 @@ the latest dependencies according to the spec file.
 
 #. Install some additional dependencies for development::
    
-   $ sudo yum install python-setuptools redhat-lsb mongodb mongodb-server qpid-cpp-server qpid-cpp-server-store python-qpid-qmf
+   $ sudo yum install python-setuptools redhat-lsb mongodb mongodb-server \
+          qpid-cpp-server qpid-cpp-server-store python-qpid-qmf python-nose \
+          python-mock python-paste python-pip
 
 The only caveat to this approach is that these dependencies will need to be maintained after this
 initial setup. Leaving the testing builds repository enabled will cause them to be automatically
@@ -128,17 +148,17 @@ Start the agent::
 
     sudo systemctl start goferd
 
-Initialize the database::
-
-    sudo systemctl start mongod
-    sudo -u apache pulp-manage-db
-
 Install a plugin (the server requires at least one to start)::
 
     git clone https://github.com/pulp/pulp_rpm.git
     cd pulp_rpm
     sudo ./manage_setup_pys.sh develop
     sudo python ./pulp-dev.py -I
+
+Initialize the database::
+
+    sudo systemctl start mongod
+    sudo -u apache pulp-manage-db
 
 Start the server::
 

--- a/playpen/dev-setup.sh
+++ b/playpen/dev-setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+if [[ $EUID -eq 0 ]]; then
+    echo "You are running this script as root."
+    echo "This script needs to be run as a non-root user with sudo access."
+    exit 1
+fi
+
+echo "Disabling selinux for dev install"
+# dev setup does not work with selinux at this time
+sudo setenforce 0
+sudo sed -i 's/enforcing/permissive/' /etc/sysconfig/selinux
+
+echo "Install some prereqs"
+sudo yum install wget yum-utils
+
+echo "setting up repos"
+# repo setup
+pushd /etc/yum.repos.d
+sudo wget -q https://repos.fedorapeople.org/repos/pulp/pulp/fedora-pulp.repo
+sudo yum-config-manager --enable pulp-2.5-testing > /dev/null
+popd
+
+# install rpms, then remove pulp*
+
+echo "installing RPMs"
+sudo yum install -y @pulp-server-qpid @pulp-admin @pulp-consumer
+sudo yum remove -y pulp-\* python-pulp\*
+sudo yum install -y python-setuptools redhat-lsb mongodb mongodb-server \
+                    qpid-cpp-server qpid-cpp-server-store python-qpid-qmf \
+                    git python-pip python-nose python-mock python-paste
+sudo yum-config-manager --disable pulp-2.5-testing > /dev/null
+
+echo "installing newer kombu (temporary step until 2.5.1 is in testing repo)"
+sudo rpm -Uvh http://koji.katello.org/packages/python-kombu/3.0.15/13.pulp.fc20/noarch/python-kombu-3.0.15-13.pulp.fc20.noarch.rpm
+
+pushd ~
+for r in pulp pulp_rpm; do
+  echo "checking out $r code"
+  git clone https://github.com/pulp/$r
+  echo "installing $r dev code"
+  pushd $r
+  sudo python ./pulp-dev.py -I
+  sudo ./manage_setup_pys.sh develop
+  popd
+done
+
+echo "Adjusting facls for apache"
+setfacl -m user:apache:rwx .
+pushd pulp
+setfacl -m user:apache:rwx .
+popd; popd
+
+
+echo "Starting services, this may take a few minutes due to mongodb journal allocation"
+for s in qpidd goferd mongod; do
+  sudo systemctl start $s
+done
+
+echo "populating mongodb"
+sudo -u apache pulp-manage-db
+
+echo "Starting more services"
+for s in httpd pulp_workers pulp_celerybeat pulp_resource_manager; do
+  sudo systemctl start $s
+done
+
+echo "Disabling SSL verification on dev setup"
+sudo sed -i 's/# verify_ssl: True/verify_ssl: False/' /etc/pulp/admin/admin.conf
+echo "done! you should be able to run 'pulp-admin login -u admin' now to log in"
+echo "To run tests, cd to pulp or pulp_rpm and run \"./run-tests.py\""
+


### PR DESCRIPTION
I created a dev-setup.sh script for testing the setup instructions from
@asmacdo. It was originally intended just to run through all his steps to test
his doc but it may be generally useful for new contributors to help them get
started quickly.

The script should work on RHEL 7+, CentOS 7+, or Fedora 19+. There is one line
that is hard-coded for Fedora 20 but it can go away once we push Pulp 2.5.1
alpha into the testing repo.
