### PR TITLE
Report number of catalog entries deleted

### DIFF
--- a/bindings/pulp/bindings/content.py
+++ b/bindings/pulp/bindings/content.py
@@ -118,5 +118,5 @@ class ContentCatalogAPI(PulpAPI):
         :return: The response.
         :rtype: pulp.bindings.responses.Response
         """
-        path = '%s%s' % (self.BASE_URL, source_id)
-        self.server.DELETE(path)
+        path = '%s%s/' % (self.BASE_URL, source_id)
+        return self.server.DELETE(path)

--- a/bindings/test/unit/test_content.py
+++ b/bindings/test/unit/test_content.py
@@ -129,5 +129,6 @@ class TestCatalog(unittest.TestCase):
         body = api.delete(source_id)
 
         # validation
-        path = '%s%s' % (ContentCatalogAPI.BASE_URL, source_id)
+        path = '%s%s/' % (ContentCatalogAPI.BASE_URL, source_id)
         connection.DELETE.assert_called_once_with(path)
+        self.assertEqual(body, connection.DELETE.return_value)

--- a/client_admin/pulp/client/admin/content.py
+++ b/client_admin/pulp/client/admin/content.py
@@ -102,6 +102,8 @@ class CatalogDeleteCommand(PulpCliCommand):
     NAME = 'delete'
     DESCRIPTION = _('delete entries from the catalog')
     SOURCE_ID_OPTION = PulpCliOption('--source-id', _('contributing content source'), aliases='-s')
+    DELETED_MSG = _('Successfully deleted [%(deleted)s] catalog entries.')
+    NONE_MATCHED_MSG = _('No catalog entries matched.')
 
     def __init__(self, context):
         """
