### PR TITLE
1161205 - Adds comments to conf files about value of defaults

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -1,3 +1,6 @@
+# The settings in this file are all commented by default, and the commented settings show the
+# default values that Pulp Admin will choose if not specified here.
+
 # The pulp server configuration
 #
 # host:

--- a/client_consumer/etc/pulp/consumer/consumer.conf
+++ b/client_consumer/etc/pulp/consumer/consumer.conf
@@ -1,3 +1,6 @@
+# The settings in this file are all commented by default, and the commented settings show the
+# default values that Pulp Consumer Client will choose if not specified here.
+
 # The pulp server configuration
 #
 # host:

--- a/nodes/common/etc/pulp/nodes.conf
+++ b/nodes/common/etc/pulp/nodes.conf
@@ -9,6 +9,9 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
 
+# The settings in this file are all commented by default, and the commented settings show the
+# default values that a Pulp Node will choose if not specified here.
+
 # The main node configuration
 # ca_path -          This is a path to a file of concatenated trusted CA certificates, or to a
 #                    directory of trusted CA certificates (with openssl-style hashed symlinks, one

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -2,8 +2,8 @@
 # Pulp Server Configuration
 # =========================
 
-# This settings in this file are all commented by default, and the commented settings show the
-# default values that Pulp will choose if not specified here.
+# The settings in this file are all commented by default, and the commented settings show the
+# default values that Pulp Server will choose if not specified here.
 
 # -- Common Configuration -----------------------------------------------------
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1161205

I grepped across all plugins (including the new Python one) and searched for conf files that are user facing. I updated all of them and checked that the defaults are actually the defaults. For the small differences I found I filed separate bugs, but those are separate issues.
