### PR TITLE
Performing a mongo $set: {} will fail on mongo 2.6+

### DIFF
--- a/server/pulp/server/managers/consumer/group/cud.py
+++ b/server/pulp/server/managers/consumer/group/cud.py
@@ -208,7 +208,8 @@ class ConsumerGroupManager(object):
         """
         group_collection = validate_existing_consumer_group(group_id)
         set_doc = dict(('notes.' + k, v) for k, v in notes.items())
-        group_collection.update({'id': group_id}, {'$set': set_doc}, safe=True)
+        if set_doc:
+            group_collection.update({'id': group_id}, {'$set': set_doc}, safe=True)
 
     def remove_notes(self, group_id, keys):
         """

--- a/server/pulp/server/managers/repo/cud.py
+++ b/server/pulp/server/managers/repo/cud.py
@@ -521,7 +521,8 @@ class RepoManager(object):
     def update_repo_scratchpad(self, repo_id, scratchpad):
         """
         Update the repository scratchpad with the specified key-value pairs.
-        New keys are added, existing keys are overwritten.
+        New keys are added, existing keys are overwritten.  If the scratchpad
+        dictionary is empty then this is a no-op.
 
         :param repo_id: A repository ID
         :type repo_id: str
@@ -531,6 +532,12 @@ class RepoManager(object):
 
         :raise MissingResource: if there is no repo with repo_id
         """
+        # If no properties are set then no update should be performed
+        # we have to perform this check as newer versions of mongo
+        # will fail if the $set operation is fed an empty dictionary
+        if not scratchpad:
+            return
+
         properties = {}
         for k, v in scratchpad.items():
             key = 'scratchpad.%s' % k

--- a/server/pulp/server/managers/repo/group/cud.py
+++ b/server/pulp/server/managers/repo/group/cud.py
@@ -259,7 +259,8 @@ class RepoGroupManager(object):
         """
         group_collection = validate_existing_repo_group(group_id)
         set_doc = dict(('notes.' + k, v) for k, v in notes.items())
-        group_collection.update({'id': group_id}, {'$set': set_doc}, safe=True)
+        if set_doc:
+            group_collection.update({'id': group_id}, {'$set': set_doc}, safe=True)
 
     def remove_notes(self, group_id, keys):
         """

--- a/server/test/unit/server/managers/repo/test_cud.py
+++ b/server/test/unit/server/managers/repo/test_cud.py
@@ -582,7 +582,9 @@ class RepoManagerTests(base.ResourceReservationTests):
         self.assertEqual(scratchpad['C'], 3)
         self.assertEqual(scratchpad['D'], 40)
         # missing resource
-        self.assertRaises(exceptions.MissingResource, self.manager.update_repo_scratchpad, 'foo', {})
+        self.assertRaises(exceptions.MissingResource,
+                          self.manager.update_repo_scratchpad,
+                          'foo', {'foo': 'bar'})
 
 
     def test_update_unit_count_missing_repo(self):


### PR DESCRIPTION
 https://jira.mongodb.org/browse/SERVER-12266

Long term this should be fixed by the move to mongoengine.
