### PR TITLE
1127817 - return a 404 for consumer history request if consumer id does not exist

### DIFF
--- a/server/pulp/server/webservices/controllers/consumers.py
+++ b/server/pulp/server/webservices/controllers/consumers.py
@@ -440,7 +440,11 @@ class ConsumerHistory(JSONController):
                                                             sort=sort,
                                                             start_date=start_date,
                                                             end_date=end_date)
-        return self.ok(results)
+
+        if results:
+            return self.ok(results)
+        else:
+            return self.not_found()
 
 
 class Profiles(JSONController):


### PR DESCRIPTION
[BZ-1127817](https://bugzilla.redhat.com/show_bug.cgi?id=1127817)
