### PR TITLE
1148928 - 404 is returned when publishing a nonexistent repo group

### DIFF
--- a/server/pulp/server/webservices/controllers/repo_groups.py
+++ b/server/pulp/server/webservices/controllers/repo_groups.py
@@ -232,6 +232,10 @@ class PublishAction(JSONController):
         if distributor_id is None:
             raise MissingValue(['id'])
 
+        # If a repo group does not exist, get_group raises a MissingResource exception
+        manager = managers_factory.repo_group_query_manager()
+        manager.get_group(repo_group_id)
+
         task_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_GROUP_TYPE, repo_group_id),
                 tags.resource_tag(tags.RESOURCE_REPOSITORY_GROUP_DISTRIBUTOR_TYPE,
                              distributor_id),


### PR DESCRIPTION
Fix publish to return a 404 like we said we do in the [Publish Docs](https://pulp-dev-guide.readthedocs.org/en/latest/integration/rest-api/repo/groups/publish.html)

[BZ-1148928](https://bugzilla.redhat.com/show_bug.cgi?id=1148928)
