### PR TITLE
Clarify contribution expectations

### DIFF
--- a/docs/sphinx/dev-guide/contributing/branching.rst
+++ b/docs/sphinx/dev-guide/contributing/branching.rst
@@ -105,7 +105,7 @@ Cherry-picking and Rebasing
 
 Don't do it! Seriously though, this should not happen between release branches.
 It is a good idea (but not required) for a developer to rebase his or her
-development branch *before* submitting a pull request. Cherry-picking may also
+development branch *before* merging a pull request. Cherry-picking may also
 be valuable among development branches. However, master and release branches
 should not be involved in either.
 

--- a/docs/sphinx/dev-guide/contributing/index.rst
+++ b/docs/sphinx/dev-guide/contributing/index.rst
@@ -1,19 +1,39 @@
 How To Contribute
 =================
 
-There are three distinct types of contributions that this guide attempts to
-support. As such, there may be portions of this document that do not apply to
-your particular area of interest.
+The Pulp team loves community contributions! We would be happy to help get you 
+started and we offer constructive feedback on pull requests. If you would 
+like to contribute, please review the following things before you make 
+your pull request:
 
-**Existing Code**
-  Add new features or fix bugs in the platform or existing type support
-  projects.
-**New Type Support**
-  Create a new project that adds support for a new content type to Pulp.
-**Integration**
-  Integrate some other project with Pulp, especially by using the event system
-  and REST API.
+1. Make sure that you choose the appropriate upstream branch.
 
+   :doc:`Branching <branching>`
+
+2. Test your code. We ask that all new code has 100% coverage.
+
+   :doc:`Testing </policies/testing>`
+
+3. Please ensure that your code follows our style guide.
+
+   :doc:`Style Guide </policies/style>`
+
+4. Please make sure that any new features are documented and that changes are 
+   reflected in existing docs.
+
+   :doc:`Documentation <documenting>`
+
+5. Please squash your commits and use our commit message guidelines.
+
+   :ref:`rebasing-and-squashing`
+
+6. Make sure your name is in our AUTHORS file found at the root of each of our 
+   repositories. That way you can prove to all your friends that you 
+   contributed to Pulp!
+
+
+Developer Guide
+^^^^^^^^^^^^^^^
 
 .. toctree::
    :maxdepth: 3

--- a/docs/sphinx/dev-guide/contributing/merging.rst
+++ b/docs/sphinx/dev-guide/contributing/merging.rst
@@ -5,11 +5,8 @@ Pull Requests
 -------------
 
 You have some commits in a branch, and you're ready to merge. The Pulp Team makes
-use of pull requests for all but the most trivial contributions.
-
-Before you make a pull request, please make sure your name is in our AUTHORS file
-found at the root of each of our repositories. That way you can prove to all your
-friends that you contributed to Pulp.
+use of pull requests for all but the most trivial contributions. Please have a
+look at our :doc:`Contribution checklist <index>`.
 
 On the GitHub page for the repo where your development branch lives, there will be
 a "Pull Request" button. Click it. From there you will choose the source and
@@ -59,19 +56,33 @@ go in one of two directions:
    We are very open and honest when we review each other's work. We will do our
    best to review your contribution with respect and professionalism. In return,
    we hope you will accept our review process as an opportunity for everyone to
-   learn something, and to make Pulp the best product it can be.
+   learn something, and to make Pulp the best product it can be. If you are
+   uncertain about comments or instructions, please let us know!
 
+
+.. _rebasing-and-squashing:
 
 Rebasing and Squashing
 ----------------------
 
 Before you submit a pull request, consider an interactive rebase with some
-squashing. Do you have a dozen commits? Consider some squashing.
+squashing. We prefer each PR to contain a single commit. This offers some
+significant advantages:
 
-- Rebasing makes it more likely that your merge will be fast-forward only, which
-  helps avoid conflicts and has other advantages.
+- Squashing makes it more likely that your merge will be fast-forward only, which
+  helps avoid conflicts.
 - Nobody wants to see a your typo fixes in the commit log. Consider squashing
   trivial commits so that each commit you merge is as story-focused as possible.
+- The ``git commit --amend`` command is very useful, but be sure that you
+  `understand what it does <https://www.atlassian.com/git/tutorials/rewriting-history/git-commit--amend>`_
+  before you use it! GitHub will update the PR and keep the comments when you force
+  push an amended commit.
+- Rebasing makes cherry picking features and bug fixes much simpler.
+
+If this is not something that you are comfortable with, an excellent resource can be
+found here:
+
+`How to Rebase a Pull Request <https://github.com/edx/edx-platform/wiki/How-to-Rebase-a-Pull-Request>`_
 
 .. warning::
    Keep in mind that rebasing creates new commits that are unique from your

--- a/docs/sphinx/dev-guide/policies/style.rst
+++ b/docs/sphinx/dev-guide/policies/style.rst
@@ -45,22 +45,10 @@ Indentation
 4 spaces, never tabs
 
 
-Copyright
----------
+Encoding
+--------
 
-Use the UTF-8 copyright character and GPL 2, so each code file begins as such:
+Specify UTF-8 encoding in each file:
 
 ::
-
   # -*- coding: utf-8 -*-
-  #
-  # Copyright © 2013 Red Hat, Inc.
-  #
-  # This software is licensed to you under the GNU General Public
-  # License as published by the Free Software Foundation; either version
-  # 2 of the License (GPLv2) or (at your option) any later version.
-  # There is NO WARRANTY for this software, express or implied,
-  # including the implied warranties of MERCHANTABILITY,
-  # NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-  # have received a copy of GPLv2 along with this software; if not, see
-  # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.


### PR DESCRIPTION
Makes a checklist of contribution expectations with links to the original documents. The docs are currently pretty spread out and it is difficult for a new person to be aware of all of the things they are supposed to consider. This clarifies the expectations without re-architecting the docs.
