### PR TITLE
Preparation for gofer 2.0 in f21 and beyond.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -240,8 +240,8 @@ Requires: mod_ssl
 Requires: openssl
 Requires: nss-tools
 Requires: python-ldap
-Requires: python-gofer >= 1.3.0
-Requires: python-gofer-qpid >= 1.3.0
+Requires: python-gofer >= 1.3.0, python-gofer < 2.0
+Requires: python-gofer-qpid >= 1.3.0, python-gofer-qpid < 2.0
 Requires: crontabs
 Requires: acl
 Requires: mod_wsgi >= 3.4-1.pulp
@@ -518,9 +518,9 @@ Group: Development/Languages
 Requires: python-%{name}-bindings = %{pulp_version}
 Requires: python-%{name}-agent-lib = %{pulp_version}
 Requires: %{name}-consumer-client = %{pulp_version}
-Requires: python-gofer >= 1.3.0
-Requires: python-gofer-qpid >= 1.3.0
-Requires: gofer >= 1.3.0
+Requires: python-gofer >= 1.3.0, python-gofer < 2.0
+Requires: python-gofer-qpid >= 1.3.0, python-gofer-qpid < 2.0
+Requires: gofer >= 1.3.0, gofer < 2.0
 Requires: m2crypto
 
 %description agent


### PR DESCRIPTION
Gofer 2.0 included in Fedora 21 and 22 (and beyond) will have some minor API incompatibilities.
