### PR TITLE
1145734 - more correct error message when apache fails

### DIFF
--- a/client_lib/pulp/client/extensions/exceptions.py
+++ b/client_lib/pulp/client/extensions/exceptions.py
@@ -405,11 +405,11 @@ class ExceptionHandler:
 
         self._log_client_exception(e)
 
-        msg = _('The web server reported an error trying to access the '
-                'Pulp application. The likely cause is that the pulp-manage-db '
-                'script has not been run prior to starting the server. '
-                'More information can be found in Apache\'s error log file '
-                'on the server itself.')
+        msg = _('There was an internal server error while trying to '
+                'access the Pulp application. One possible cause is that '
+                'the database needs to be migrated to the latest version. If '
+                'this is the case, run pulp-manage-db and restart the services.'
+                ' More information may be found in Apache\'s log.')
 
         self.prompt.render_failure_message(msg)
         return CODE_APACHE_SERVER_EXCEPTION


### PR DESCRIPTION
[BZ-1145734](https://bugzilla.redhat.com/show_bug.cgi?id=1145734) 

Suggesting that the user should run `pulp-manage-db` is often accurate but it can be a confusing message if the error is unrelated. New message provides context so the user will know if they need to run `pulp-manage-db`.
