### PR TITLE
1136919 - Removes redundant amqp_port_t definitions from pulp-server

### DIFF
--- a/server/selinux/server/enable.sh
+++ b/server/selinux/server/enable.sh
@@ -34,12 +34,4 @@ boolean -m --on httpd_can_network_connect
 boolean -m --on httpd_tmp_exec
 _EOF
 
-    semanage port -l | grep amqp_port_t | grep tcp | grep 5672 > /dev/null || \
-        /usr/sbin/semanage port -a -t amqp_port_t -p tcp 5672
-    semanage port -l | grep amqp_port_t | grep udp | grep 5672 > /dev/null || \
-        /usr/sbin/semanage port -a -t amqp_port_t -p udp 5672
-    semanage port -l | grep amqp_port_t | grep tcp | grep 5671 > /dev/null || \
-        /usr/sbin/semanage port -a -t amqp_port_t -p tcp 5671
-    semanage port -l | grep amqp_port_t | grep udp | grep 5671 > /dev/null || \
-        /usr/sbin/semanage port -a -t amqp_port_t -p udp 5671
 fi


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1136919

The way to speed this up is to remove these unnecessary statements. It took me a while to convince myself they are unecessary across all platforms, but I'm convinced.

The default selinux policy defines the amqp_type_t and specifies the same ports and protocol types. These ports and protocol types are defined in the AMQP standard.

I convinced myself of this in a few ways:
- I opened some EL 6.0 6.5 and 7.0 SRC RPMs of selinux-policy and built them with `rpmbuild -bp selinux.....` and then grepped for amqp. You'll find a line similar to below as part of a patch. This line is also present in the other SRC rpms I looked at.

`./policy-F13.patch:+network_port(amqp, tcp,5671,s0, udp,5671,s0,tcp,5672,s0, udp,5672,s0)`
- I started a vanilla EL6.0 box on beaker and installed the selinux-policy RPM then ran `sudo semanage port -l` and observed that all of the amqp 5672/5671 tcp/udp definition were there without any pulp policy introducing them.
- Finally I looked through the fedora 19 base selinux policy and observed that are included in base (not as a patch). A similar line to the network_port line from above.
