### PR TITLE
1159067 - Read user cred from config

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -85,3 +85,18 @@
 # enable_color: true
 # wrap_to_terminal: false
 # wrap_width: 80
+
+
+# Client authentication
+#
+# This enables the user to run pulp-admin commands without providing a username
+# and password using the command line
+#
+# username:
+#   pulp username
+# password:
+#   pulp user's password
+
+[auth]
+#username: admin
+#password: admin

--- a/client_admin/pulp/client/admin/config.py
+++ b/client_admin/pulp/client/admin/config.py
@@ -42,6 +42,10 @@ DEFAULT = {
         'wrap_to_terminal': 'false',
         'wrap_width': '80',
     },
+    'auth': {
+        'username': 'admin',
+        'password': 'admin',
+    },
 }
 
 
@@ -81,6 +85,12 @@ SCHEMA = (
             ('enable_color', REQUIRED, BOOL),
             ('wrap_to_terminal', REQUIRED, BOOL),
             ('wrap_width', REQUIRED, NUMBER)
+        )
+    ),
+    ('auth', REQUIRED,
+        (
+            ('username', OPTIONAL, ANY),
+            ('password', OPTIONAL, ANY),
         )
     ),
 )

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -35,9 +35,12 @@ def main(config, exception_handler_class=ExceptionHandler):
     parser = OptionParser()
     parser.disable_interspersed_args()
     parser.add_option('-u', '--username', dest='username', action='store', default=None,
-                      help=_('credentials for the Pulp server; if specified will bypass the stored certificate'))
+                      help=_('username for the Pulp server; if used will bypass the stored '
+                             'certificate and override config file values and the default'))
     parser.add_option('-p', '--password', dest='password', action='store', default=None,
-                      help=_('credentials for the Pulp server; must be specified with --username'))
+                      help=_('password for the Pulp server; must be used with --username. '
+                             'if used will bypass the stored certificate and override config '
+                             'file values and the default'))
     parser.add_option('--debug', dest='debug', action='store_true', default=False,
                       help=_('enables debug logging'))
     parser.add_option('--config', dest='config', default=None,
@@ -59,6 +62,12 @@ def main(config, exception_handler_class=ExceptionHandler):
     # REST Bindings
     username = options.username
     password = options.password
+
+    # get username/password from config ~/.pulp/admin.conf if available
+    if not username and not password:
+        username = config['auth']['username']
+        password = config['auth']['password']
+
     if username and not password:
         prompt_msg = 'Enter password: '
         password = prompt.prompt_password(_(prompt_msg))

--- a/docs/user-guide/admin-client/authentication.rst
+++ b/docs/user-guide/admin-client/authentication.rst
@@ -10,20 +10,51 @@ All pulp-admin commands accept username and password to capture authentication c
 
 ::
 
-	$ pulp-admin --help
-	Usage: pulp-admin [options]
+    $ pulp-admin --help
+    Usage: pulp-admin [options]
 
-	Options:
-	-h, --help	            show this help message and exit
-	-u USERNAME, --username=USERNAME
-		                    credentials for the Pulp server; if specified will
-	    	                bypass the stored certificate
-	-p PASSWORD, --password=PASSWORD
-		                    credentials for the Pulp server; must be specified
-	    	                with --username
-	--debug	        	    enables debug logging
-	--config=CONFIG	        absolute path to the configuration file
-	--map                   prints a map of the CLI sections and commands
+    Options:
+      -h, --help            show this help message and exit
+      -u USERNAME, --username=USERNAME
+                            username for the Pulp server; if used will bypass the
+                            stored certificate and override config file values and
+                            the default
+      -p PASSWORD, --password=PASSWORD
+                            password for the Pulp server; must be used with
+                            --username. if used will bypass the stored certificate
+                            and override config file values and the default
+      --debug               enables debug logging
+      --config=CONFIG       absolute path to the configuration file
+      --map                 prints a map of the CLI sections and commands
+
+
+Pulp Admin client allows the user to specify username and password credentials
+in the user's local admin.conf ``~/.pulp/admin.conf``. Using the conf file 
+avoids having to pass user credentials repeatedly using the command line.
+Also reading the password from a file that can only be read by certain users 
+is more secure because it cannot be shown by listing the system processes
+
+::
+
+    # The following snippet is from ~/.pulp/admin.conf
+
+    [auth]
+    username: admin
+    password: admin
+
+    # This enables the user to run pulp-admin commands without providing a username
+    # and password using the command line
+
+    $ pulp-admin repo list
+    +----------------------------------------------------------------------+
+                                  Repositories
+    +----------------------------------------------------------------------+
+
+
+pulp-admin finds username and password credentials in the following order.
+    - credentials specified from the command line.
+    - credentials set in user's ``~/.pulp/admin.conf``.
+    - default credentials used by Pulp
 
 Pulp Server installation comes with one default user created with admin level privileges.
 Username and password for this user can be configured in ``/etc/pulp/server.conf`` at the time
@@ -34,11 +65,11 @@ running a pulp-admin command.
 
 ::
 
-	$ pulp-admin -u admin repo list
-	Enter password:
-	+----------------------------------------------------------------------+
-	                              Repositories
-	+----------------------------------------------------------------------+
+    $ pulp-admin -u admin repo list
+    Enter password:
+    +----------------------------------------------------------------------+
+                                  Repositories
+    +----------------------------------------------------------------------+
 
 
 Note that username and password are parameters to the ``pulp-admin`` command, not the sub-command,

--- a/docs/user-guide/release-notes/master.rst
+++ b/docs/user-guide/release-notes/master.rst
@@ -8,6 +8,10 @@ Pulp master
 New Features
 ------------
 
+- Pulp now allows user credentials to be read from user's ``~/.pulp/admin.conf``.
+  This should allow pulp-admin to be automated more easily and more securely.
+  Please see our :ref:`Authentication` documentation for details.
+
 Deprecation
 -----------
 


### PR DESCRIPTION
Bug 1159067 - [RFE] allow pulp to read user credentials from users admin.conf
if he/she does not want to provide password on command prompt
or --password in pulp-admin

this is basically for writing a batch job that would include multiple command lines together.
