### PR TITLE
1146294 - do not require pulp.bindings.server to access DEFAULT_CA_PATH

### DIFF
--- a/bindings/pulp/bindings/server.py
+++ b/bindings/pulp/bindings/server.py
@@ -14,11 +14,10 @@ from M2Crypto import httpslib, m2, SSL
 
 from pulp.bindings import exceptions
 from pulp.bindings.responses import Response, Task
+from pulp.common.constants import DEFAULT_CA_PATH
 from pulp.common.compat import json
 from pulp.common.util import ensure_utf_8, encode_unicode
 
-
-DEFAULT_CA_PATH = '/etc/pki/tls/certs/ca-bundle.crt'
 
 
 class PulpConnection(object):

--- a/common/pulp/common/constants.py
+++ b/common/pulp/common/constants.py
@@ -56,3 +56,6 @@ CALL_COMPLETE_STATES = (CALL_SKIPPED_STATE, CALL_FINISHED_STATE, CALL_ERROR_STAT
 # 3.0 as part of https://bugzilla.redhat.com/show_bug.cgi?id=1160410
 
 PRIMARY_ID = '___/primary/___'
+
+# this is used by both platform and plugins to find the default CA path
+DEFAULT_CA_PATH = '/etc/pki/tls/certs/ca-bundle.crt'


### PR DESCRIPTION
The Katello agent uses DEFAULT_CA_PATH, but does not install the Pulp bindings
by default. The constant should live in pulp.common.constants instead.
