### PR TITLE
1161690 - Add release note for RabbitMQ support.

### DIFF
--- a/docs/sphinx/user-guide/release-notes/2.5.x.rst
+++ b/docs/sphinx/user-guide/release-notes/2.5.x.rst
@@ -12,6 +12,10 @@ New Features
   It now works with the ANONYMOUS authentication mechanism. Users can still use a
   username/password however if they set up a SASL database as described in the
   installation document.
+- Pulp now supports `RabbitMQ`_ as its task message broker. See the inline comments in
+  ``/etc/pulp/server.conf`` for instruction on configuring Pulp to use RabbitMQ.
+
+.. _RabbitMQ: https://www.rabbitmq.com/
 
 
 Rest API Changes


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1161690
