### PR TITLE
Updates to /status API

### DIFF
--- a/bindings/pulp/bindings/server_info.py
+++ b/bindings/pulp/bindings/server_info.py
@@ -17,6 +17,7 @@ Handles calls to the server that query the plugin and type capabilities.
 
 from pulp.bindings.base import PulpAPI
 
+
 class ServerInfoAPI(PulpAPI):
     def __init__(self, pulp_connection):
         super(ServerInfoAPI, self).__init__(pulp_connection)
@@ -50,13 +51,4 @@ class ServerInfoAPI(PulpAPI):
         @return: Response
         """
         path = self.base_path + 'distributors/'
-        return self.server.GET(path)
-
-    def ping(self):
-        """
-        Retrieves basic status information from the server.
-
-        @return: Response
-        """
-        path = '/v2/services/status/'
         return self.server.GET(path)

--- a/common/pulp/common/constants.py
+++ b/common/pulp/common/constants.py
@@ -59,3 +59,5 @@ PRIMARY_ID = '___/primary/___'
 
 # this is used by both platform and plugins to find the default CA path
 DEFAULT_CA_PATH = '/etc/pki/tls/certs/ca-bundle.crt'
+
+SCHEDULER_WORKER_NAME = "scheduler"

--- a/docs/dev-guide/integration/rest-api/status.rst
+++ b/docs/dev-guide/integration/rest-api/status.rst
@@ -1,10 +1,30 @@
 Status
 ======
 
+.. _getting_the_server_status:
+
 Getting the Server Status
 -------------------------
 
-An unauthenticated resource that shows the current status of the pulp server.
+An unauthenticated resource that shows the current status of the Pulp server. A
+200 response shows that the server is up and running. Users of this API may
+want to examine ``pulp_messaging_connection``, ``pulp_database_connection``
+and ``known_workers`` to get more detailed status information.
+
+Note that this API is meant to provide an "at-a-glance" status to aid debugging
+of a Pulp deployment, and is not meant to replace monitoring of Pulp components
+in a production environment.
+
+A healthy Pulp installation will contain exactly one record for
+"resource_manager" and "scheduler" in the worker list, and one or more
+"reserved_resource_worker" records. It will also have
+``messaging_connection`` and ``database_connection`` entries that contain ``{connected: True}``.
+Note that if the scheduler is not running, other workers may be running but not
+updating their last heartbeat record.
+
+The version of Pulp is also returned via ``platform_version`` in the
+``versions`` object. This field is calculated from the "pulp-server" python
+package version. Do not use the deprecated ``api_version`` record.
 
 | :method:`get`
 | :path:`/v2/status/`
@@ -12,12 +32,36 @@ An unauthenticated resource that shows the current status of the pulp server.
 
 | :response_list:`_`
 
-    * :response_code:`200,pulp server is up and running`
-    * :response_code:`500,pulp server is down and the administrator should be notified`
+    * :response_code:`200, pulp server is up and running`
+    * :response_code:`500, pulp server is down and the administrator should be notified`
 
 | :return:`JSON document showing current server status`
 
 :sample_response:`200` ::
 
-    {"api_version": "2"}
-
+{
+    "api_version": "2",
+    "database_connection": {
+        "connected": true
+    },
+    "known_workers": [
+        {
+            "last_heartbeat": "2015-01-02T20:39:58Z",
+            "name": "scheduler@status-info-net0.default.virt"
+        },
+        {
+            "last_heartbeat": "2015-01-02T20:40:34Z",
+            "name": "reserved_resource_worker-0@status-info-net0.default.virt"
+        },
+        {
+            "last_heartbeat": "2015-01-02T20:40:36Z",
+            "name": "resource_manager@status-info-net0.default.virt"
+        }
+    ],
+    "messaging_connection": {
+        "connected": true
+    },
+    "versions": {
+        "platform_version": "2.6.0"
+    }
+}

--- a/docs/user-guide/release-notes/2.6.x.rst
+++ b/docs/user-guide/release-notes/2.6.x.rst
@@ -20,6 +20,9 @@ New Features
   username/password however if they set up a SASL database as described in the
   installation document.
 
+- Additional status information is available via the status API.  More
+  information is available in the :ref:`status API document <getting_the_server_status>`.
+
 .. _RabbitMQ: https://www.rabbitmq.com/
 
 Deprecation
@@ -36,6 +39,10 @@ Deprecation
  * The ``cancel_sync_repo`` method provided by the ``Importer`` base plugin class is deprecated and
    will be removed in a future release. Read more about the
    :ref:`plugin cancellation changes <plugin_cancel_now_exits_behavior_change>`.
+
+ * The ``api_version`` field that is returned by the ``/status`` API is
+   deprecated and will be removed in a future release.
+
 
 .. _2.5.x_upgrade_to_2.6.0:
 

--- a/server/pulp/server/async/worker_watcher.py
+++ b/server/pulp/server/async/worker_watcher.py
@@ -28,21 +28,6 @@ from pulp.server.managers import resources
 _logger = logging.getLogger(__name__)
 
 
-def _is_resource_manager(event):
-    """
-    Determine if this event is for a resource manager.
-
-    :param event: A celery event
-    :type event: dict
-    :return: True if this event is from a resource manager, False otherwise.
-    :rtype: bool
-    """
-    if re.match('^%s' % RESOURCE_MANAGER_QUEUE, event['hostname']):
-        return True
-    else:
-        return False
-
-
 def _parse_and_log_event(event):
     """
     Parse and return the event information we are interested in. Also log it.
