### PR TITLE
1159067 - Read user cred from config

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -85,3 +85,22 @@
 # enable_color: true
 # wrap_to_terminal: false
 # wrap_width: 80
+
+
+# Client authentication
+#
+# This enables all system users to run pulp-admin commands using the username
+# and password specified here. Values contained in a user's ~/.pulp/admin.conf
+# override values specified here.
+#
+# WARNING: This file is world-readable so only use a password here that is
+#          appropriate for any system user to read.
+#
+# username:
+#   pulp username
+# password:
+#   pulp user's password
+
+[auth]
+#username: admin
+#password: admin

--- a/client_admin/test/unit/test_config.py
+++ b/client_admin/test/unit/test_config.py
@@ -1,4 +1,8 @@
 
+import os
+import os.path
+import tempfile
+
 from unittest import TestCase
 
 from mock import patch, Mock
@@ -38,7 +42,6 @@ class TestConfig(TestCase):
                 msg = '[%s].%s has not default' % (section, key)
                 self.assertTrue(self.schema_has_property(section, key), msg=msg)
 
-
     @patch('os.listdir')
     @patch('os.path.expanduser')
     @patch('os.path.exists', Mock(return_value=False))
@@ -61,7 +64,7 @@ class TestConfig(TestCase):
         fake_config.assert_called_with(*paths)
         fake_config().validate.assert_called_with(SCHEMA)
         self.assertEqual(cfg, fake_config())
-        
+
     @patch('pulp.client.admin.config.Config')
     def test_read_paths(self, fake_config):
         paths = ['path_A', 'path_B']
@@ -86,6 +89,7 @@ class TestConfig(TestCase):
         self.assertFalse(fake_config().validate.called)
         self.assertEqual(cfg, fake_config())
 
+    @patch('pulp.client.admin.config.validate_overrides', Mock(return_value=True))
     @patch('os.listdir')
     @patch('os.path.expanduser')
     @patch('os.path.exists', Mock(return_value=True))
@@ -106,6 +110,73 @@ class TestConfig(TestCase):
             '/home/pulp/.pulp/admin.conf'
         ]
 
