### PR TITLE
1079511 - better relative url collision prevention

### DIFF
--- a/server/pulp/plugins/conduits/repo_config.py
+++ b/server/pulp/plugins/conduits/repo_config.py
@@ -1,27 +1,11 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2012 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 """
-Repo Config Conduit
-
-This conduit provides the utility methods needed by the distributors API for configuration validation.
+This conduit provides the utility methods needed by the distributors API for
+configuration validation.
 """
 
-import logging
+import os
 
 from pulp.server.db.model.repository import RepoDistributor
-
-_LOG = logging.getLogger(__name__)
 
 
 class RepoConfigConduit(object):
@@ -30,34 +14,37 @@ class RepoConfigConduit(object):
 
     def get_repo_distributors_by_relative_url(self, rel_url, repo_id=None):
         """
-        Get the config repo_id and config objects matching a given relative URL
+        Get the config repo_id and config objects matching a given relative URL. This is agnostic
+        to preceding slashes.
 
         :param rel_url: a relative URL for a distributor config
         :type  rel_url: str
 
-        :param repo_id: the id of a repo to skip, If not specified all repositories will be included in the
-                        search
+        :param repo_id: the id of a repo to skip, If not specified all repositories will be
+                        included in the search
         :type  repo_id: str
 
-        :return: a cursor to iterate over the list of repository configurations whose configuration conflicts
-                 with rel_url
-        :rtype:  pymongo.cursor.Cursor
+        :return:        a cursor to iterate over the list of repository configurations whose
+                        configuration conflicts with rel_url
+        :rtype:         pymongo.cursor.Cursor
         """
-        # build a list of all the sub urls that could conflict with the provided URL
-        current_url_pieces = [x for x in rel_url.split("/") if x]
-        matching_url_list = []
-        workingUrl = "/"
-        for piece in current_url_pieces:
-            workingUrl += piece
-            matching_url_list.append(workingUrl)
-            workingUrl += "/"
 
-        # calculate the base field of the URL, this is used for tests where the repo id
-        # is used as a substitute for the relative url: /repo-id/
+        # build a list of all the sub urls that could conflict with the provided URL.
+        current_url_pieces = [x for x in rel_url.split('/') if x]
+        matching_url_list = []
+        working_url = ''
+        for piece in current_url_pieces:
+            working_url = os.path.join(working_url, piece)
+            matching_url_list.append(working_url)
+            matching_url_list.append('/' + working_url)
+
+        # When a relative_url is not specified on repo creation, the url is the repo-id.
         repo_id_url = current_url_pieces[0]
 
