### PR TITLE
Bumps python-qpid dep to release three

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -1,6 +1,6 @@
 {
     "python-qpid": {
-        "version": "0.26-2",
+        "version": "0.26-3",
         "platform": ["el6"]
     },
     "qpid-cpp": {


### PR DESCRIPTION
This bumps to the [python-qpid-0.26-3](http://koji.katello.org/koji/taskinfo?taskID=193876) that is already built on Koji. This is important for the transition of kombu to 3.0.24.