+        fake_config.assert_called_with(*paths)
+        fake_config().validate.assert_called_with(SCHEMA)
+        self.assertEqual(cfg, fake_config())
+
+    @patch('os.listdir')
+    @patch('os.path.expanduser')
+    @patch('pulp.client.admin.config.Config')
+    def test_validate_overrides_when_has_password(self,
+                                                  fake_config,
+                                                  fake_expanduser,
+                                                  fake_listdir):
+        # we are trying to fake Config.has_option return True
+        # so it means config file has password
+        fake_instance = fake_config.return_value
+
+        def has_option(*args):
+            return True
+
+        fake_instance.has_option = has_option
+
+        fn = tempfile.NamedTemporaryFile()
+        fake_expanduser.return_value = fn.name
+
+        os.chmod(fn.name, 0777)
+        fake_listdir.return_value = ['A', 'B', 'C']
+        self.assertRaises(RuntimeError, read_config)
+
+        #validation
+        paths = [fn.name]
+
+        # Config is only called from within
+        # pulp.client.admin.config.validate_overrides
+        # not not from read_config as it would have exited
+        # after throwing exception when config has password
+        # and file is world readable
+        fake_config.assert_called_with(*paths)
+        self.assertFalse(fake_config().validate.called)
+
+    @patch('os.listdir')
+    @patch('os.path.expanduser')
+    @patch('pulp.client.admin.config.Config')
+    def test_validate_overrides_when_does_not_have_password(self,
+                                                            fake_config,
+                                                            fake_expanduser,
+                                                            fake_listdir):
+        # we are trying to fake Config.has_option return False
+        # so it means config file does not have password
+        fake_instance = fake_config.return_value
+
+        def has_option(*args): return False
+        fake_instance.has_option = has_option
+
+        fn = tempfile.NamedTemporaryFile()
+        fake_expanduser.return_value = fn.name
+
+        os.chmod(fn.name, 0777)
+        fake_listdir.return_value = ['A', 'B', 'C']
+        cfg = read_config()
+
+        #validation
+        paths = [
+            '/etc/pulp/admin/admin.conf',
+            '/etc/pulp/admin/conf.d/A',
+            '/etc/pulp/admin/conf.d/B',
+            '/etc/pulp/admin/conf.d/C',
+            fn.name,
+        ]
         fake_config.assert_called_with(*paths)
         fake_config().validate.assert_called_with(SCHEMA)
         self.assertEqual(cfg, fake_config())

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -35,9 +35,12 @@ def main(config, exception_handler_class=ExceptionHandler):
     parser = OptionParser()
     parser.disable_interspersed_args()
     parser.add_option('-u', '--username', dest='username', action='store', default=None,
-                      help=_('credentials for the Pulp server; if specified will bypass the stored certificate'))
+                      help=_('username for the Pulp server; if used will bypass the stored '
+                             'certificate and override config file values and the default'))
     parser.add_option('-p', '--password', dest='password', action='store', default=None,
-                      help=_('credentials for the Pulp server; must be specified with --username'))
+                      help=_('password for the Pulp server; must be used with --username. '
+                             'if used will bypass the stored certificate and override config '
+                             'file values and the default'))
     parser.add_option('--debug', dest='debug', action='store_true', default=False,
                       help=_('enables debug logging'))
     parser.add_option('--config', dest='config', default=None,
@@ -59,6 +62,12 @@ def main(config, exception_handler_class=ExceptionHandler):
     # REST Bindings
     username = options.username
     password = options.password
+
+    # get username/password from config ~/.pulp/admin.conf if available
+    if not username and not password:
+        username = config['auth']['username']
+        password = config['auth']['password']
+
     if username and not password:
         prompt_msg = 'Enter password: '
         password = prompt.prompt_password(_(prompt_msg))

--- a/docs/user-guide/admin-client/authentication.rst
+++ b/docs/user-guide/admin-client/authentication.rst
@@ -10,20 +10,51 @@ All pulp-admin commands accept username and password to capture authentication c
 
 ::
 
-	$ pulp-admin --help
-	Usage: pulp-admin [options]
+    $ pulp-admin --help
+    Usage: pulp-admin [options]
 
-	Options:
-	-h, --help	            show this help message and exit
-	-u USERNAME, --username=USERNAME
-		                    credentials for the Pulp server; if specified will
-	    	                bypass the stored certificate
-	-p PASSWORD, --password=PASSWORD
-		                    credentials for the Pulp server; must be specified
-	    	                with --username
-	--debug	        	    enables debug logging
-	--config=CONFIG	        absolute path to the configuration file
-	--map                   prints a map of the CLI sections and commands
+    Options:
+      -h, --help            show this help message and exit
+      -u USERNAME, --username=USERNAME
+                            username for the Pulp server; if used will bypass the
+                            stored certificate and override config file values and
+                            the default
+      -p PASSWORD, --password=PASSWORD
+                            password for the Pulp server; must be used with
+                            --username. if used will bypass the stored certificate
+                            and override config file values and the default
+      --debug               enables debug logging
+      --config=CONFIG       absolute path to the configuration file
+      --map                 prints a map of the CLI sections and commands
+
+
+Pulp Admin client allows the user to specify username and password credentials
+in the user's local admin.conf ``~/.pulp/admin.conf``. Using the conf file 
+avoids having to pass user credentials repeatedly using the command line.
+Also reading the password from a file that can only be read by certain users 
+is more secure because it cannot be shown by listing the system processes.
+
+::
+
+    # Add the following snippet to ``~/.pulp/admin.conf``
+
+    [auth]
+    username: admin
+    password: admin
+
+    # This enables the user to run pulp-admin commands without providing a username
+    # and password using the command line
+
+    $ pulp-admin repo list
+    +----------------------------------------------------------------------+
+                                  Repositories
+    +----------------------------------------------------------------------+
+
+
+pulp-admin finds username and password credentials in the following order.
+    - credentials specified from the command line.
+    - credentials set in user's ``~/.pulp/admin.conf``.
+    - default credentials used by Pulp.
 
 Pulp Server installation comes with one default user created with admin level privileges.
 Username and password for this user can be configured in ``/etc/pulp/server.conf`` at the time
@@ -34,11 +65,11 @@ running a pulp-admin command.
 
 ::
 
-	$ pulp-admin -u admin repo list
-	Enter password:
-	+----------------------------------------------------------------------+
-	                              Repositories
-	+----------------------------------------------------------------------+
+    $ pulp-admin -u admin repo list
+    Enter password:
+    +----------------------------------------------------------------------+
+                                  Repositories
+    +----------------------------------------------------------------------+
 
 
 Note that username and password are parameters to the ``pulp-admin`` command, not the sub-command,

--- a/docs/user-guide/release-notes/master.rst
+++ b/docs/user-guide/release-notes/master.rst
@@ -8,6 +8,10 @@ Pulp master
 New Features
 ------------
 
+- Pulp now allows user credentials to be read from user's ``~/.pulp/admin.conf``.
+  This should allow pulp-admin to be automated more easily and more securely.
+  Please see our :ref:`Authentication` documentation for details.
+
 Deprecation
 -----------
 


### PR DESCRIPTION
Allow pulp to read user credentials from users admin.conf
if he/she does not want to provide password on command prompt
or --password in pulp-admin
