### PR TITLE
tests no longer echo database cleaning

### DIFF
--- a/playpen/v2_plugins/harness/clean/clean.sh
+++ b/playpen/v2_plugins/harness/clean/clean.sh
@@ -1,2 +1,2 @@
-echo "Purging the database of repositories and content units"
+printf "Purging the database of repositories and content units\n"
 mongo localhost:27017/pulp_database db-clean.js


### PR DESCRIPTION
Echoing "Purging the database of all content type definitions and collections" every time tests are run is really annoying. `printf` doesn't print when being run from the tests, but it does still work when running `clean.sh` directly.
