### PR TITLE
1119744 - Bumps qpid-server release to qpid-cpp.0.26-9 which should fix this bug

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -4,7 +4,7 @@
         "platform": ["el6"]
     },
     "qpid-cpp": {
-        "version": "0.26-8",
+        "version": "0.26-9",
         "platform": ["el6"]
     },
     "qpid-qmf": {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1119744

This was fixed upstream supposedly with release 9. The [comment on upstream](https://issues.apache.org/jira/browse/QPID-5900?focusedCommentId=14063976&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14063976) includes output that is convincing.
