### PR TITLE
[WIP] 1111591 - require passwords to not be empty strings

### DIFF
--- a/client_admin/pulp/client/admin/auth.py
+++ b/client_admin/pulp/client/admin/auth.py
@@ -109,11 +109,19 @@ class UserSection(PulpCliSection):
             prompt_msg = "Enter password for user [%s] : " % login
             verify_msg = "Re-enter password for user [%s]: " % login
             unmatch_msg = "Passwords do not match"
-            password = self.context.prompt.prompt_password(_(prompt_msg), _(verify_msg), _(unmatch_msg))
+
+        while True:
+            password = self.context.prompt.prompt_password(_(prompt_msg), _(verify_msg),
+                                                           _(unmatch_msg))
             if password is self.context.prompt.ABORT:
                 self.context.prompt.render_spacer()
                 self.context.prompt.write(_('Create user cancelled'))
                 return os.EX_NOUSER
+            if password:
+                break
+            else:
+                self.context.prompt.render_spacer()
+                self.prompt.render_failure_message(_('Password cannot be emtpy'))
 
         name = kwargs['name'] or login
 


### PR DESCRIPTION
This is a work around to fix [BZ-1111591](https://bugzilla.redhat.com/show_bug.cgi?id=111159). A better solution would be add an optional validator to Okaara's `prompt_password`.

Currently empty passwords cannot work because the password will be assigned the next value it is given. The command:

```
pulp-admin -u user -p  login
```

takes the argument "login" as a password.

We should not allow the user to get into an unusable state. 
