### PR TITLE
1145723 - log worker startup/shutdown messages in Celery logs

### DIFF
--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -263,12 +263,25 @@ start_beat () {
                 --pidfile="$CELERYBEAT_PID_FILE"
 }
 
+# this function implements the fix for bz #1145723
+write_log_message () {
+  echo -n `date "+%Y-%m-%d %T"` >> $CELERYBEAT_LOG_FILE
+  echo " $1" >> $CELERYBEAT_LOG_FILE
+  # it is possible that we are the first to touch this file. If so, fix
+  # permissions.
+  chown $CELERYD_USER $CELERYBEAT_LOG_FILE
+}
+
 
 
 case "$1" in
     start)
         check_dev_null
         check_paths
+        write_log_message "**********************************************************"
+        write_log_message "* Celerybeat startup requested. After startup is         *"
+        write_log_message "* complete, messages will be logged to /var/log/messages.*"
+        write_log_message "**********************************************************"
         start_beat
     ;;
     stop)

--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -229,6 +229,24 @@ _chuid () {
     su - "$CELERYD_USER" -s /bin/sh -c "$CELERYD_MULTI $*"
 }
 
+# this function implements the fix for bz #1145723
+write_log_message () {
+  if [ $PULP_CONCURRENCY -ge 1 ]; then
+    for i in "${CELERYD_NODES_ARRAY[@]}"
+    do
+      local log_file="`dirname $CELERYD_LOG_FILE`/${i}.log"
+      echo -n `date "+%Y-%m-%d %T"` >> $log_file
+      echo " $1" >> $log_file
+    done
+  else
+    local log_file="`dirname $CELERYD_LOG_FILE`/${CELERYD_NODES}.log"
+    echo -n `date "+%Y-%m-%d %T"` >> $log_file
+    echo " $1" >> $log_file
+  fi
+  # it is possible that we are the first to touch this file. If so, fix
+  # permissions.
+  chown $CELERYD_USER $log_file
+}
 
 start_workers () {
     if [ ! -z "$CELERYD_ULIMIT" ]; then
@@ -324,6 +342,10 @@ case "$1" in
     start)
         check_dev_null
         check_paths
+        write_log_message "********************************************************"
+        write_log_message "* Celery startup requested. After startup is complete, *"
+        write_log_message "* messages will be logged to /var/log/messages.        *"
+        write_log_message "********************************************************"
         start_workers
     ;;
 


### PR DESCRIPTION
On RHEL6, Pulp's init.d scripts invoke celery in a way that creates log files
under `/var/log/pulp/` that are not used during normal operation. This causes
confusion for users since they think the logs are going to be there instead of
to `/var/log/messages`.

The init.d scripts have been modified to print startup/shutdown messages in
these logs, and direct users to `/var/log/messages` for more information.

I did not add "startup" to the log filenames in case a user is already
collecting logs from their existing locations.
