### PR TITLE
Add intersphinx and extlinks to platform

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,13 @@ import sys, os
 #sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('./_extensions'))
 
+# this var should refer to where intersphinx should pull inv files from. For
+# example, this would be set to '2.6-release' for the 2.6 branches, which would
+# pull objects.inv from http://pulp-rpm.readthedocs.org/en/2.6-release/objects.inv.
+# For master, this should point to 'latest'.
+
+rtd_builder = 'latest'
+
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -26,7 +33,7 @@ sys.path.insert(0, os.path.abspath('./_extensions'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx', 'rest_api']
+extensions = ['sphinx.ext.intersphinx', 'rest_api', 'sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -242,7 +249,23 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
+intersphinx_mapping = {'python': ('http://docs.python.org/2.7/', None),
+                       'rpm':    (("http://pulp-rpm.readthedocs.org/en/%s/" % rtd_builder),
+                                  None),
+                       'puppet': (("http://pulp-puppet.readthedocs.org/en/%s/" % rtd_builder),
+                                  None),
+                       'ostree': (("http://pulp-ostree.readthedocs.org/en/%s/" % rtd_builder),
+                                  None),
+                       'deb':    (("http://pulp-deb.readthedocs.org/en/%s/" % rtd_builder),
+                                  None),
+                       'docker': (("http://pulp-docker.readthedocs.org/en/%s/" % rtd_builder),
+                                  None)}
 
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None,
-                       'okaara' : ('http://jdob.fedorapeople.org/okaara', None)}
+extlinks = {'bz': ('https://bugzilla.redhat.com/show_bug.cgi?id=%s', 'RHBZ #'),
+            'fixedbugs': ('https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED'\
+                          '&bug_status=RELEASE_PENDING&bug_status=CLOSED&classificatio'\
+                          'n=Community&component=API%%2Fintegration&component=async%%2Ft'\
+                          'asks&component=consumers&component=documentation&component='\
+                          'nodes&component=rel-eng&component=user-experience&component'\
+                          '=z_other&list_id=2768089&product=Pulp&query_format=advanced'\
+                          '&target_release=%s', None)}

--- a/docs/dev-guide/contributing/building.rst
+++ b/docs/dev-guide/contributing/building.rst
@@ -532,3 +532,8 @@ was 2.5, the stable folder should look similar to this::
 
 The ``rhel-pulp.repo`` and ``fedora-pulp.repo`` files also need to be updated
 for the new GPG public key location if you are creating a new X release.
+
+In addition to this, you will also need to create a new readthedocs builder.
+Once that is complete, edit ``rtd_builder`` in ``docs/conf.py`` for each plugin
+to change the version of platform docs that the plugin docs point to. This step
+is not needed for experimental or tech preview plugins.

--- a/docs/user-guide/release-notes/2.1.x.rst
+++ b/docs/user-guide/release-notes/2.1.x.rst
@@ -18,10 +18,10 @@ that contain a lot of metadata.
 Notable Bugs
 ------------
 
-`928087 <https://bugzilla.redhat.com/show_bug.cgi?id=928087>`_ - pickling error in pulp.log when cancelling sync
+:bz:`928087` - pickling error in pulp.log when cancelling sync
 tasks
 
-`949186 <https://bugzilla.redhat.com/show_bug.cgi?id=949186>`_ - The pycurl downloader times out on active
+:bz:`949186` - The pycurl downloader times out on active
 downloads, even during very good transfer rates
 
 All Bugs
@@ -68,27 +68,27 @@ Client Changes
 Noteworthy Bugs Fixed
 ---------------------
 
-`872724 <https://bugzilla.redhat.com/show_bug.cgi?id=872724>`_ - Requesting package profile on consumer without
+:bz:`872724` - Requesting package profile on consumer without
 a package profile results in error
 
-`878234 <https://bugzilla.redhat.com/show_bug.cgi?id=878234>`_ - Consumer group package_install, update and
+:bz:`878234` - Consumer group package_install, update and
 uninstall not returning correct result
 
-`916794 <https://bugzilla.redhat.com/show_bug.cgi?id=916794>`_ - pulp-admin orphan list, Performance & Memory
+:bz:`916794` - pulp-admin orphan list, Performance & Memory
 concerns (~17 minutes and consuming consuming ~1.65GB memory). The --summary flag was removed and summary
 behavior was made the default when listing orphans. A new --details flag has been added to get the previous
 behavior.
 
-`918160 <https://bugzilla.redhat.com/show_bug.cgi?id=918160>`_ - Orphan list --summary mode isn't a summary.
+:bz:`918160` - Orphan list --summary mode isn't a summary.
 Listing orphans now returns a much smaller set of related fields (namely only the unit keys).
 
-`920792 <https://bugzilla.redhat.com/show_bug.cgi?id=920792>`_ - High memory usage (growth of 2GB) from orphan
+:bz:`920792` - High memory usage (growth of 2GB) from orphan
 remove --all. All server-side orphan operations now use generators instead of database batch queries.
 
 RFE Bugs
 --------
 
-`876725 <https://bugzilla.redhat.com/show_bug.cgi?id=876725>`_ - RFE - consumer/agent - support option to
+:bz:`876725` - RFE - consumer/agent - support option to
 perform 'best effort' install of content. We will now avoid aborting an install when one of the packages is not
 available for installation.
 

--- a/docs/user-guide/release-notes/2.2.x.rst
+++ b/docs/user-guide/release-notes/2.2.x.rst
@@ -52,9 +52,7 @@ Bug Fixes
 ---------
 
 Multiple proxy-related issues related to authentication and HTTPS to the proxy
-were fixed in
-`1022662 <https://bugzilla.redhat.com/show_bug.cgi?id=1022662>`_ and
-`1014368 <https://bugzilla.redhat.com/show_bug.cgi?id=1014368>`_.
+were fixed in :bz:`1022662` and :bz:`1014368`.
 
 See the RPM-specific user guide for highlights of the most important bug fixes
 there. All bug fixes for this release can be seen at this link:

--- a/docs/user-guide/release-notes/2.3.x.rst
+++ b/docs/user-guide/release-notes/2.3.x.rst
@@ -83,5 +83,5 @@ Pulp 2.3.1
 Bugs Fixed
 ----------
 
-The ``pulp-qpid-ssl-cfg`` tool `displayed an incorrect path <https://bugzilla.redhat.com/show_bug.cgi?id=1039619>`_
+The ``pulp-qpid-ssl-cfg`` tool :bz:`displayed an incorrect path <1039619>`
 to the qpid configuration file.

--- a/docs/user-guide/release-notes/2.4.x.rst
+++ b/docs/user-guide/release-notes/2.4.x.rst
@@ -12,7 +12,7 @@ POODLE attack.
 Bugs
 ----
 You can see the complete list of bugs that were
-`fixed in Pulp 2.4.3 <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=API%2Fintegration&component=async%2Ftasks&component=consumers&component=documentation&component=nodes&component=rel-eng&component=user-experience&component=z_other&list_id=2768089&product=Pulp&query_format=advanced&target_release=2.4.3>`_.
+:fixedbugs:`fixed in Pulp 2.4.3 <2.4.3>`.
 
 Upgrade Instructions for 2.4.2 --> 2.4.3
 ----------------------------------------
@@ -49,7 +49,7 @@ Rest API Changes
 ----------------
 
 * Certain API calls under ``/consumers/`` related to repo binding would
-  `erroneously return full task information <https://bugzilla.redhat.com/show_bug.cgi?id=1130119>`_.
+  :bz:`erroneously return full task information <1130119>`.
   This has been corrected; these calls now only return the task's ID.
 
 Upgrade Instructions for 2.4.1 --> 2.4.2
@@ -68,7 +68,7 @@ Pulp 2.4.1
 Bugs
 ----
 You can see the complete list of bugs that were
-`fixed in Pulp 2.4.1 <https://bugzilla.redhat.com/buglist.cgi?bug_status=VERIFIED&bug_status=RELEASE_PENDING&bug_status=CLOSED&classification=Community&component=API%2Fintegration&component=async%2Ftasks&component=consumers&component=documentation&component=nodes&component=rel-eng&component=user-experience&component=z_other&list_id=2768089&product=Pulp&query_format=advanced&target_release=2.4.1>`_.
+:fixedbugs:`fixed in Pulp 2.4.1 <2.4.1>`.
 
 Backwards Incompatible Changes
 ------------------------------
@@ -196,12 +196,12 @@ Agent Changes
 Bugs
 ----
 You can see the complete list of bugs that were
-`fixed in Pulp 2.4.0 <https://bugzilla.redhat.com/buglist.cgi?list_id=1242840&resolution=---&resolution=CURRENTRELEASE&classification=Community&target_release=2.4.0&query_format=advanced&bug_status=VERIFIED&bug_status=CLOSED&component=admin-client&component=bindings&component=consumer-client%2Fagent&component=consumers&component=coordinator&component=documentation&component=events&component=nodes&component=okaara&component=rel-eng&component=repositories&component=rest-api&component=selinux&component=upgrade&component=users&component=z_other&product=Pulp>`_.
+:bz:`fixed in Pulp 2.4.0 <2.4.0>`.
 
 Known Issues
 ------------
 
-* There was `one regression <https://bugzilla.redhat.com/show_bug.cgi?id=1128292>`_ discovered during
+* There was :bz:`one regression <1128292>` discovered during
   the 2.4.0 QE cycle that has not been resolved as of the release. The 2.4.0 distributor publishes
   groups in a slightly different way than Anaconda expects during interactive kickstarting. This
   causes no groups to be chosen by default during the package group selection installation step. The
@@ -209,7 +209,7 @@ Known Issues
   select at least one package group during the installation. Automated kickstarts are not affected by
   this issue.
 
-* There is a `configuration bug <https://bugzilla.redhat.com/show_bug.cgi?id=1132609>`_ related to
+* There is a :bz:`configuration bug <1132609>` related to
   using MongoDB with authenticated database users. The error presents itself during syncs and other
   task-related operations. A workaround is documented in comment #1 of the bug.
 

--- a/docs/user-guide/tuning.rst
+++ b/docs/user-guide/tuning.rst
@@ -122,8 +122,7 @@ and `RabbitMQ <http://www.rabbitmq.com/ha.html>`_.
 
 .. WARNING:: There is a bug in versions of Apache Qpid older than 0.30 that
    involves running out of file descriptors. This is an issue on deployments
-   with large numbers of consumers. See `Red Hat Bugzilla #1122987
-   <https://bugzilla.redhat.com/show_bug.cgi?id=1122987>`_ for more information
+   with large numbers of consumers. See :bz:`1122987` for more information
    about this and for suggested workarounds.
 
 
@@ -213,5 +212,5 @@ typical statistics that can be collected and reviewed periodically:
 
 Many of these statistics can be collected and viewed using tools like `Celery
 Flower <https://pypi.python.org/pypi/flower/>`_ or `Munin
-<http://munin-monitoring.org/`_.
+<http://munin-monitoring.org/>`_.
 


### PR DESCRIPTION
This links to pulp_{rpm,puppet,ostree,deb,docker}. It also adds support for
`:bz:` and `:fixedbugs:` links.
