### PR TITLE
1150128 - The pulp-consumer tool now reports the error message for permission exceptions.

### DIFF
--- a/client_consumer/pulp/client/consumer/exception_handler.py
+++ b/client_consumer/pulp/client/consumer/exception_handler.py
@@ -1,15 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 import logging
 from gettext import gettext as _
 
@@ -28,15 +16,8 @@ class ConsumerExceptionHandler(ExceptionHandler):
         the displayed error message to that behavior.
         """
 
-        msg = _('Authentication Failed')
-
-        desc = _('A valid Pulp user is required to register a new consumer. '
-                 'Please double check the username and password and attempt the '
-                 'request again.')
-
-        _logger.error("%(msg)s - %(desc)s" % {'msg': msg, 'desc': desc})
-
+        msg = _(e.error_message)
+        _logger.error(msg)
         self.prompt.render_failure_message(msg)
-        self.prompt.render_paragraph(desc)
 
         return CODE_PERMISSIONS_EXCEPTION

--- a/client_consumer/test/unit/test_exception_handler.py
+++ b/client_consumer/test/unit/test_exception_handler.py
@@ -30,11 +30,10 @@ class ConsumerExceptionHandlerTests(base.PulpClientTests):
         # Test
         response_body = {'auth_error_code': 'authentication_failed'}
         e = exceptions.PermissionsException(response_body)
+        e.error_message = "I've made a huge mistake."
         code = self.handler.handle_permission(e)
 
         # Verify
         self.assertEqual(code, exceptions.CODE_PERMISSIONS_EXCEPTION)
-        self.assertTrue('Authentication' in self.recorder.lines[0])
+        self.assertTrue("I've made a huge mistake.\n" == self.recorder.lines[0])
         self.assertEqual(TAG_FAILURE, self.prompt.get_write_tags()[0])
-        self.assertTrue('A valid' in self.recorder.lines[2]) # skip blank line
-        self.assertEqual(TAG_PARAGRAPH, self.prompt.get_write_tags()[1])

--- a/server/pulp/server/webservices/controllers/decorators.py
+++ b/server/pulp/server/webservices/controllers/decorators.py
@@ -1,14 +1,3 @@
-# Copyright (c) 2011 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 """
 This module contains decorators for web.py class methods.
 
@@ -20,7 +9,7 @@ that certain other methods will exist.
 import logging
 
 from pulp.common import error_codes
-from pulp.server.auth.authorization import CREATE, READ, UPDATE, DELETE, EXECUTE
+from pulp.server.auth.authorization import CREATE, READ, UPDATE, DELETE, EXECUTE, OPERATION_NAMES
 from pulp.server.config import config
 from pulp.server.compat import wraps
 from pulp.server.exceptions import PulpCodedAuthenticationException
@@ -187,12 +176,11 @@ def auth_required(operation=None, super_user_only=False):
                 raise PulpCodedAuthenticationException(error_code=error_codes.PLP0025)
 
             # Check Authorization
-
             principal_manager = factory.principal_manager()
             user_query_manager = factory.user_query_manager()
-
             if super_user_only and not user_query_manager.is_superuser(userid):
-                raise PulpCodedAuthenticationException(error_code=error_codes.PLP0029, user=userid)
+                raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026, user=userid,
+                                                       operation=OPERATION_NAMES[operation])
             # if the operation is None, don't check authorization
             elif operation is not None:
                 if is_consumer:
@@ -200,14 +188,16 @@ def auth_required(operation=None, super_user_only=False):
                         # set default principal = SYSTEM
                         principal_manager.set_principal()
                     else:
-                        raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026, user=userid,
-                                                               operation=operation)
+                        raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026,
+                                                               user=userid,
+                                                               operation=OPERATION_NAMES[operation])
                 elif user_query_manager.is_authorized(http.resource_path(), userid, operation):
                     user = user_query_manager.find_by_login(userid)
                     principal_manager.set_principal(user)
                 else:
-                    raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026, user=userid,
-                                                           operation=operation)
+                    raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026,
+                                                           user=userid,
+                                                           operation=OPERATION_NAMES[operation])
 
             # Authentication and authorization succeeded. Call method and then clear principal.
             value = method(self, *args, **kwargs)

