### PR TITLE
US3018 - Adjusts cancel methods in base plugin classes to exit immediately

### DIFF
--- a/docs/user-guide/release-notes/master.rst
+++ b/docs/user-guide/release-notes/master.rst
@@ -11,6 +11,18 @@ New Features
 Deprecation
 -----------
 
+ * The ``cancel_publish_repo`` method provided by the ``Distributor`` base plugin class is
+   deprecated and will be removed in a future release. Read more about the
+   :ref:`plugin cancellation changes <plugin_cancel_now_exits_behavior_change>`.
+
+ * The ``cancel_publish_group`` method provided by the ``GroupDistributor`` base plugin class is
+   deprecated and will be removed in a future release. Read more about the
+   :ref:`plugin cancellation changes <plugin_cancel_now_exits_behavior_change>`.
+
+ * The ``cancel_sync_repo`` method provided by the ``Importer`` base plugin class is deprecated and
+   will be removed in a future release. Read more about the
+   :ref:`plugin cancellation changes <plugin_cancel_now_exits_behavior_change>`.
+
 Client Changes
 --------------
 
@@ -36,3 +48,28 @@ Binding API Changes
 
 Plugin API Changes
 ------------------
+
+.. _plugin_cancel_now_exits_behavior_change:
+
+**Cancel Exits Immediately by Default**
+
+    The ``cancel_publish_repo``, ``cancel_publish_group``, and ``cancel_sync_repo`` methods
+    provided by the ``Distributor``, ``GroupDistributor``, and ``Importer`` base plugin classes now
+    provide a behavior that exits immediately by default. Previously these methods raised a
+    NotImplementedError() which required plugin authors to provide an implementation for these
+    methods. These methods will be removed in a future version of Pulp, and all plugins will be
+    required to adopt the exit-immediately behavior.
+
+    A cancel can occur at any time, which mean that in a future version of Pulp any part of plugin
+    code can have its execution interrupted at any time. For this reason, the following
+    recommendations should be adopted by plugin authors going forward in preparation for this
+    future change:
+
+     * Group together multiple database calls that need to occur together for database consistency.
+
+     * Do not use subprocess. If your plugin code process gets cancelled it could leave orphaned
+       processes.
+
+     * Assume that plugin code which is supposed to run later may not run.
+
+     * Assume that the previous executions of plugin code may not have run to completion.

--- a/server/pulp/plugins/distributor.py
+++ b/server/pulp/plugins/distributor.py
@@ -11,6 +11,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+import sys
+
 
 class Distributor(object):
     """
@@ -152,8 +154,12 @@ class Distributor(object):
     def cancel_publish_repo(self):
         """
         Call cancellation control hook.
+
+        This call provides an exit-immediately behavior, and does not provide any cleanup.
+
+        :raise SystemExit: raised through a call to sys.exit()
         """
-        raise NotImplementedError()
+        sys.exit()
 
     def create_consumer_payload(self, repo, config, binding_config):
         """
@@ -321,9 +327,13 @@ class GroupDistributor(object):
         """
         Call cancellation control hook.
 
-        @param call_request: call request for the call to cancel
-        @type call_request: CallRequest
-        @param call_report: call report for the call to cancel
-        @type call_report: CallReport
+        This call provides an exit-immediately behavior, and does not provide any cleanup.
+
+        :param call_request: call request for the call to cancel
+        :type call_request: CallRequest
+        :param call_report: call report for the call to cancel
+        :type call_report: CallReport
+
+        :raise SystemExit: raised through a call to sys.exit()
         """
-        raise NotImplementedError()
+        sys.exit()

--- a/server/pulp/plugins/importer.py
+++ b/server/pulp/plugins/importer.py
@@ -11,6 +11,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+import sys
+
 
 class Importer(object):
     """
@@ -280,13 +282,11 @@ class Importer(object):
         """
         Cancels an in-progress sync.
 
-        This call is responsible for halting a current sync by stopping any
-        in-progress downloads and performing any cleanup necessary to get the
-        system back into a stable state.
+        This call provides an exit-immediately behavior, and does not provide any cleanup.
 
-        :raise NotImplementedError: if this method is not overridden
+        :raise SystemExit: raised through a call to sys.exit()
         """
-        raise NotImplementedError()
+        sys.exit()
 
     def resolve_dependencies(self, repo, units, dependency_conduit, config):
         """

--- a/server/test/unit/plugins/test_distributor.py
+++ b/server/test/unit/plugins/test_distributor.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import mock
+
+from pulp.plugins.distributor import Distributor, GroupDistributor
+
+
+class TestDistributor(unittest.TestCase):
+
+    @mock.patch('pulp.plugins.distributor.sys.exit', autospec=True)
+    def test_cancel_publish_repo_calls_sys_exit(self, mock_sys_exit):
+        Distributor().cancel_publish_repo()
+        mock_sys_exit.assert_called_once_with()
+
+
+class TestGroupDistributor(unittest.TestCase):
+
+    @mock.patch('pulp.plugins.distributor.sys.exit', autospec=True)
+    def test_cancel_publish_group_calls_sys_exit(self, mock_sys_exit):
+        GroupDistributor().cancel_publish_group(mock.Mock(), mock.Mock())
+        mock_sys_exit.assert_called_once_with()

--- a/server/test/unit/plugins/test_importer.py
+++ b/server/test/unit/plugins/test_importer.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import mock
+
+from pulp.plugins.importer import Importer
+
+
+class TestImporter(unittest.TestCase):
+
+    @mock.patch('pulp.plugins.importer.sys.exit', autospec=True)
+    def test_cancel_sync_repo_calls_sys_exit(self, mock_sys_exit):
+        Importer().cancel_sync_repo()
+        mock_sys_exit.assert_called_once_with()


### PR DESCRIPTION
https://rally1.rallydev.com/#/7675694122d/detail/userstory/23288232616

This PR adjusts three methods in the base plugin classes provided by platform: cancel_publish_group, cancel_publish_repo, and cancel_sync_repo. They used to raise NotImplementedError exceptions, but we are changing the default behavior to exit immediately. I also added tests because there were none for those methods. I've added a pretty verbose release note about this also.
