### PR TITLE
1145701 - bump release to allow a koji rebuild

### DIFF
--- a/deps/mod_wsgi/mod_wsgi.spec
+++ b/deps/mod_wsgi/mod_wsgi.spec
@@ -1,6 +1,6 @@
 Name:           mod_wsgi
 Version:        3.4
-Release:        1.pulp%{?dist}
+Release:        2.pulp%{?dist}
 Summary:        A WSGI interface for Python web applications in Apache
 
 Group:          System Environment/Libraries


### PR DESCRIPTION
The mod_wsgi package was built for "katello-thirdparty-pulp-rhel6" and then
tagged over. However, that build target was only configured to build for
x86_64.

I need to bump the release field in order to rebuild on pulp-2.5-testing-rhel6,
which has x86_64 and i686 arches.