--- a/server/test/unit/server/webservices/controllers/test_decorators.py
+++ b/server/test/unit/server/webservices/controllers/test_decorators.py
@@ -13,6 +13,12 @@ class TestAuthenticationMethods(base.PulpWebserviceTests):
     This class tests the authentication methods
     """
 
+    def func(self):
+        """
+        This method is used in tests involving the decorator. It does absolutely nothing.
+        """
+        pass
+
     @mock.patch('pulp.server.webservices.http.request_info', autospec=True, return_value='notauser')
     def test_check_preauthenticate_failed(self, mock_request_info):
         self.assertRaises(PulpCodedAuthenticationException, decorators.check_preauthenticated)
@@ -56,3 +62,54 @@ class TestAuthenticationMethods(base.PulpWebserviceTests):
         self.assertRaises(PulpCodedAuthenticationException, decorators.oauth_authentication)
         mock_auth_manager.return_value.check_oauth.assert_called_once_with('notnone', 'notnone', 'url',
                                                                            'notnone', 'notnone')
+
+    @mock.patch('pulp.server.webservices.http.resource_path', autospec=True)
+    @mock.patch('pulp.server.managers.factory.principal_manager', autospec=True)
+    @mock.patch('pulp.server.webservices.controllers.decorators.check_preauthenticated')
+    @mock.patch('pulp.server.managers.auth.user.query.UserQueryManager.is_superuser',
+                return_value=False)
+    @mock.patch('pulp.server.managers.auth.user.query.UserQueryManager.is_authorized',
+                return_value=False)
+    def test_auth_decorator_not_super(self, mock_is_authed, *unused_mocks):
+        """
+        Test that if the user is not a super user and the operation requires super user,
+        an exception is raised. This test mocks out the authentication portion of the decorator.
+        """
+        decorated_func = decorators.auth_required(0, True)(self.func)
+        self.assertRaises(PulpCodedAuthenticationException, decorated_func, None)
+        self.assertEqual(0, mock_is_authed.call_count)
+
+    @mock.patch('pulp.server.webservices.http.resource_path', autospec=True)
+    @mock.patch('pulp.server.managers.factory.principal_manager', autospec=True)
+    @mock.patch('pulp.server.webservices.controllers.decorators.consumer_cert_authentication',
+                return_value='gob')
+    @mock.patch('pulp.server.webservices.controllers.decorators.user_cert_authentication',
+                return_value=None)
+    @mock.patch('pulp.server.webservices.controllers.decorators.password_authentication',
+                return_value=None)
+    @mock.patch('pulp.server.webservices.controllers.decorators.check_preauthenticated',
+                return_value=None)
+    @mock.patch('pulp.server.webservices.controllers.decorators.is_consumer_authorized',
+                return_value=False)
+    def test_auth_decorator_consumer_not_authorized(self, mock_is_authorized, *unused_mocks):
+        """
+        Test that if the consumer isn't authorized for a particular action, an exception is
+        raised.
+        """
+        decorated_func = decorators.auth_required(0, False)(self.func)
+        self.assertRaises(PulpCodedAuthenticationException, decorated_func, None)
+        self.assertEqual(1, mock_is_authorized.call_count)
+
+    @mock.patch('pulp.server.webservices.http.resource_path', autospec=True)
+    @mock.patch('pulp.server.managers.factory.principal_manager', autospec=True)
+    @mock.patch('pulp.server.webservices.controllers.decorators.check_preauthenticated')
+    @mock.patch('pulp.server.managers.auth.user.query.UserQueryManager.is_authorized',
+                return_value=False)
+    def test_auth_decorator_not_authorized(self, mock_is_authorized, *unused_mocks):
+        """
+        Test that if an admin user isn't authorized for a particular action, an exception
+        is raised.
+        """
+        decorated_func = decorators.auth_required(0, False)(self.func)
+        self.assertRaises(PulpCodedAuthenticationException, decorated_func, None)
+        self.assertEqual(1, mock_is_authorized.call_count)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1150128

I didn't make a second exception for authorization (like the authentication one https://github.com/pulp/pulp/blob/519f6fd55cd09318b908da23205b4dbf88b45873/server/pulp/server/exceptions.py#L117) because I felt that they should both be returning 401 unauthorized and it felt a bit silly to just subclass the authentication class.

What I did do is change the pulp-consumer tool to print the error message rather than always assuming a permissions exception is because of failed authentication.
