### PR TITLE
Clarify tagging process and ressurect tag.sh for use with nonrelease builds

### DIFF
--- a/docs/dev-guide/contributing/building.rst
+++ b/docs/dev-guide/contributing/building.rst
@@ -37,12 +37,12 @@ and 2.4-release. For RHEL 7, these map to pulp-2.4-testing-rhel7, pulp-2.4-beta-
 pulp-2.4-rhel7, respectively. You can see the full list of Pulp's Koji tags
 `here <http://koji.katello.org/koji/search?match=glob&type=tag&terms=pulp*>`_.
 
-Another thing to know about Koji is that once a particular NEVRA is built in Koji, it cannot be
-built again. However, it can be tagged into multiple Koji tags. For example, if
-python-celery-3.1.11-1.el7.x86_64 is built into the pulp-2.4-beta-rhel7 tag and you wish to add
-that exact package in the pulp-2.4-rhel7 tag, you cannot build it again. Instead, you must tag that
-package for the new tag. You will see later on in this document that Pulp has a tool to help you do
-this.
+Another thing to know about Koji is that once a particular NEVRA (Name, Epoch, Version, Release,
+Architecture) is built in Koji, it cannot be built again. However, it can be tagged into multiple
+Koji tags. For example, if ``python-celery-3.1.11-1.el7.x86_64`` is built into the
+``pulp-2.4-beta-rhel7`` tag and you wish to add that exact package in the ``pulp-2.4-rhel7`` tag,
+you cannot build it again. Instead, you must tag that package for the new tag. You will see later
+on in this document that Pulp has a tool to help you do this.
 
 What you will need
 ^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ tag the git repository with your changes::
 
     $ tito tag --keep-version
 
-Pay attention to the output of tito here as well. It will instruct you to push you branch and the
+Pay attention to the output of tito here as well. It will instruct you to push your branch and the
 new tag to github.
 
 .. warning::
@@ -235,9 +235,32 @@ and your Koji username is ``cduryee``, you should do this::
 
     $ for x in pulp pulp-puppet pulp-rpm pulp-nodes; do koji -d add-pkg --owner "cduryee" pulp-2.5-beta-rhel7 $x; done
 
-Next it is time to raise the versions of the setup.py, conf.py, and spec files. Each Python package
-in each Pulp repository has a setup.py. Find each of these, and set its version appropriately. Do
-the same for the conf.py in the ``docs/`` folder for each repository.
+Next it is time to raise the version of the branches. This process is different depending on the
+stream you are building.
+
+.. note::
+
+   Pulp uses the release field in pre-release builds as a build number. The first pre-release build
+   will always be 0.1, and every build thereafter prior to the release will be the last release plus
+   0.1, even when switching from alpha to beta. For example, if we have build 7 2.5.0 alphas and it
+   is time for the first beta, we would be going from 2.5.0-0.7.alpha to 2.5.0-0.8.beta. We loosely
+   follow the
+   `Fedora Package Versioning Scheme <http://fedoraproject.org/wiki/Packaging:NamingGuidelines#Package_Versioning>`_.
+
+Beta, Testing, and Release Candidate Tagging
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+These streams can make use of the tagging bash script, ``tag.sh``. The script will ask you to edit
+the changelog entries, tag the git repositories, and push the tags to GitHub.
+
+For example, to tag 2.4.2-0.3.beta you can do this::
+
+    $ ./pulp/tag.sh -v 2.4.2-0.3.beta
+
+Release Tagging
+^^^^^^^^^^^^^^^
+For a release you will need to raise the versions of the setup.py, conf.py, and spec files. Each
+Python package in each Pulp repository has a setup.py. Find each of these, and set its version
+appropriately. Do the same for the conf.py in the ``docs/`` folder for each repository.
 
 .. note::
 
@@ -251,22 +274,18 @@ changelog entries for the last build in your release stream and group them into 
 you are building. This way we can avoid lots of entries for ``0.1.beta``, ``0.2.beta``, etc. that
 all have a bug or two (or none) each. If you are making a release, there should be no changelog
 entries for the pre-release builds included at all. Once you have done this, you can use tito to tag
