### PR TITLE
1160796 - SELinux change allowing celery to make TCP connections to all hosts and ports

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -27,7 +27,6 @@ require {
 
 allow celery_t self:netlink_route_socket { bind create getattr nlmsg_read write read };
 allow celery_t self:process { signal signull };
-allow celery_t self:tcp_socket { connect create getattr getopt read setopt shutdown write };
 allow celery_t self:udp_socket { ioctl getattr create connect write read };
 allow celery_t self:unix_dgram_socket { create connect };
 
@@ -62,9 +61,6 @@ apache_read_sys_content(celery_t)
 corecmd_exec_bin(celery_t)
 corecmd_exec_shell(celery_t)
 corecmd_read_bin_symlinks(celery_t)
-corenet_tcp_connect_amqp_port(celery_t)
-corenet_tcp_connect_mongod_port(celery_t)
-corenet_tcp_connect_http_port(celery_t)
 dev_read_urand(celery_t)
 files_list_tmp(celery_t)
 files_rw_pid_dirs(celery_t)
@@ -77,10 +73,21 @@ sysnet_read_config(celery_t)
 
 ######################################
 #
-# corenet_tcp_connect_smtp_port is needed for Email Notifier to send event info via SMTP
+# Pulp workers do network related things including:
+#  - connect to mongod and amqp. This is required for correct processing of tasks
+#  - sync data to/from remote hosts via HTTP/HTTPS
+#  - send e-mail using SMTP for notification purposes
+#  - use a network proxy
+#
+# Pulp allows several protocols above to be used over non-standard ports so all ports are allowed.
+# Users who want additional network security can use a firewall at the host or network level for
+# additional protection.
 #
 
-corenet_tcp_connect_smtp_port(celery_t)
+allow celery_t self:tcp_socket create_stream_socket_perms;
+corenet_tcp_connect_all_ports(celery_t)
+corenet_tcp_bind_all_ports(celery_t)
+corenet_tcp_bind_generic_node(celery_t)
 
 ######################################
 #


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1160796

This PR removes some portions of the SELinux policy that granted specific ports, and replaces it with a policy that grants all TCP port access to all nodes. It also adds some notes to the policy about why. These changes were also discussed on #selinux on freenode.

The BZ is about a problem accessing the proxy port, but after discussion it was determined that restricting Pulp's network access prevents normal pulp operation since sync or SMTP can be done on any port. Rather than adding another whitelist for the default proxy port, we're opening up all TCP connections. This is also OK because admins can use network or host firewalls to guard against unwanted network traffic.

I compiled this on EL6, EL7, FC19, and FC20 to ensure it will compile without error.

I also smoke tested repo create/sync/delete and consumer register/bind/update/unbind/unregister on EL6 with SELinux in enforcing mode and everything worked for me.
