### PR TITLE
Ports DB connection to mongoengine and adds lots of tests

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -265,6 +265,7 @@ Requires: python-%{name}-common = %{pulp_version}
 Requires: python-celery >= 3.1.0
 Requires: python-celery < 3.2.0
 Requires: python-pymongo >= 2.5.2
+Requires: python-mongoengine >= 0.7.10
 Requires: python-setuptools
 Requires: python-webpy
 Requires: python-okaara >= 1.0.32

--- a/server/test/unit/server/db/test_connection.py
+++ b/server/test/unit/server/db/test_connection.py
@@ -1,43 +1,262 @@
 #!/usr/bin/python
-#
-# Copyright (c) 2011 Red Hat, Inc.
-#
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
-from ... import base
+from ConfigParser import NoOptionError
 import unittest
 
-from mock import patch
+from mock import patch, Mock, call
 
 from pulp.server import config
 from pulp.server.db import connection
 
 
-class TestDatabase(base.PulpServerTests):
-
-    def test_database_name(self):
-        self.assertEquals(connection._DATABASE.name, self.config.get("database", "name"))
+class MongoEngineConnectionError(Exception):
+    pass
 
 
-class TestDatabaseVersion(base.PulpServerTests):
+class TestDatabaseSeeds(unittest.TestCase):
+
+    def tearDown(self):
+        # Reload the configuration so that things are cleaned up properly
+        config.load_configuration()
+        super(TestDatabaseSeeds, self).tearDown()
+
+    def test_seeds_default(self):
+        self.assertEqual(config.config.get('database', 'seeds'), 'localhost:27017')
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_seeds_is_set_from_argument(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize(seeds='seeds_set_from_argument')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        mock_mongoengine.connect.assert_called_once_with('seeds_set_from_argument',
+                                                         max_pool_size=max_pool_size)
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_seeds_from_config(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        config.config.set('database', 'seeds', 'other_value_for_seeds')
+        connection.initialize()
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        mock_mongoengine.connect.assert_called_once_with('other_value_for_seeds',
+                                                         max_pool_size=max_pool_size)
+
+
+class TestDatabaseName(unittest.TestCase):
+
+    def tearDown(self):
+        # Reload the configuration so that things are cleaned up properly
+        config.load_configuration()
+        super(TestDatabaseName, self).tearDown()
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test__DATABASE_uses_default_name(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize()
+        name = config.config.get('database', 'name')
+        expected_database = getattr(mock_mongoengine.connect.return_value, name)
+        self.assertEquals(connection._DATABASE, expected_database)
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_name_is_set_from_argument(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize(name='name_set_from_argument')
+        expected_database = getattr(mock_mongoengine.connect.return_value, 'name_set_from_argument')
+        self.assertEquals(connection._DATABASE, expected_database)
+
+
+class TestDatabaseReplicaSet(unittest.TestCase):
+
+    def tearDown(self):
+        # Reload the configuration so that things are cleaned up properly
+        config.load_configuration()
+        super(TestDatabaseReplicaSet, self).tearDown()
+
+    def test_replica_set_default_does_not_exist(self):
+        self.assertRaises(NoOptionError, config.config.get, 'database', 'replica_set')
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_database_sets_replica_set(self, mock_mongoengine):
+        mock_replica_set = Mock()
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize(replica_set=mock_replica_set)
+        database = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        mock_mongoengine.connect.assert_called_once_with(database, max_pool_size=max_pool_size,
+                                                         replicaset=mock_replica_set)
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_database_replica_set_from_config(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        config.config.set('database', 'replica_set', 'real_replica_set')
+        connection.initialize()
+        database = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        mock_mongoengine.connect.assert_called_once_with(database, max_pool_size=max_pool_size,
+                                                         replicaset='real_replica_set')
+
+
+class TestDatabaseMaxPoolSize(unittest.TestCase):
+
+    def tearDown(self):
+        # Reload the configuration so that things are cleaned up properly
+        config.load_configuration()
+        super(TestDatabaseMaxPoolSize, self).tearDown()
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_database_max_pool_size_default_is_10(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize()
+        database = config.config.get('database', 'seeds')
+        mock_mongoengine.connect.assert_called_once_with(database, max_pool_size=10)
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_database_max_pool_size_uses_default(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize()
+        database = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        mock_mongoengine.connect.assert_called_once_with(database, max_pool_size=max_pool_size)
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_database_max_pool_size(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize(max_pool_size=5)
+        database = config.config.get('database', 'seeds')
+        mock_mongoengine.connect.assert_called_once_with(database, max_pool_size=5)
+
+
+class TestDatabase(unittest.TestCase):
+
+    def tearDown(self):
+        # Reload the configuration so that things are cleaned up properly
+        config.load_configuration()
+        super(TestDatabase, self).tearDown()
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_mongoengine_connect_is_called(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize()
+        mock_mongoengine.connect.assert_called_once()
+
+    @patch('pulp.server.db.connection.NamespaceInjector')
+    @patch('pulp.server.db.connection.mongoengine')
+    def test__DATABASE_receives_namespace_injector(self, mock_mongoengine, mock_namespace_injector):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize()
+        mock_son_manipulator = connection._DATABASE.add_son_manipulator
+        mock_namespace_injector.assert_called_once_with()
+        mock_son_manipulator.assert_called_once_with(mock_namespace_injector.return_value)
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test__DATABASE_collection_names_is_caled(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize()
+        connection._DATABASE.collection_names.assert_called_once_with()
+
+    @patch('pulp.server.db.connection.mongoengine')
+    @patch('pulp.server.db.connection._logger')
+    def test_unexpected_Exception_is_logged(self, mock__logger, mock_mongoengine):
+        mock_mongoengine.connect.side_effect = IOError()
+        self.assertRaises(IOError, connection.initialize)
+        self.assertTrue(connection._CONNECTION is None)
+        self.assertTrue(connection._DATABASE is None)
+        mock__logger.critical.assert_called_once()
+
+
+class TestDatabaseSSL(unittest.TestCase):
+
+    def tearDown(self):
+        # Reload the configuration so that things are cleaned up properly
+        config.load_configuration()
+        super(TestDatabaseSSL, self).tearDown()
+
+    def test_ssl_off_by_default(self):
+        self.assertEqual(config.config.getboolean('database', 'ssl'), False)
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_ssl_is_skipped_if_off(self, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        config.config.set('database', 'ssl', 'false')
+        connection.initialize()
+        seeds = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        mock_mongoengine.connect.assert_called_once_with(seeds, max_pool_size=max_pool_size)
+
+    @patch('pulp.server.db.connection.ssl')
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_ssl_is_configured_with_verify_ssl_on(self, mock_mongoengine, mock_ssl):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        config.config.set('database', 'verify_ssl', 'true')
+        config.config.set('database', 'ssl', 'true')
+        connection.initialize()
+        seeds = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        ssl_cert_reqs = mock_ssl.CERT_REQUIRED
+        ssl_ca_certs = config.config.get('database', 'ca_path')
+        mock_mongoengine.connect.assert_called_once_with(seeds, max_pool_size=max_pool_size,
+                                                         ssl=True, ssl_cert_reqs=ssl_cert_reqs,
+                                                         ssl_ca_certs=ssl_ca_certs)
+
+    @patch('pulp.server.db.connection.ssl')
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_ssl_is_configured_with_verify_ssl_off(self, mock_mongoengine, mock_ssl):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        config.config.set('database', 'verify_ssl', 'false')
+        config.config.set('database', 'ssl', 'true')
+        connection.initialize()
+        seeds = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        ssl_cert_reqs = mock_ssl.CERT_NONE
+        ssl_ca_certs = config.config.get('database', 'ca_path')
+        mock_mongoengine.connect.assert_called_once_with(seeds, max_pool_size=max_pool_size,
+                                                         ssl=True, ssl_cert_reqs=ssl_cert_reqs,
+                                                         ssl_ca_certs=ssl_ca_certs)
+
+    @patch('pulp.server.db.connection.ssl')
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_ssl_is_configured_with_ssl_keyfile(self, mock_mongoengine, mock_ssl):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        config.config.set('database', 'ssl_keyfile', 'keyfilepath')
+        config.config.set('database', 'verify_ssl', 'false')
+        config.config.set('database', 'ssl', 'true')
+        connection.initialize()
+        seeds = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        ssl_cert_reqs = mock_ssl.CERT_NONE
+        ssl_ca_certs = config.config.get('database', 'ca_path')
+        mock_mongoengine.connect.assert_called_once_with(seeds, max_pool_size=max_pool_size,
+                                                         ssl=True, ssl_cert_reqs=ssl_cert_reqs,
+                                                         ssl_ca_certs=ssl_ca_certs,
+                                                         ssl_keyfile='keyfilepath')
+
+    @patch('pulp.server.db.connection.ssl')
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_ssl_is_configured_with_ssl_certfile(self, mock_mongoengine, mock_ssl):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        config.config.set('database', 'ssl_certfile', 'certfilepath')
+        config.config.set('database', 'verify_ssl', 'false')
+        config.config.set('database', 'ssl', 'true')
+        connection.initialize()
+        seeds = config.config.get('database', 'seeds')
+        max_pool_size = connection._DEFAULT_MAX_POOL_SIZE
+        ssl_cert_reqs = mock_ssl.CERT_NONE
+        ssl_ca_certs = config.config.get('database', 'ca_path')
+        mock_mongoengine.connect.assert_called_once_with(seeds, max_pool_size=max_pool_size,
+                                                         ssl=True, ssl_cert_reqs=ssl_cert_reqs,
+                                                         ssl_ca_certs=ssl_ca_certs,
+                                                         ssl_certfile='certfilepath')
+
+
+class TestDatabaseVersion(unittest.TestCase):
 
     """
     test DB version parsing. Info on expected versions is at
     https://github.com/mongodb/mongo/blob/master/src/mongo/util/version.cpp#L39-45
     """
-    @patch("pymongo.MongoClient")
-    @patch("pulp.server.db.connection._end_request_decorator")
-    def _test_initialize(self, version_str, mock_end, mock_mongoclient):
-        mock_mongoclient_instance = mock_mongoclient.return_value
-        mock_mongoclient_instance.server_info.return_value = {"version": version_str}
+    @patch('pulp.server.db.connection.mongoengine')
+    def _test_initialize(self, version_str, mock_mongoengine):
+        mock_mongoclient_connect = mock_mongoengine.connect.return_value
+        mock_mongoclient_connect.server_info.return_value = {'version': version_str}
         connection.initialize()
 
     def test_database_version_bad_version(self):
@@ -67,51 +286,110 @@ class TestDatabaseVersion(base.PulpServerTests):
             pass  # expected exception
 
 
-class TestDatabaseAuthentication(base.PulpServerTests):
+class TestDatabaseAuthentication(unittest.TestCase):
 
     def tearDown(self):
         # Reload the configuration so that things are cleaned up properly
         config.load_configuration()
         super(TestDatabaseAuthentication, self).tearDown()
 
-    @patch("pymongo.MongoClient")
-    @patch("pulp.server.db.connection._end_request_decorator")
-    def test_initialize_username_and_password(self, mock_end, mock_mongoclient):
-        mock_mongoclient_instance = mock_mongoclient.return_value
-        mock_mongoclient_instance.server_info.return_value = {"version":
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_initialize_username_and_password(self, mock_mongoengine):
+        mock_mongoengine_instance = mock_mongoengine.connect.return_value
+        mock_mongoengine_instance.server_info.return_value = {"version":
                                                               connection.MONGO_MINIMUM_VERSION}
         config.config.set('database', 'username', 'admin')
         config.config.set('database', 'password', 'admin')
         connection.initialize()
         self.assertTrue(connection._DATABASE.authenticate.called)
 
-    @patch("pymongo.MongoClient")
-    @patch("pulp.server.db.connection._end_request_decorator")
-    def test_initialize_no_username_or_password(self, mock_end, mock_mongoclient):
-        mock_mongoclient_instance = mock_mongoclient.return_value
-        mock_mongoclient_instance.server_info.return_value = {"version":
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_initialize_no_username_or_password(self, mock_mongoengine):
+        mock_mongoengine_instance = mock_mongoengine.connect.return_value
+        mock_mongoengine_instance.server_info.return_value = {"version":
                                                               connection.MONGO_MINIMUM_VERSION}
         config.config.set('database', 'username', '')
         config.config.set('database', 'password', '')
         connection.initialize()
         self.assertFalse(connection._DATABASE.authenticate.called)
 
-    @patch("pymongo.MongoClient")
-    @patch("pulp.server.db.connection._end_request_decorator")
-    def test_initialize_username_no_password(self, mock_end, mock_mongoclient):
-        mock_mongoclient_instance = mock_mongoclient.return_value
-        mock_mongoclient_instance.server_info.return_value = {"version":
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_initialize_username_no_password(self, mock_mongoengine):
+        mock_mongoengine_instance = mock_mongoengine.connect.return_value
+        mock_mongoengine_instance.server_info.return_value = {"version":
                                                               connection.MONGO_MINIMUM_VERSION}
         config.config.set('database', 'username', 'admin')
         config.config.set('database', 'password', '')
         self.assertRaises(Exception, connection.initialize)
 
-    @patch("pymongo.MongoClient")
-    @patch("pulp.server.db.connection._end_request_decorator")
-    def test_initialize_password_no_username(self, mock_end, mock_mongoclient):
-        mock_mongoclient_instance = mock_mongoclient.return_value
-        mock_mongoclient_instance.server_info.return_value = {"version":
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_initialize_password_no_username(self, mock_mongoengine):
+        mock_mongoengine_instance = mock_mongoengine.connect.return_value
+        mock_mongoengine_instance.server_info.return_value = {"version":
                                                               connection.MONGO_MINIMUM_VERSION}
         config.config.set('database', 'username', '')
         config.config.set('database', 'password', 'foo')
         self.assertRaises(Exception, connection.initialize)
+
+
+class TestDatabaseRetryOnInitialConnectionSupport(unittest.TestCase):
+
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_retry_waits_when_mongoengine_connection_error_is_raised(self, mock_mongoengine):
+        def break_out_on_second(*args, **kwargs):
+            mock_mongoengine.connect.side_effect = StopIteration()
+            raise MongoEngineConnectionError()
+
+        mock_mongoengine.connect.side_effect = break_out_on_second
+        mock_mongoengine.connection.ConnectionError = MongoEngineConnectionError
+
+        self.assertRaises(StopIteration, connection.initialize)
+
+    @patch('pulp.server.db.connection.time.sleep')
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_retry_sleeps_with_backoff(self, mock_mongoengine, mock_sleep):
+        def break_out_on_second(*args, **kwargs):
+            mock_sleep.side_effect = StopIteration()
+
+        mock_sleep.side_effect = break_out_on_second
+        mock_mongoengine.connect.side_effect = MongoEngineConnectionError()
+        mock_mongoengine.connection.ConnectionError = MongoEngineConnectionError
+
+        self.assertRaises(StopIteration, connection.initialize)
+        mock_sleep.assert_has_calls([call(1), call(2)])
+
+    @patch('pulp.server.db.connection.time.sleep')
+    @patch('pulp.server.db.connection.mongoengine')
+    def test_retry_with_max_timeout(self, mock_mongoengine, mock_sleep):
+        def break_out_on_second(*args, **kwargs):
+            mock_sleep.side_effect = StopIteration()
+
+        mock_sleep.side_effect = break_out_on_second
+        mock_mongoengine.connect.side_effect = MongoEngineConnectionError()
+        mock_mongoengine.connection.ConnectionError = MongoEngineConnectionError
+
+        self.assertRaises(StopIteration, connection.initialize, max_timeout=1)
+        mock_sleep.assert_has_calls([call(1), call(1)])
+
+    @patch('pulp.server.db.connection.mongoengine')
+    @patch('pulp.server.db.connection.itertools')
+    def test_retry_uses_itertools_chain_and_repeat(self, mock_itertools, mock_mongoengine):
+        mock_mongoengine.connect.return_value.server_info.return_value = {'version': '2.6.0'}
+        connection.initialize()
+        mock_itertools.repeat.assert_called_once_with(32)
+        mock_itertools.chain.assert_called_once_with([1, 2, 4, 8, 16],
+                                                     mock_itertools.repeat.return_value)
+
+
+class TestGetDatabaseFunction(unittest.TestCase):
+
+    @patch('pulp.server.db.connection._DATABASE')
+    def test_get_database(self, mock__DATABASE):
+        self.assertEqual(mock__DATABASE, connection.get_database())
+
+
+class TestGetConnectionFunction(unittest.TestCase):
+
+    @patch('pulp.server.db.connection._CONNECTION')
+    def test_get_connection(self, mock__CONNECTION):
+        self.assertEqual(mock__CONNECTION, connection.get_connection())


### PR DESCRIPTION
This PR replaces PyMongo connection with mongoengine which still uses PyMongo underneath. It also improves the test coverage significantly of the module significantly and fixes some internationalization problems.

I removed the send_message() and send_message_with_response() wrappers which were related to an older bug, [BZ 976561](https://bugzilla.redhat.com/show_bug.cgi?id=976561). I tested with mongoengine==0.7.10 and pymongo==2.6.3

I think this may be an issue that was fixed in pymongo. The oldest version Pulp would use is pymongo==2.5.2 on EL6. When I [look into the PyMongo code](https://github.com/mongodb/mongo-python-driver/blob/v2.5/pymongo/mongo_client.py#L922) it seems to do a good job of releasing these sockets at the right times.

I also hand tested it by doing the following:
1. Adjust Pulp to use only 1 WSGI process, restart httpd, and verify with `ps` that exactly 1 WSGI process is running for Pulp. My WSGI PID is 21638
2. I then create 5000 rpms and upload them as described by [this comment](https://bugzilla.redhat.com/show_bug.cgi?id=976561#c10).
3. I also monitored the uploads using `sudo lsof -p 21638 | wc -l`

I was able to upload all the RPMs without error, and I monitored the lsof output which was at 251 prior to the upload starting and stayed between 258 - 260 at all times during the upload. I also propose that I move [BZ 976561](https://bugzilla.redhat.com/show_bug.cgi?id=976561) to ON_QA for 2.6 so that QE can verify I haven't introduced a regression. I'd like feedback on that idea specifically.

I did not refactor PulpCollection or provide coverage for the helper methods it uses. Those things will be rewritten at a later time so writing tests for them now is not valuable.
