### PR TITLE
1129488 - Adjusts mongoDB auto-reconnect to never stop attempting

### DIFF
--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -18,8 +18,6 @@
 #
 # name:              name of the database to use
 # seeds:             comma-separated list of hostname:port of database replica seed hosts
-# operation_retries: number of retries on database operations to perform before giving up and
-#                    reporting an error (Deprecated in 2.4.1)
 # username:          The user name to use for authenticating to the MongoDB server
 # password:          The password to use for authenticating to the MongoDB server
 # replica_set:       uncomment and set this value to the name of replica set configured in MongoDB,
@@ -39,7 +37,6 @@
 [database]
 # name: pulp_database
 # seeds: localhost:27017
-# operation_retries: 2
 # username:
 # password:
 # replica_set:

--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -15,6 +15,7 @@ from pulp.server.async import worker_watcher
 from pulp.server.db import connection as db_connection
 from pulp.server.db.model.criteria import Criteria
 from pulp.server.db.model.dispatch import ScheduledCall, ScheduleEntry
+from pulp.server.db.connection import retry_decorator
 from pulp.server.managers import resources
 from pulp.server.managers.schedule import utils
 
@@ -352,6 +353,7 @@ class Scheduler(beat.Scheduler):
         self._most_recent_timestamp = max(update_timestamps)
 
     @property
+    @retry_decorator()
     def schedule_changed(self):
         """
         Looks at the update timestamps in the database to determine if there

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -27,7 +27,6 @@ _default_values = {
     'database': {
         'name': 'pulp_database',
         'seeds': 'localhost:27017',
-        'operation_retries': '2',
         'ssl': 'false',
         'ssl_keyfile': '',
         'ssl_certfile': '',

--- a/server/pulp/server/db/connection.py
+++ b/server/pulp/server/db/connection.py
@@ -127,43 +127,28 @@ class PulpCollectionFailure(PulpException):
     """
 
 
-def _retry_decorator(full_name=None, retries=0):
+def retry_decorator(full_name=None):
     """
     Collection instance method decorator providing retry support for pymongo
     AutoReconnect exceptions
     :param full_name: the full name of the database collection
     :type  full_name: str
-    :param retries: the number of times to retry the operation before allowing
-                    the exception to blow the stack
-    :type  retries: int
     """
 
     def _decorator(method):
 
         @wraps(method)
         def retry(*args, **kwargs):
-
-            tries = 0
-
-            while tries <= retries:
-
+            while True:
                 try:
                     return method(*args, **kwargs)
 
                 except AutoReconnect:
-                    tries += 1
+                    msg = _('%(method)s operation failed on %(name)s') % {'method': method.__name__,
+                                                                          'name': full_name}
+                    _logger.error(msg)
 
-                    _logger.warn(_('%(method)s operation failed on %(name)s: tries remaining: %(tries)d') %
-                              {'method': method.__name__, 'name': full_name,
-                               'tries': retries - tries + 1})
-
-                    if tries <= retries:
-                        time.sleep(0.3)
-
-            raise PulpCollectionFailure(
-                _('%(method)s operation failed on %(name)s: database connection '
-                  'still down after %(tries)d tries') %
-                {'method': method.__name__, 'name': full_name, 'tries': (retries + 1)})
+                    time.sleep(0.3)
 
         return retry
 
@@ -188,7 +173,7 @@ def _end_request_decorator(method):
 
 class PulpCollection(Collection):
     """
-    pymongo.collection.Collection wrapper that provides support for retries when
+    pymongo.collection.Collection wrapper that provides auto-retry support when
     pymongo.errors.AutoReconnect exception is raised
     and automatically manages connection sockets for long-running and threaded
     applications
@@ -200,13 +185,11 @@ class PulpCollection(Collection):
                           'index_information', 'options', 'group', 'rename', 'distinct', 'map_reduce',
                           'inline_map_reduce', 'find_and_modify')
 
-    def __init__(self, database, name, create=False, retries=0, **kwargs):
+    def __init__(self, database, name, create=False, **kwargs):
         super(PulpCollection, self).__init__(database, name, create=create, **kwargs)
 
-        self.retries = retries
-
         for m in self._decorated_methods:
-            setattr(self, m, _retry_decorator(self.full_name, self.retries)(getattr(self, m)))
+            setattr(self, m, retry_decorator(self.full_name)(getattr(self, m)))
 
     def __getstate__(self):
         return {'name': self.name}
@@ -248,8 +231,7 @@ def get_collection(name, create=False):
     if _DATABASE is None:
         raise PulpCollectionFailure(_('Cannot get collection from uninitialized database'))
 
-    retries = config.config.getint('database', 'operation_retries')
-    return PulpCollection(_DATABASE, name, retries=retries, create=create)
+    return PulpCollection(_DATABASE, name, create=create)
 
 
 def get_database():


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1129488

This was already fixed once with #1118 and those changes are correctly applied in the 2.4 release, but in the merge forward to 2.5 the changes got lost.