@@ -84,19 +69,15 @@ def handle_worker_heartbeat(event):
     """
     Celery event handler for 'worker-heartbeat' events.
 
-    The event is first parsed and logged. If this event is from the resource manager, there is
-    no further processing to be done. Then the existing Worker objects are searched
-    for one to update. If an existing one is found, it is updated. Otherwise a new
-    Worker entry is created. Logging at the info and debug level is also done.
+    The event is first parsed and logged.  Then the existing Worker objects are
+    searched for one to update. If an existing one is found, it is updated.
+    Otherwise a new Worker entry is created. Logging at the info and debug
+    level is also done.
 
     :param event: A celery event to handle.
     :type event: dict
     """
     event_info = _parse_and_log_event(event)
-
-    # if this is the resource_manager do nothing
-    if _is_resource_manager(event):
-        return
 
     find_worker_criteria = Criteria(filters={'_id': event_info['worker_name']},
                                     fields=('_id', 'last_heartbeat'))
@@ -131,10 +112,6 @@ def handle_worker_offline(event):
     :type event: dict
     """
     event_info = _parse_and_log_event(event)
-
-    # if this is the resource_manager do nothing
-    if _is_resource_manager(event):
-        return
 
     msg = _("Worker '%(worker_name)s' shutdown") % event_info
     _logger.info(msg)

--- a/server/pulp/server/managers/status.py
+++ b/server/pulp/server/managers/status.py
@@ -1,0 +1,62 @@
+"""
+Manager to return status information about a running Pulp instance
+"""
+
+from pkg_resources import get_distribution
+
+from pulp.server.async.celery_instance import celery
+from pulp.server.db import connection
+from pulp.server.db.model.criteria import Criteria
+from pulp.server.managers import resources
+
+
+def get_version():
+    """
+    :returns:          Pulp platform version
+    :rtype:            str
+    """
+    return {'platform_version': get_distribution("pulp-server").version}
+
+
+def get_workers():
+    """
+    :returns:          list of workers with their heartbeats
+    :rtype:            list
+    """
+    empty_criteria = Criteria()
+    return resources.filter_workers(empty_criteria)
+
+
+def get_mongo_conn_status():
+    """
+    Perform a simple mongo operation and return success or failure.
+
+    This uses a "raw" pymongo Collection to avoid any auto-retry logic.
+
+    :returns:          mongo connection status
+    :rtype:            bool
+    """
+    try:
+        db = connection.get_database()
+        db.workers.count()
+        return {'connected': True}
+    except:
+        return {'connected': False}
+
+
+def get_broker_conn_status():
+    """
+    :returns:          message broker connection status
+    :rtype:            bool
+    """
+    # not all drivers support heartbeats. For now, we need to make an
+    # explicit connection and then release it.
+    # See https://github.com/celery/kombu/issues/432 for more detail.
+    try:
+        conn = celery.connection()
+        conn.connect()
+        conn.release()
+        return {'connected': True}
+    except:
+        # if the above was not successful for any reason, return False
+        return {'connected': False}

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -271,6 +271,16 @@ class TestSchedulerTick(unittest.TestCase):
 
         mock_trim.assert_called_once_with()
 
+    @mock.patch('celery.beat.Scheduler.__init__', new=mock.Mock())
+    @mock.patch('celery.beat.Scheduler.tick')
+    @mock.patch('pulp.server.async.scheduler.worker_watcher.handle_worker_heartbeat')
+    def test_calls_handle_heartbeat(self, mock_heartbeat, mock_tick):
+        sched_instance = scheduler.Scheduler()
+
+        sched_instance.tick()
+
+        mock_heartbeat.assert_called_once()
+
 
 class TestSchedulerSetupSchedule(unittest.TestCase):
 

--- a/server/test/unit/server/async/test_worker_watcher.py
+++ b/server/test/unit/server/async/test_worker_watcher.py
@@ -6,18 +6,6 @@ from pulp.server.async import worker_watcher
 from pulp.server.async.celery_instance import RESOURCE_MANAGER_QUEUE
 
 
-class TestIsResourceManager(unittest.TestCase):
-    def test__is_resource_manager_positive(self):
-        event = {'hostname': RESOURCE_MANAGER_QUEUE + 'the rest of the hostname'}
-        result = worker_watcher._is_resource_manager(event)
-        self.assertTrue(result)
-
-    def test__is_resource_manager_negative(self):
-        event = {'hostname': 'not a matching hostname'}
-        result = worker_watcher._is_resource_manager(event)
-        self.assertFalse(result)
-
-
 class TestParseAndLogEvent(unittest.TestCase):
     @mock.patch('pulp.server.async.worker_watcher.datetime')
     @mock.patch('pulp.server.async.worker_watcher._log_event')
@@ -59,14 +47,13 @@ class TestLogEvent(unittest.TestCase):
 class TestHandleWorkerHeartbeat(unittest.TestCase):
     @mock.patch('__builtin__.list', return_value=False)
     @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event')
-    @mock.patch('pulp.server.async.worker_watcher._is_resource_manager', return_value=False)
     @mock.patch('pulp.server.async.worker_watcher.Criteria')
     @mock.patch('pulp.server.async.worker_watcher.resources')
     @mock.patch('pulp.server.async.worker_watcher.Worker')
     @mock.patch('pulp.server.async.worker_watcher._')
     @mock.patch('pulp.server.async.worker_watcher._logger')
     def test_handle_worker_heartbeat_new(self, mock__logger, mock_gettext, mock_worker,
-                                         mock_resources, mock_criteria, mock__is_resource_manager,
+                                         mock_resources, mock_criteria,
                                          mock__parse_and_log_event, mock_list):
         mock_event = mock.Mock()
 
@@ -77,22 +64,20 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
         mock_criteria.assert_called_once_with(filters={'_id': event_info['worker_name']},
                                               fields=('_id', 'last_heartbeat'))
         mock_resources.filter_workers.assert_called_once(mock_criteria.return_value)
-        mock_worker.assert_called_once_with(event_info['worker_name'],
-                                                     event_info['timestamp'])
+        mock_worker.assert_called_once_with(event_info['worker_name'], event_info['timestamp'])
         mock_gettext.assert_called_once_with("New worker '%(worker_name)s' discovered")
         mock__logger.assert_called_once()
         mock_worker.return_value.save.assert_called_once_with()
 
     @mock.patch('__builtin__.list', return_value=True)
     @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event')
-    @mock.patch('pulp.server.async.worker_watcher._is_resource_manager', return_value=False)
     @mock.patch('pulp.server.async.worker_watcher.Criteria')
     @mock.patch('pulp.server.async.worker_watcher.resources')
     @mock.patch('pulp.server.async.worker_watcher.Worker')
     @mock.patch('pulp.server.async.worker_watcher._', new=mock.Mock())
     @mock.patch('pulp.server.async.worker_watcher._logger', new=mock.Mock())
     def test_handle_worker_heartbeat_update(self, mock_worker, mock_resources,
-                                            mock_criteria, mock__is_resource_manager,
+                                            mock_criteria,
                                             mock__parse_and_log_event, mock_list):
         mock_event = mock.Mock()
 
@@ -110,48 +95,20 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
             update={'$set': {'last_heartbeat': event_info['timestamp']}}
         )
 
-    @mock.patch('__builtin__.list', return_value=True)
-    @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event', new=mock.Mock())
-    @mock.patch('pulp.server.async.worker_watcher._is_resource_manager', return_value=True)
-    @mock.patch('pulp.server.async.worker_watcher.Criteria')
-    @mock.patch('pulp.server.async.worker_watcher.resources', new=mock.Mock())
-    @mock.patch('pulp.server.async.worker_watcher.Worker', new=mock.Mock())
-    @mock.patch('pulp.server.async.worker_watcher._', new=mock.Mock())
-    @mock.patch('pulp.server.async.worker_watcher._logger', new=mock.Mock())
-    def test_handle_worker_heartbeat_with_resource_manager_event(self, mock_criteria,
-                                                                 mock__is_resource_manager,
-                                                                 mock_list):
-        mock_event = mock.Mock()
-        worker_watcher.handle_worker_heartbeat(mock_event)
-        self.assertTrue(not mock_criteria.called)
-
 
 class TestHandleWorkerOffline(unittest.TestCase):
     @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event')
-    @mock.patch('pulp.server.async.worker_watcher._is_resource_manager', return_value=False)
     @mock.patch('pulp.server.async.worker_watcher._delete_worker')
     @mock.patch('pulp.server.async.worker_watcher._')
     @mock.patch('pulp.server.async.worker_watcher._logger')
     def test_handle_worker_offline(self, mock__logger, mock_gettext, mock__delete_worker,
-                                   mock__is_resource_manager, mock__parse_and_log_event):
+                                   mock__parse_and_log_event):
         mock_event = mock.Mock()
 
         worker_watcher.handle_worker_offline(mock_event)
 
         event_info = mock__parse_and_log_event.return_value
         mock__parse_and_log_event.assert_called_once_with(mock_event)
-        mock__is_resource_manager.assert_called_once_with(mock_event)
         mock_gettext.assert_called_once_with("Worker '%(worker_name)s' shutdown")
         mock__logger.info.assert_called_once()
         mock__delete_worker.assert_called_once_with(event_info['worker_name'], normal_shutdown=True)
-
-    @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event', new=mock.Mock())
-    @mock.patch('pulp.server.async.worker_watcher._is_resource_manager', return_value=True)
-    @mock.patch('pulp.server.async.worker_watcher._delete_worker', new=mock.Mock())
-    @mock.patch('pulp.server.async.worker_watcher._')
-    @mock.patch('pulp.server.async.worker_watcher._logger', new=mock.Mock())
-    def test_handle_worker_offline_with_resource_manager(self, mock_gettext,
-                                                         mock__is_resource_manager):
-        mock_event = mock.Mock()
-        worker_watcher.handle_worker_offline(mock_event)
-        self.assertTrue(not mock_gettext.called)

--- a/server/test/unit/server/managers/test_resources.py
+++ b/server/test/unit/server/managers/test_resources.py
@@ -173,3 +173,12 @@ class TestGetUnreservedWorker(ResourceReservationTests):
             pass
         else:
             self.fail("NoWorkers() Exception should have been raised.")
+
+    def test_is_worker(self):
+        self.assertTrue(resources._is_worker("a_worker@some.hostname"))
+
+    def test_is_not_worker_is_scheduler(self):
+        self.assertEquals(resources._is_worker("scheduler@some.hostname"), False)
+
+    def test_is_not_worker_is_resource_mgr(self):
+        self.assertEquals(resources._is_worker("resource_manager@some.hostname"), False)

--- a/server/test/unit/test_manager_factory.py
+++ b/server/test/unit/test_manager_factory.py
@@ -40,6 +40,7 @@ from pulp.server.managers.repo.sync import RepoSyncManager
 
 # -- test cases --------------------------------------------------------------
 
+
 class FactoryTests(unittest.TestCase):
 
     def clean(self):
@@ -61,7 +62,7 @@ class FactoryTests(unittest.TestCase):
         self.assertTrue(isinstance(factory.permission_query_manager(), PermissionQueryManager))
         self.assertTrue(isinstance(factory.role_manager(), RoleManager))
         self.assertTrue(isinstance(factory.role_query_manager(), RoleQueryManager))
-        self.assertTrue(isinstance(factory.user_manager(), UserManager))             
+        self.assertTrue(isinstance(factory.user_manager(), UserManager))
         self.assertTrue(isinstance(factory.user_query_manager(), UserQueryManager))
         self.assertTrue(isinstance(factory.repo_manager(), RepoManager))
         self.assertTrue(isinstance(factory.repo_unit_association_manager(), RepoUnitAssociationManager))

--- a/server/test/unit/test_status_manager.py
+++ b/server/test/unit/test_status_manager.py
@@ -1,0 +1,50 @@
+from base import PulpServerTests
+
+from mock import patch, Mock
+
+from pulp.server.managers import status as status_manager
+
+
+class StatusManagerTests(PulpServerTests):
+
+    @patch('pulp.server.managers.status.get_distribution')
+    def test_get_version(self, mock_get_distribution):
+        mock_distribution = Mock()
+        mock_distribution.version = "1.2.3"
+        mock_get_distribution.return_value = mock_distribution
+
+        self.assertEquals(status_manager.get_version(), {'platform_version': '1.2.3'})
+
+    @patch('pulp.server.managers.resources.filter_workers')
+    def test_get_workers(self, mock_filter_workers):
+        mock_filter_workers.return_value = [{"last_heartbeat": "123456", "name": "some_worker_1"},
+                                            {"last_heartbeat": "123456", "name": "some_worker_2"}]
+
+        self.assertEquals(status_manager.get_workers(), [{"last_heartbeat": "123456",
+                                                          "name": "some_worker_1"},
+                                                         {"last_heartbeat": "123456",
+                                                          "name": "some_worker_2"}])
+
+    @patch('pulp.server.async.celery_instance.celery')
+    def test_get_broker_conn_status(self, mock_celery):
+        mock_celery.connection = Mock()
+
+        self.assertEquals(status_manager.get_broker_conn_status(), {'connected': True})
+
+    @patch('pulp.server.db.connection.get_database')
+    def test_get_mongo_conn_status(self, mock_get_database):
+        self.assertEquals(status_manager.get_mongo_conn_status(), {'connected': True})
+
+    @patch('pulp.server.async.celery_instance.celery.connection')
+    def test_get_broker_conn_status_exception(self, mock_celery_conn):
+        mock_conn = Mock()
+        mock_conn.connect.side_effect = Exception("boom!")
+        mock_celery_conn.return_value = mock_conn
+
+        self.assertEquals(status_manager.get_broker_conn_status(), {'connected': False})
+
+    @patch('pulp.server.db.connection.get_database')
+    def test_get_mongo_conn_status_exception(self, mock_get_database):
+        mock_get_database.side_effect = Exception("boom!")
+
+        self.assertEquals(status_manager.get_mongo_conn_status(), {'connected': False})


### PR DESCRIPTION
This patch returns additional data from the /status API call. Specifically, it
returns a worker list, the message broker connection status, the database
connection status, and the Pulp version (RHBZ #704184).

There is a small behavior change to include the resource manager and scheduler
as part of the worker heartbeat list. Previously, these were not included in
the list.