### PR TITLE
Add annoying printout to our tests so we fix PEP8.

### DIFF
--- a/flake8.cfg
+++ b/flake8.cfg
@@ -1,0 +1,5 @@
+[flake8]
+exclude = ./docs/*
+# E401: multiple imports on one line
+ignore = E401
+max-line-length = 100

--- a/run-tests.py
+++ b/run-tests.py
@@ -11,6 +11,10 @@ PROJECT_DIR = os.path.dirname(__file__)
 subprocess.call(['find', PROJECT_DIR, '-name', '*.pyc', '-delete'])
 
 
+config_file = os.path.join(PROJECT_DIR, 'flake8.cfg')
+subprocess.call(['flake8', '--config', config_file, PROJECT_DIR])
+
+
 PACKAGES = [
     os.path.dirname(__file__),
     'pulp',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,3 @@
+coverage
+flake8
+nose


### PR DESCRIPTION
These PEP-8 warnings will not affect the exit code of run-tests.py at
this time. I just want it to be on our minds to fix this stuff. Once we
reach coverage, we can make it fail if flake8 exits due to PEP-8.
