### PR TITLE
support shared storage in orphan purge.

### DIFF
--- a/server/pulp/server/managers/content/orphan.py
+++ b/server/pulp/server/managers/content/orphan.py
@@ -319,10 +319,10 @@ class OrphanManager(object):
         :type path: str
         """
         try:
-            if os.path.isdir(path):
-                shutil.rmtree(path)
-            else:
+            if os.path.isfile(path) or os.path.islink(path):
                 os.unlink(path)
+            else:
+                shutil.rmtree(path)
         except OSError, e:
             logger.error(_('Delete path: %(p)s failed: %(m)s'), {'p': path, 'm': str(e)})
 

--- a/server/test/unit/test_content_orphan_manager.py
+++ b/server/test/unit/test_content_orphan_manager.py
@@ -291,34 +291,54 @@ class OrphanManagerGeneratorTests(OrphanManagerTests):
 
 class TestDelete(TestCase):
 
-
     @patch('shutil.rmtree')
     @patch('os.unlink')
-    @patch('os.path.isdir')
-    def test_delete_dir(self, is_dir, unlink, rmtree):
+    @patch('os.path.islink')
+    @patch('os.path.isfile')
+    def test_delete_dir(self, is_file, is_link, unlink, rmtree):
         path = 'path-1'
-        is_dir.return_value = True
+        is_file.return_value = False
+        is_link.return_value = False
 
         # test
         OrphanManager.delete(path)
 
         # validation
-        is_dir.assert_called_with(path)
+        is_file.assert_called_with(path)
+        is_link.assert_called_with(path)
         rmtree.assert_called_with(path)
         self.assertFalse(unlink.called)
 
     @patch('shutil.rmtree')
     @patch('os.unlink')
-    @patch('os.path.isdir')
-    def test_delete_file(self, is_dir, unlink, rmtree):
+    @patch('os.path.isfile')
+    def test_delete_file(self, is_file, unlink, rmtree):
         path = 'path-1'
-        is_dir.return_value = False
+        is_file.return_value = True
 
         # test
         OrphanManager.delete(path)
 
         # validation
-        is_dir.assert_called_with(path)
+        is_file.assert_called_with(path)
+        unlink.assert_called_with(path)
+        self.assertFalse(rmtree.called)
+
+    @patch('shutil.rmtree')
+    @patch('os.unlink')
+    @patch('os.path.islink')
+    @patch('os.path.isfile')
+    def test_delete_link(self, is_file, is_link, unlink, rmtree):
+        path = 'path-1'
+        is_file.return_value = False
+        is_link.return_value = True
+
+        # test
+        OrphanManager.delete(path)
+
+        # validation
+        is_file.assert_called_with(path)
+        is_link.assert_called_with(path)
         unlink.assert_called_with(path)
         self.assertFalse(rmtree.called)
 


### PR DESCRIPTION
The orphan purge needs to be updated to support a newly introduced pattern to support units with shared storage.  In this context, this is NOT Amazon S3 or GridFS.  This simply means that there are units with a storage_path that is a link to the same (file|directory).  the directory structure looks like this:

```
-- content/
         | -- shared/
                   | <thing>/
                           | -- content/
                           | -- links/
                                   | --- linkA --> ../content
                                   | --- linkB --> ../content
```

When all of the links are gone, the link target (../content) can be cleaned up.

The ostree units use the shared storage model like this:

```
-- content/
         | -- shared/
                   | -- <remote_id>/
                                 | -- content/<big-ostree-repository>
                                 | -- links/
                                        | --- snapshotA ---> /var/lib/pulp/content/shared/<remote-id>/content/
                                        | --- snapshotB ---> /var/lib/pulp/content/shared/<remote-id>/content/
```

We need the orphan unit purge logic to support this as follows.  When storage_path points into pulp's content/shared/\* it needs to:
- remove the link
- remove the link target (content) when there are no more links.