@@ -121,4 +123,8 @@ class CatalogDeleteCommand(PulpCliCommand):
         :type kwargs: dict
         """
         source_id = kwargs[self.SOURCE_ID_OPTION.keyword]
-        self.context.server.content_catalog.delete(source_id)
+        response = self.context.server.content_catalog.delete(source_id)
+        if response.response_body['deleted']:
+            self.context.prompt.render_success_message(self.DELETED_MSG % response.response_body)
+        else:
+            self.context.prompt.render_success_message(self.NONE_MATCHED_MSG)

--- a/client_admin/test/unit/test_content.py
+++ b/client_admin/test/unit/test_content.py
@@ -87,6 +87,8 @@ class TestCatalogDeleteCommand(TestCase):
     def test_run(self):
         source_id = 'content-world'
         context = Mock()
+        response = Mock(response_code=200, response_body={'deleted': 10})
+        context.server.content_catalog.delete.return_value = response
 
         # test
         command = CatalogDeleteCommand(context)
@@ -94,4 +96,22 @@ class TestCatalogDeleteCommand(TestCase):
         command._run(**kwargs)
 
         # validation
+        msg = 'Successfully deleted [10] catalog entries.'
         context.server.content_catalog.delete.assert_called_once_with(source_id)
+        context.prompt.render_success_message.assert_called_once_with(msg)
+
+    def test_run_nothing_matched(self):
+        source_id = 'content-world'
+        context = Mock()
+        response = Mock(response_code=200, response_body={'deleted': 0})
+        context.server.content_catalog.delete.return_value = response
+
+        # test
+        command = CatalogDeleteCommand(context)
+        kwargs = {CatalogDeleteCommand.SOURCE_ID_OPTION.keyword: source_id}
+        command._run(**kwargs)
+
+        # validation
+        msg = 'No catalog entries matched.'
+        context.server.content_catalog.delete.assert_called_once_with(source_id)
+        context.prompt.render_success_message.assert_called_once_with(msg)

--- a/docs/sphinx/dev-guide/integration/rest-api/content/catalog.rst
+++ b/docs/sphinx/dev-guide/integration/rest-api/content/catalog.rst
@@ -16,6 +16,12 @@ Delete entries from the catalog by content source by ID.
 | :param_list:`delete` None
 | :response_list:`_`
 
-* :response_code:`200,if the entries were successfully deleted from the catalog`
+* :response_code:`200,even if no entries matched and deleted`
 
-| :return:`None`
+| :return:`A summary of entries deleted`
+
+:sample_response:`200` ::
+
+ {"deleted": 10}
+
+

--- a/docs/sphinx/user-guide/content-sources.rst
+++ b/docs/sphinx/user-guide/content-sources.rst
@@ -106,6 +106,7 @@ The pulp-admin client can be used to delete entries contributed by specific cont
 sources as follows::
 
   $ pulp-admin content catalog delete -s content-world
+  Successfully deleted [10] catalog entries.
 
 
 

--- a/docs/sphinx/user-guide/release-notes/2.5.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.5.x.rst
@@ -22,6 +22,10 @@ Rest API Changes
   named `queue`. The `queue` attribute now correctly records the queue a task is put in. The
   `queue` attribute is deprecated and will be removed from the `Task Report` in Pulp 3.0.0.
 
+* The URL for the content catalog entries ``/v2/content/catalog/<source-id>`` is missing
+  the trailing '/' and has been deprecated. Support for the URL ``/v2/content/catalog/<source-id>/``
+  has been added.
+
 .. _2.5.0_upgrade_to_2.5.1:
 
 Upgrade Instructions for 2.5.0 --> 2.5.1

--- a/server/pulp/server/webservices/controllers/contents.py
+++ b/server/pulp/server/webservices/controllers/contents.py
@@ -334,8 +334,9 @@ class CatalogResource(JSONController):
     @auth_required(DELETE)
     def DELETE(self, source_id):
         manager = factory.content_catalog_manager()
-        manager.purge(source_id)
-        return self.ok(None)
+        purged = manager.purge(source_id)
+        deleted = dict(deleted=purged)
+        return self.ok(deleted)
 
 
 class ContentSourceCollection(JSONController):
@@ -390,7 +391,8 @@ _URLS = ('/types/$', ContentTypesCollection,
          '/orphans/([^/]+)/$', OrphanTypeSubCollection,
          '/orphans/([^/]+)/([^/]+)/$', OrphanResource,
          '/actions/delete_orphans/$', DeleteOrphansAction,  # deprecated in 2.4
-         '/catalog/([^/]+)$', CatalogResource,
+         '/catalog/([^/]+)$', CatalogResource,  # deprecated in 2.5, missing trailing '/'
+         '/catalog/([^/]+)/$', CatalogResource,
          '/sources/$', ContentSourceCollection,
          '/sources/([^/]+)/$', ContentSourceResource,)
 

--- a/server/test/unit/server/webservices/controllers/test_contents.py
+++ b/server/test/unit/server/webservices/controllers/test_contents.py
@@ -53,13 +53,15 @@ class CatalogTests(base.PulpWebserviceTests):
     @patch('pulp.server.managers.content.catalog.ContentCatalogManager.purge')
     def test_delete(self, mock_purge):
         source_id = 'test-source'
+        mock_purge.return_value = 10
 
         # test
-        url = '/v2/content/catalog/%s' % source_id
+        url = '/v2/content/catalog/%s/' % source_id
         status, body = self.delete(url)
 
         # validation
         self.assertEqual(status, 200)
+        self.assertEqual(body, {'deleted': 10})
         mock_purge.assert_called_with(source_id)
 
 

--- a/server/test/unit/test_content_catalog_manager.py
+++ b/server/test/unit/test_content_catalog_manager.py
@@ -103,7 +103,8 @@ class TestCatalogManager(PulpServerTests):
         collection = ContentCatalog.get_collection()
         self.assertEqual(20, collection.find().count())
         manager = ContentCatalogManager()
-        manager.purge(source_a)
+        purged = manager.purge(source_a)
+        self.assertEqual(purged, 10)
         self.assertEqual(collection.find({'source_id': source_a}).count(), 0)
         self.assertEqual(collection.find({'source_id': source_b}).count(), 10)
 
@@ -140,7 +141,8 @@ class TestCatalogManager(PulpServerTests):
         collection = ContentCatalog.get_collection()
         self.assertEqual(20, collection.find().count())
         manager = ContentCatalogManager()
-        manager.purge_expired(0)
+        purged = manager.purge_expired(0)
+        self.assertEqual(purged, 10)
         self.assertEqual(collection.find({'source_id': source_a}).count(), 10)
         self.assertEqual(collection.find({'source_id': source_b}).count(), 0)
 
@@ -155,7 +157,8 @@ class TestCatalogManager(PulpServerTests):
         collection = ContentCatalog.get_collection()
         self.assertEqual(20, collection.find().count())
         manager = ContentCatalogManager()
-        manager.purge_orphans([source_b])
+        purged = manager.purge_orphans([source_b])
+        self.assertEqual(purged, 10)
         self.assertEqual(collection.find({'source_id': source_a}).count(), 0)
         self.assertEqual(collection.find({'source_id': source_b}).count(), 10)
 


### PR DESCRIPTION
This is a follow on to work already merged to 2.5-dev.  During testing, it seemed wrong for the admin command for deleting catalog entries did not display feedback.  

This includes:
- Updating the manager to return the number of entries deleted.
- Updating the controller to return the information.
- Updating the binding to return the information
- Update the command to display the information.

While doing this, noticed and fixed the content catalog URL (missing trailing `/` ).  Added support for the correct URL and deprecated the existing one.
