### PR TITLE
1165404, 1165346 - document default host name in conusmer.conf, admin.conf

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -4,7 +4,7 @@
 # The pulp server configuration
 #
 # host:
-#   The pulp server hostname
+#   The pulp server hostname. If not specified, this value will default to socket.gethostname()
 # port:
 #   The port providing the RESTful API
 # rsa_pub:
@@ -23,7 +23,7 @@
 #   CA certificates (with openssl-style hashed symlinks, one certificate per file).
 
 [server]
-# host: # If not specified, this value will default to socket.gethostname().
+# host:
 # port: 443
 # api_prefix: /pulp/api
 # verify_ssl: True

--- a/client_consumer/etc/pulp/consumer/consumer.conf
+++ b/client_consumer/etc/pulp/consumer/consumer.conf
@@ -4,7 +4,7 @@
 # The pulp server configuration
 #
 # host:
-#   The pulp server hostname
+#   The pulp server hostname.  If not specifiec, this value will default to socket.gethostname()
 # port:
 #   The port providing the RESTful API
 # rsa_pub:


### PR DESCRIPTION
Default behavior is socket.gethostname().  Modifying conf file to reflect this

 [BZ-1165346](https://bugzilla.redhat.com/show_bug.cgi?id=1165346)
[BZ-1165404](https://bugzilla.redhat.com/show_bug.cgi?id=1165404)
