### PR TITLE
1165346 - document default host name in admin.conf

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -23,7 +23,7 @@
 #   CA certificates (with openssl-style hashed symlinks, one certificate per file).
 
 [server]
-# host:
+# host: # If not specified, this value will default to socket.gethostname().
 # port: 443
 # api_prefix: /pulp/api
 # verify_ssl: True


### PR DESCRIPTION
The default behavior is to call `socket.gethostname()` but this is not consistent with the rest of the conf file which contains the default values commented out.

[BZ - 1165346](https://bugzilla.redhat.com/show_bug.cgi?id=1165346)
