### PR TITLE
1135589 - move PRIMARY_ID definition

### DIFF
--- a/common/pulp/common/constants.py
+++ b/common/pulp/common/constants.py
@@ -50,3 +50,9 @@ CALL_INCOMPLETE_STATES = (CALL_WAITING_STATE, CALL_ACCEPTED_STATE, CALL_RUNNING_
                           CALL_SUSPENDED_STATE)
 CALL_COMPLETE_STATES = (CALL_SKIPPED_STATE, CALL_FINISHED_STATE, CALL_ERROR_STATE,
                         CALL_CANCELED_STATE, CALL_TIMED_OUT_STATE)
+
+# this constant is used to determine which content source is the primary
+# source, vs an alternate source.  Note that this field will go away in Pulp
+# 3.0 as part of https://bugzilla.redhat.com/show_bug.cgi?id=1160410
+
+PRIMARY_ID = '___/primary/___'

--- a/nodes/extensions/admin/pulp_node/extensions/admin/rendering.py
+++ b/nodes/extensions/admin/pulp_node/extensions/admin/rendering.py
@@ -12,7 +12,7 @@
 from gettext import gettext as _
 from operator import itemgetter
 
-from pulp.server.content.sources.model import PRIMARY_ID
+from pulp.common.constants import PRIMARY_ID
 
 from pulp_node.error import *
 from pulp_node.reports import RepositoryProgress, RepositoryReport

--- a/nodes/test/unit/test_admin_extensions.py
+++ b/nodes/test/unit/test_admin_extensions.py
@@ -19,7 +19,8 @@ from base import ClientTests, Response, Task
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)) + "/../../child")
 
 from pulp.agent.lib.report import ContentReport
-from pulp.server.content.sources.model import DownloadReport, DownloadDetails, PRIMARY_ID
+from pulp.common.constants import PRIMARY_ID
+from pulp.server.content.sources.model import DownloadReport, DownloadDetails
 
 from pulp_node.extensions.admin.commands import *
 from pulp_node.extensions.admin.rendering import ProgressTracker

--- a/server/pulp/server/content/sources/model.py
+++ b/server/pulp/server/content/sources/model.py
@@ -17,12 +17,12 @@ from urlparse import urljoin
 from logging import getLogger
 from ConfigParser import ConfigParser
 
-from pulp.server.managers import factory as managers
-from pulp.plugins.loader import api as plugins
+from pulp.common.constants import PRIMARY_ID
 from pulp.plugins.conduits.cataloger import CatalogerConduit
-
+from pulp.plugins.loader import api as plugins
 from pulp.server.content.sources import constants
 from pulp.server.content.sources.descriptor import is_valid, to_seconds, DEFAULT
+from pulp.server.managers import factory as managers
 
 
 log = getLogger(__name__)
@@ -34,8 +34,6 @@ PATHS_REGEX = re.compile(r'\s+')
 REFRESHING = 'Refreshing [%s] url:%s'
 REFRESH_SUCCEEDED = 'Refresh [%s] succeeded.  Added: %d, Deleted: %d'
 REFRESH_FAILED = 'Refresh [%s] url: %s, failed: %s'
-
-PRIMARY_ID = '___/primary/___'
 
 
 class Request(object):

--- a/server/test/functional/test_content_sources.py
+++ b/server/test/functional/test_content_sources.py
@@ -23,13 +23,13 @@ from nectar.config import DownloaderConfig
 from nectar.downloaders.local import LocalFileDownloader
 from nectar.downloaders.threaded import HTTPThreadedDownloader
 
+from pulp.common.constants import PRIMARY_ID
 from pulp.plugins.loader import api as plugins
 from pulp.plugins.conduits.cataloger import CatalogerConduit
 from pulp.server.db import connection
 from pulp.server.db.model.content import ContentCatalog
 from pulp.server.content.sources import ContentContainer, Request, ContentSource, Listener
 from pulp.server.content.sources.descriptor import nectar_config
-from pulp.server.content.sources.model import PRIMARY_ID
 from pulp.server.managers import factory as managers
 
 

--- a/server/test/unit/server/content/sources/test_model.py
+++ b/server/test/unit/server/content/sources/test_model.py
@@ -14,10 +14,11 @@ import sys
 from unittest import TestCase
 from mock import patch, Mock
 
+from pulp.common.constants import PRIMARY_ID
 from pulp.plugins.conduits.cataloger import CatalogerConduit
 from pulp.server.content.sources import constants
 from pulp.server.content.sources.model import Request, PrimarySource, ContentSource, RefreshReport
-from pulp.server.content.sources.model import PRIMARY_ID, DownloadDetails, DownloadReport
+from pulp.server.content.sources.model import DownloadDetails, DownloadReport
 from pulp.server.content.sources.descriptor import DEFAULT
 
 TYPE = '1234'


### PR DESCRIPTION
The PRIMARY_ID constant was defined in model.py which also attempted to read
`server.conf` for database connection info. This meant that pulp-admin required
access to `server.conf`.

I moved PRIMARY_ID to pulp.common.constants so it can be imported without
pulling in other code.