-the repository for building::
+the repository for building. You will need to use tito in each of the directories that contain a
+spec file.::
 
     $ tito tag --keep-version --no-auto-changelog
 
-Pay attention to the output of tito, as you will need to push your changes to the upstream Pulp
+Pay attention to the instructions from tito, as you will need to push your changes to the upstream Pulp
 repository, as well as the tags that tito generated.
 
-.. note::
 
-   Pulp uses the release field in pre-release builds as a build number. The first pre-release build
-   will always be 0.1, and every build thereafter prior to the release will be the last release plus
-   0.1, even when switching from alpha to beta. For example, if we have build 7 2.5.0 alphas and it
-   is time for the first beta, we would be going from 2.5.0-0.7.alpha to 2.5.0-0.8.beta. We loosely
-   follow the
-   `Fedora Package Versioning Scheme <http://fedoraproject.org/wiki/Packaging:NamingGuidelines#Package_Versioning>`_.
 
+Submit to Koji
+^^^^^^^^^^^^^^
 We are now prepared to submit the build to Koji. This task is simple::
 
     $ ./builder.py <X.Y> <stream>

--- a/tag.sh
+++ b/tag.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+#
+# Tagging script
+#
+
+set -e  # exit on failed
+
+VERSION=
+BUILD_TAG=
+GIT="git"
+TITO="tito"
+TITO_TAG_FLAGS=
+BRANCH=
+PARENT='master'
+
+GIT_ROOTS="pulp pulp_rpm pulp_puppet"
+PACKAGES="
+  pulp/
+  pulp/nodes/
+  pulp_rpm/
+  pulp_puppet/"
+
+NEXT_VR_SCRIPT=\
+$(cat << END
+import sys
+sys.path.insert(0, 'rel-eng/lib')
+import tools
+print tools.next()
+END
+)
+
+set_version()
+{
+  pushd pulp
+  VERSION=`python -c "$NEXT_VR_SCRIPT"`
+  popd
+}
+
+tito_tag()
+{
+  # $1=<git-root>
+  pushd $1
+  $TITO tag $TITO_TAG_FLAGS && $GIT push origin HEAD && $GIT push --tags
+  popd
+}
+
+git_tag()
+{
+  # $1=<git-root>
+  pushd $1
+  $GIT tag -m "Build Tag" $BUILD_TAG && $GIT push --tags
+  popd
+}
+
+git_prep()
+{
+  verify_branch
+  for DIR in $GIT_ROOTS
+  do
+    pushd $DIR
+    echo "Preparing git in repository [$DIR] using [$BRANCH]"
+    if [ "$PARENT" != "$BRANCH" ]
+    then
+      $GIT checkout $BRANCH && $GIT pull --rebase
+      $GIT checkout $PARENT && $GIT pull --rebase
+      git_pre_tag_merge
+      $GIT checkout $BRANCH
+    else
+      $GIT checkout $BRANCH && $GIT pull --rebase
+    fi
+    popd
+  done
+}
+
+git_pre_tag_merge()
+{
+  commits=(`$GIT log $PARENT..$BRANCH`)
+  if [ ${#commits[@]} -gt 0 ]
+  then
+    echo "(pre-tag) Merging $BRANCH => $PARENT"
+    echo ""
+    $GIT log $PARENT..$BRANCH
+    echo ""
+    read -p "Continue [y|n]: " ANS
+    if [ $ANS = "y" ]
+    then
+      MESSAGE="Merge $BRANCH => $PARENT, pre-build"
+      $GIT merge -m "$MESSAGE" $BRANCH
+      $GIT push origin HEAD
+    else
+      exit 0
+    fi
+  fi
+}
+
+git_post_tag_merge()
+{
+  if [ "$PARENT" = "$BRANCH" ]
+  then
+    return
+  fi
+  for DIR in $GIT_ROOTS
+  do
+    echo "(post-tag) Merging (-s ours) $DIR $BRANCH => $PARENT"
+    pushd $DIR
+    $GIT checkout $PARENT
+    $GIT log $PARENT..$BRANCH
+    echo ""
+    read -p "Continue [y|n]: " ANS
+    if [ $ANS = "y" ]
+    then
+      MESSAGE="Merge (-s ours) $BRANCH => $PARENT, post-build"
+      $GIT merge -s ours -m "$MESSAGE" $BRANCH
+      $GIT push origin HEAD
+    fi
+    popd
+  done
+}
+
+verify_branch()
+{
+  for DIR in $GIT_ROOTS
+  do
+    pushd $DIR
+    $GIT fetch --tags
+    set +e
+    $GIT tag -l $BRANCH | grep $BRANCH >& /dev/null
+    if [ $? = 0 ]; then
+      echo "[$BRANCH] must be a branch."
+      exit 1
+    fi
+    set -e
+    popd
+  done
+}
+
+verify_version()
+{
+  set +e
+  echo $VERSION | grep -E "(alpha|beta)$"
+  if [ $? = 1 ]
+  then
+    echo ""
+    echo "WARNING: [$VERSION] does not contain (alpha|beta)."
+    read -p "Is this a STABLE build [y|n]: " ANS
+    if [ $ANS != "y" ]
+    then
+      exit 0
+    fi
+  fi
+  set -e
+}
+
+usage()
+{
+cat << EOF
+usage: $0 options
+
+This script tags all pulp projects
+
+OPTIONS:
+   -h      Show this message
+   -v      The pulp version and release. Eg: 2.3.0-1
+   -a      Auto accept the changelog
+   -b      Checkout the specified branch
+   -p      A parent branch. (default: master)
+EOF
+}
+
+while getopts "hav:b:p:" OPTION
+do
+  case $OPTION in
+    h)
+      usage
+      exit 1
+      ;;
+    v)
+      VERSION=$OPTARG
+      ;;
+    a)
+      TITO_TAG_FLAGS="$TITO_TAG_FLAGS --accept-auto-changelog"
+      ;;
+    b)
+      BRANCH=$OPTARG
+      ;;
+    p)
+      PARENT=$OPTARG
+      ;;
+    ?)
+      usage
+      exit
+      ;;
+  esac
+done
+
+# git (pre-tag) preparation
+if [[ -n $BRANCH ]]
+then
+  if [ "$BRANCH" = "$PARENT" ]
+  then
+    BRANCHES=$BRANCH
+  else
+    BRANCHES="$PARENT/$BRANCH"
+  fi
+  echo "Prepare git repositories using: [$BRANCHES]"
+  read -p "Continue [y|n]: " ANS
+  if [ $ANS = "y" ]
+  then
+    git_prep
+    echo ""
+    echo ""
+  fi
+fi
+
+# version based on main pulp project
+# unless specified using -v
+if [[ -z $VERSION ]]
+then
+  set_version
+fi
+
+# verify the version
+verify_version
+
+# confirmation
+echo ""
+echo ""
+echo "Using:"
+echo "  version [$VERSION]"
+echo "  tito options: $TITO_TAG_FLAGS"
+echo ""
+read -p "Continue [y|n]: " ANS
+if [ $ANS != "y" ]
+then
+  exit 0
+fi
+
+# used by tagger
+PULP_VERSION_AND_RELEASE=$VERSION
+export PULP_VERSION_AND_RELEASE
+
+BUILD_TAG="build-$VERSION"
+
+# tito tagging
+for PACKAGE in $PACKAGES
+do
+  tito_tag $PACKAGE
+done
+
+# git (correlated build) tagging
+for GIT_ROOT in $GIT_ROOTS
+do
+  git_tag $GIT_ROOT
+done
+
+# git (post-tag) merging
+if [[ -n $BRANCH ]]
+then
+  git_post_tag_merge
+fi
+


### PR DESCRIPTION
Tagging process differs between a release build and others. Docs now suggest using `tag.sh` to speed up tagging for all non release builds and doing it manually for releases. This allows the builder to combine the changelogs for all of the builds leading up to the release, similar to a git squash. The resulting changelogs are cleaner and the build process is fast for the majority of the builds.
