### PR TITLE
Removes default admin/admin credentials from global admin.conf

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -88,22 +88,3 @@
 # enable_color: true
 # wrap_to_terminal: false
 # wrap_width: 80
-
-
-# Client authentication
-#
-# This enables all system users to run pulp-admin commands using the username
-# and password specified here. Values contained in a user's ~/.pulp/admin.conf
-# override values specified here.
-#
-# WARNING: This file is world-readable so only use a password here that is
-#          appropriate for any system user to read.
-#
-# username:
-#   pulp username
-# password:
-#   pulp user's password
-
-[auth]
-#username: admin
-#password: admin

--- a/client_admin/test/unit/test_config.py
+++ b/client_admin/test/unit/test_config.py
@@ -1,11 +1,6 @@
-
-import os
-import os.path
-import tempfile
-
 from unittest import TestCase
 
-from mock import patch, Mock
+from mock import call, Mock, patch
 
 from pulp.client.admin.config import read_config, validate_overrides, SCHEMA, DEFAULT
 
@@ -131,7 +126,7 @@ class TestConfig(TestCase):
         mock_os_stat.return_value.st_mode = 33279
         mock_config.return_value.has_option.return_value = True
         self.assertRaises(RuntimeError, validate_overrides, '/tmp/admin.conf')
-        mock_os_stat.assert_called_once_with('/tmp/admin.conf')
+        mock_os_stat.assert_has_calls([call('/tmp/admin.conf')])
         mock_config.return_value.has_option.assert_called_once_with('auth', 'password')
 
     @patch('pulp.client.admin.config.os.stat')

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -40,11 +40,11 @@ def main(config, exception_handler_class=ExceptionHandler):
     parser.disable_interspersed_args()
     parser.add_option('-u', '--username', dest='username', action='store', default=None,
                       help=_('username for the Pulp server; if used will bypass the stored '
-                             'certificate and override config file values and the default'))
+                             'certificate and override a username specified in ~/.pulp/admin.conf'))
     parser.add_option('-p', '--password', dest='password', action='store', default=None,
                       help=_('password for the Pulp server; must be used with --username. '
-                             'if used will bypass the stored certificate and override config '
-                             'file values and the default'))
+                             'if used will bypass the stored certificate and override a password '
+                             'specified in ~/.pulp/admin.conf'))
     parser.add_option('--debug', dest='debug', action='store_true', default=False,
                       help=_('enables debug logging'))
     parser.add_option('--config', dest='config', default=None,
@@ -67,10 +67,14 @@ def main(config, exception_handler_class=ExceptionHandler):
     username = options.username
     password = options.password
 
-    # get username/password from config ~/.pulp/admin.conf if available
     if not username and not password:
-        username = config['auth']['username']
-        password = config['auth']['password']
+        # Try to get username/password from config if not explicitly set. username and password are
+        # not included by default so we need to catch KeyError Exceptions.
+        try:
+            username = config['auth']['username']
+            password = config['auth']['password']
+        except KeyError:
+            pass
 
     if username and not password:
         prompt_msg = 'Enter password: '

--- a/docs/user-guide/admin-client/authentication.rst
+++ b/docs/user-guide/admin-client/authentication.rst
@@ -17,12 +17,12 @@ All pulp-admin commands accept username and password to capture authentication c
       -h, --help            show this help message and exit
       -u USERNAME, --username=USERNAME
                             username for the Pulp server; if used will bypass the
-                            stored certificate and override config file values and
-                            the default
+                            stored certificate and override a username specified
+                            in ~/.pulp/admin.conf
       -p PASSWORD, --password=PASSWORD
                             password for the Pulp server; must be used with
-                            --username. if used will bypass the stored certificate
-                            and override config file values and the default
+                            --username. If used will bypass the stored certificate
+                            and override a password specified in ~/.pulp/admin.conf
       --debug               enables debug logging
       --config=CONFIG       absolute path to the configuration file
       --map                 prints a map of the CLI sections and commands
@@ -51,10 +51,9 @@ is more secure because it cannot be shown by listing the system processes.
     +----------------------------------------------------------------------+
 
 
-pulp-admin finds username and password credentials in the following order.
+pulp-admin searches for a username and password to use in the following order:
     - credentials specified from the command line.
-    - credentials set in user's ``~/.pulp/admin.conf``.
-    - default credentials used by Pulp.
+    - credentials set in the user's ``~/.pulp/admin.conf``.
 
 Pulp Server installation comes with one default user created with admin level privileges.
 Username and password for this user can be configured in ``/etc/pulp/server.conf`` at the time
@@ -65,7 +64,7 @@ running a pulp-admin command.
 
 ::
 
-    $ pulp-admin -u admin repo list
+    $ pulp-admin repo list
     Enter password:
     +----------------------------------------------------------------------+
                                   Repositories

--- a/docs/user-guide/consumer-client/register.rst
+++ b/docs/user-guide/consumer-client/register.rst
@@ -8,7 +8,7 @@ functionality provided by Pulp.
 
 ::
 
- $ sudo pulp-consumer -u admin register --consumer-id my-consumer
+ $ sudo pulp-consumer register --consumer-id my-consumer
  Enter password:
  Consumer [my-consumer] successfully registered
 
@@ -30,7 +30,7 @@ the registration request.
 
 ::
 
- $ sudo pulp-consumer -u admin register --consumer-id my-consumer
+ $ sudo pulp-consumer register --consumer-id my-consumer
  Enter password:
  Consumer [my-consumer] successfully registered
 

--- a/docs/user-guide/nodes.rst
+++ b/docs/user-guide/nodes.rst
@@ -455,7 +455,7 @@ On the Pulp server to be used as the child node:
 
 ::
 
- $ pulp-consumer -u admin register --consumer-id child-1
+ $ pulp-consumer register --consumer-id child-1
 
 7. Activate the node.
 


### PR DESCRIPTION
This removes the admin/admin credentials from being used as defaults. It also updates the documentation so that users know username/password can be put into ~/.pulp/admin.conf

I worked on a validation that disallows passwords from being added to the global admin.conf, but the run_test.py was adding them in during the test runner. That was an unexpected side effect and isn't the real point of this PR so I backed out of that change. At a minimum the example was removed from the global admin.conf.
