### PR TITLE
1165355 - Add a sanitize_checksum_type function.

### DIFF
--- a/server/pulp/plugins/util/verification.py
+++ b/server/pulp/plugins/util/verification.py
@@ -50,6 +50,30 @@ class VerificationException(ValueError):
     pass
 
 
+def sanitize_checksum_type(checksum_type):
+    """ 
+    This function will always return the given checksum_type in lower case, unless it is sha, in
+    which case it will return "sha1". SHA and SHA-1 are the same algorithm, and so we prefer to use
+    "sha1", since it is a more specific name. For some unit types (such as RPM), this can cause
+    conflicts inside of Pulp when repos or uploads use a mix of sha and sha1. See
+    https://bugzilla.redhat.com/show_bug.cgi?id=1165355
+
+    :param checksum_type: The checksum type we are sanitizing
+    :type  checksum_type: basestring
+    :return:              A sanitized checksum type, converting "sha" to "sha1", otherwise returning
+                          the given checksum_type in lowercase.
+    :rtype:               basestring
+    """
+    # In our unit tests, there are examples of checksum_type being None. Since None doesn't have
+    # string-like operations we cannot continue, so we should return.
+    if checksum_type is None:
+        return checksum_type
+
+    if checksum_type.lower() == "sha":
+        return "sha1"
+    return checksum_type.lower()
+
+
 def verify_size(file_object, expected_size):
     """
     Returns whether or not the size of the contents of the given file-like object match

--- a/server/test/unit/plugins/util/test_verification.py
+++ b/server/test/unit/plugins/util/test_verification.py
@@ -17,6 +17,51 @@ import unittest
 from pulp.plugins.util import verification
 
 
+class TestSanitizeChecksumType(unittest.TestCase):
+    """
+    This class contains tests for the sanitize_checksum_type() function.
+    """
+    def test_none(self):
+        """
+        Assert correct behavior when the checksum_type is None.
+        """
+        checksum_type = verification.sanitize_checksum_type(None)
+
+        self.assertEqual(checksum_type, None)
+
+    def test_nothing_necessary(self):
+        """
+        Assert that the method doesn't change the checksum_type when it's not needed.
+        """
+        checksum_type = verification.sanitize_checksum_type('sha512')
+
+        self.assertEqual(checksum_type, 'sha512')
+
+    def test_sha_to_sha1(self):
+        """
+        Assert that "sha" is converted to "sha1".
+        """
+        checksum_type = verification.sanitize_checksum_type('sha')
+
+        self.assertEqual(checksum_type, 'sha1')
+
+    def test_ShA_to_sha1(self):
+        """
+        Assert that "ShA" is converted to "sha1".
+        """
+        checksum_type = verification.sanitize_checksum_type('ShA')
+
+        self.assertEqual(checksum_type, 'sha1')
+
+    def test_SHA256_to_sha256(self):
+        """
+        Assert that "SHA256" is converted to "sha256".
+        """
+        checksum_type = verification.sanitize_checksum_type('SHA256')
+
+        self.assertEqual(checksum_type, 'sha256')
+
+
 class VerificationTests(unittest.TestCase):
 
     def test_size(self):


### PR DESCRIPTION
This is the fix for the SHA/SHA-1 collision bug our users have been experiencing.

Most of the work is in the pulp_rpm project:

```
https://github.com/pulp/pulp_rpm/pull/602
```

https://bugzilla.redhat.com/show_bug.cgi?id=1165355
