### PR TITLE
1099649 - Allow '.' in role resource permissions

### DIFF
--- a/server/pulp/server/auth/authorization.py
+++ b/server/pulp/server/auth/authorization.py
@@ -45,7 +45,9 @@ def _operations_not_granted_by_roles(resource, operations, roles):
     """
     culled_ops = operations[:]
     for role in roles:
-        permissions = role['permissions']
+        permissions = {}
+        for item in role['permissions']:
+            permissions[item['resource']] = item['permission']
         if resource not in permissions:
             continue
         for operation in culled_ops[:]:

--- a/server/pulp/server/db/migrations/0012_role_schema_change.py
+++ b/server/pulp/server/db/migrations/0012_role_schema_change.py
@@ -1,0 +1,16 @@
+from pulp.server.db.model.auth import Role
+
+
+def migrate(*args, **kwargs):
+    """
+    Move role permissions into the permissions database
+    """
+    collection = Role.get_collection()
+    for role in collection.find({}):
+        updated_permissions = []
+        if isinstance(role['permissions'], dict):
+            for resource, permission in role['permissions'].items():
+                resource_permission = dict(resource=resource, permission=permission)
+                updated_permissions.append(resource_permission)
+            role['permissions'] = updated_permissions
+            collection.save(role, safe=True)

--- a/server/test/unit/server/db/migrations/test_migration_0012.py
+++ b/server/test/unit/server/db/migrations/test_migration_0012.py
@@ -1,0 +1,40 @@
+import unittest
+import mock
+import copy
+from pulp.server.db.migrate.models import MigrationModule
+
+MIGRATION = 'pulp.server.db.migrations.0012_role_schema_change'
+CURRENT = [{"_id": "547e3f9ee138237a3451e419", "display_name": "test",
+            "_ns": "roles", "id": "test",
+            "permissions": {"/v2/random": [4, 2, 1, 3]}}]
+TARGET = [{"_id": "547e3f9ee138237a3451e419", "display_name": "test",
+           "_ns": "roles", "id": "test",
+           "permissions": [{"resource": "/v2/random", "permission": [4, 2, 1, 3]}]}]
+
+
+class TestMigration(unittest.TestCase):
+
+    @mock.patch('pulp.server.db.migrations.0012_role_schema_change.Role')
+    def test_migrate(self, mock_connection):
+        """
+        Test the schema change happens like it should.
+        """
+        role_schema = copy.deepcopy(CURRENT)
+        migration = MigrationModule(MIGRATION)._module
+        collection = mock_connection.get_collection.return_value
+        collection.find.return_value = role_schema
+        migration.migrate()
+        self.assertEquals(role_schema, TARGET)
+
+    @mock.patch('pulp.server.db.migrations.0012_role_schema_change.Role')
+    def test_idempotence(self, mock_connection):
+        """
+        Test the idempotence of the migration
+        """
+        role_schema = copy.deepcopy(TARGET)
+        migration = MigrationModule(MIGRATION)._module
+        collection = mock_connection.get_collection.return_value
+        collection.find.return_value = role_schema
+        migration.migrate()
+        self.assertFalse(collection.save.called)
+        self.assertEquals(role_schema, TARGET)


### PR DESCRIPTION
Allows the use of resources that contain a '.' in role permission definitions

[BZ-1099649](https://bugzilla.redhat.com/show_bug.cgi?id=1099649)