-        #search for all the sub url as well as any url that would fall within the specified url
-        spec = {'$or': [{'config.relative_url': {'$regex': '^' + workingUrl + '.*'}},
+        # Search for all the sub urls as well as any url that would fall within the specified url.
+        # The regex here basically matches the a url if it starts with (optional preceding slash)
+        # the working url. Anything can follow as long as it is separated by a slash.
+        spec = {'$or': [{'config.relative_url': {'$regex': '^/?' + working_url + '(/.*|/?\z)'}},
                         {'config.relative_url': {'$in': matching_url_list}},
                         {'$and': [{'config.relative_url': {'$exists': False}},
                                   {'repo_id': repo_id_url}]}

--- a/server/test/unit/test_repo_config_conduit.py
+++ b/server/test/unit/test_repo_config_conduit.py
@@ -1,31 +1,11 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
-"""
-Test Cases for the Repo Config Conduit
-
-"""
-
 import base
 from operator import itemgetter
 
 from pulp.devel import mock_plugins
-
 from pulp.plugins.conduits.repo_config import RepoConfigConduit
 from pulp.server.db.model.repository import Repo, RepoDistributor
 from pulp.server.managers import factory as manager_factory
 
-# -- test cases ---------------------------------------------------------------
 
 class RepoConfigConduitTests(base.PulpServerTests):
 
@@ -46,13 +26,19 @@ class RepoConfigConduitTests(base.PulpServerTests):
         self.repo_manager.create_repo('repo-2')
         self.distributor_manager.add_distributor('repo-2', 'mock-distributor', {"relative_url": "/a/bc/e"},
                                                  True, distributor_id='dist-3')
-
         self.repo_manager.create_repo('repo-3')
         self.distributor_manager.add_distributor('repo-3', 'mock-distributor', {},
                                                  True, distributor_id='dist-4')
         self.repo_manager.create_repo('repo-4')
-        self.distributor_manager.add_distributor('repo-4', 'mock-distributor', {"relative_url": "/repo-5"},
+        self.distributor_manager.add_distributor('repo-4', 'mock-distributor', {"relative_url": "repo-5"},
                                                  True, distributor_id='dist-5')
+        self.repo_manager.create_repo('repo-5')
+        self.distributor_manager.add_distributor('repo-5', 'mock-distributor', {"relative_url": "a/bcd/e"},
+                                                 True, distributor_id='dist-1')
+        self.repo_manager.create_repo('repo-6')
+        self.distributor_manager.add_distributor('repo-6', 'mock-distributor', {"relative_url": "a/bcde/f/"},
+                                                 True, distributor_id='dist-1')
+
         self.conduit = RepoConfigConduit('rpm')
 
     def tearDown(self):
@@ -67,12 +53,21 @@ class RepoConfigConduitTests(base.PulpServerTests):
         Repo.get_collection().remove()
         RepoDistributor.get_collection().remove()
 
-
     def test_get_distributors_by_relative_url_with_same_url(self):
         """
         Test for distributors with an identical relative url
         """
         matches = self.conduit.get_repo_distributors_by_relative_url("/a/bc/d")
+
+        self.assertEquals(matches.count(), 1)
+        self.assertEquals(next(matches)['repo_id'], 'repo-1')
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/d")
+
+        self.assertEquals(matches.count(), 1)
+        self.assertEquals(next(matches)['repo_id'], 'repo-1')
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/d/")
 
         self.assertEquals(matches.count(), 1)
         self.assertEquals(next(matches)['repo_id'], 'repo-1')
@@ -84,11 +79,23 @@ class RepoConfigConduitTests(base.PulpServerTests):
         matches = self.conduit.get_repo_distributors_by_relative_url("/a/bc/d", 'repo-1')
         self.assertEquals(matches.count(), 0)
 
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/d", 'repo-1')
+        self.assertEquals(matches.count(), 0)
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/d/", 'repo-1')
+        self.assertEquals(matches.count(), 0)
+
     def test_get_distributors_by_relative_url_with_different_url(self):
         """
         Test for distributors with no matching relative url
         """
         matches = self.conduit.get_repo_distributors_by_relative_url("/d")
+        self.assertEquals(matches.count(), 0)
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("d")
+        self.assertEquals(matches.count(), 0)
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("d/")
         self.assertEquals(matches.count(), 0)
 
     def test_get_distributors_by_relative_url_with_superset_url(self):
@@ -102,12 +109,33 @@ class RepoConfigConduitTests(base.PulpServerTests):
         self.assertEquals(matches[0]['repo_id'], 'repo-1')
         self.assertEquals(matches[1]['repo_id'], 'repo-2')
 
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc")
+        self.assertEquals(matches.count(), 2)
+        #verify that the correct 2 repositories were found
+        matches = sorted(list(matches), key=itemgetter('repo_id'))
+        self.assertEquals(matches[0]['repo_id'], 'repo-1')
+        self.assertEquals(matches[1]['repo_id'], 'repo-2')
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/")
+        self.assertEquals(matches.count(), 2)
+        #verify that the correct 2 repositories were found
+        matches = sorted(list(matches), key=itemgetter('repo_id'))
+        self.assertEquals(matches[0]['repo_id'], 'repo-1')
+        self.assertEquals(matches[1]['repo_id'], 'repo-2')
 
     def test_get_distributors_by_relative_url_with_subset_url(self):
         """
         Test for distributors with urls that would override the proposed relative url
         """
-        matches = self.conduit.get_repo_distributors_by_relative_url("/a/bc/d/e")
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/d/e")
+        self.assertEquals(matches.count(), 1)
+        self.assertEquals(next(matches)['repo_id'], 'repo-1')
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/d/e")
+        self.assertEquals(matches.count(), 1)
+        self.assertEquals(next(matches)['repo_id'], 'repo-1')
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bc/d/e/")
         self.assertEquals(matches.count(), 1)
         self.assertEquals(next(matches)['repo_id'], 'repo-1')
 
@@ -119,3 +147,41 @@ class RepoConfigConduitTests(base.PulpServerTests):
         matches = self.conduit.get_repo_distributors_by_relative_url("/repo-3")
         self.assertEquals(matches.count(), 1)
         self.assertEquals(next(matches)['repo_id'], 'repo-3')
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("repo-3")
+        self.assertEquals(matches.count(), 1)
+        self.assertEquals(next(matches)['repo_id'], 'repo-3')
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("repo-3/")
+        self.assertEquals(matches.count(), 1)
+        self.assertEquals(next(matches)['repo_id'], 'repo-3')
+
+    def test_get_distributors_without_leading_or_trailing_slash_relative_url(self):
+        """
+        Test matching repos that include preceding slashes with a search that doesn't include
+        preceding and trailing slashes.
+        """
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bcd/e")
+
+        self.assertEqual(matches.count(), 1)
+        self.assertEqual(next(matches)['repo_id'], 'repo-5')
+
+    def test_get_distributors_without_leading_slash_relative_url(self):
+        """
+        Test matching repos that do not include preceding slashes with a search that doesn't
+        include preceding and trailing slashes.
+        """
+
+        matches = self.conduit.get_repo_distributors_by_relative_url("a/bcde/f")
+
+        self.assertEqual(matches.count(), 1)
+        self.assertEqual(next(matches)['repo_id'], 'repo-6')
+
+    def test_get_distributors_url_does_not_conflict_with_repo_id(self):
+        """
+        Test matching repos with a defined relative-url using their repo id instead of relative-url.
+        """
+        matches = self.conduit.get_repo_distributors_by_relative_url("repo-1")
+
+        self.assertEqual(matches.count(), 0)


### PR DESCRIPTION
[BZ-1153295](https://bugzilla.redhat.com/show_bug.cgi?id=1153795)
[BZ-1079511](https://bugzilla.redhat.com/show_bug.cgi?id=1079511)

Repos should not be able to have the same relative url or race conditions will exist. The logic to prevent them was already in the code, but assumed that the relative urls would have a preceding slash. It seems that most of the time, including in our examples, we do not include the preceding slash. In order to maintain backwards compatibility, we have to support both while also preventing collisions between them.

I may have gone a little overboard on the tests, but there are enough weird edge cases that a little redundancy in the tests is better than a missed edge case. 
