### PR TITLE
Ports auth decorators to work with both Django and webpy

### DIFF
--- a/server/pulp/server/webservices/application.py
+++ b/server/pulp/server/webservices/application.py
@@ -123,6 +123,7 @@ def _initialize_pulp():
     # If we got this far, it was successful, so flip the flag
     _IS_INITIALIZED = True
 
+
 def wsgi_application():
     """
     Application factory to create, configure, and return a WSGI application

--- a/server/pulp/server/webservices/controllers/decorators.py
+++ b/server/pulp/server/webservices/controllers/decorators.py
@@ -27,11 +27,12 @@ from pulp.server.exceptions import PulpCodedAuthenticationException
 from pulp.server.managers import factory
 from pulp.server.webservices import http
 
+
 # -- constants ----------------------------------------------------------------
 
 _LOG = logging.getLogger(__name__)
 
-DEFAULT_CONSUMER_PERMISSIONS = {'/v2/repositories/' : [READ]}
+DEFAULT_CONSUMER_PERMISSIONS = {'/v2/repositories/': [READ]}
 
 
 # -- supported authentication methods -----------------------------------------
@@ -103,7 +104,6 @@ def oauth_authentication():
     _LOG.debug("User authenticated with Oauth: %s" % userid)
     return userid, is_consumer
 
-# -- consumer authorization checking -----------------------------------------
 
 def is_consumer_authorized(resource, consumerid, operation):
     """
@@ -133,7 +133,6 @@ def is_consumer_authorized(resource, consumerid, operation):
         parts = parts[:-1]
     return False
 
-# -- decorator ---------------------------------------------------------------
 
 def auth_required(operation=None, super_user_only=False):
     """
@@ -160,7 +159,7 @@ def auth_required(operation=None, super_user_only=False):
         @wraps(method)
         def _auth_decorator(self, *args, **kwargs):
 
-            # Check Authentication 
+            # Check Authentication
 
             # Run through each registered and enabled auth function
             is_consumer = False

--- a/server/pulp/server/webservices/http.py
+++ b/server/pulp/server/webservices/http.py
@@ -19,11 +19,16 @@ import base64
 import httplib
 import os
 import re
+import threading
 import urllib
 
 import web
 
 from pulp.server.compat import http_responses
+
+
+_thread_local = threading.local()
+
 
 # constants --------------------------------------------------------------------
 
@@ -31,6 +36,30 @@ API_HREF = '/pulp/api'
 API_V2_HREF = API_HREF + '/v2'
 
 # request methods -------------------------------------------------------------
+
+
+def _is_django():
+    """
+    Checks if the current request is handling Django by looking in thread-local data.
+
+    :return: True if being handled by Django, False otherwise
+    :rtype: bool
+    """
+    return hasattr(_thread_local, 'wsgi_environ')
+
+
+def _get_wsgi_environ():
+    """
+    Get the WSGI environment dictionary abstracted from which framework is serving this request.
+
+    :return: The WSGI environment dictionary
+    :rtype: bool
+    """
+    if _is_django():
+        return _thread_local.wsgi_environ
+    else:
+        return web.ctx.environ
+
 
 def request_info(key):
     """
@@ -42,7 +71,7 @@ def request_info(key):
     @rtype: str or None
     @return: request value
     """
-    return web.ctx.environ.get(key, None)
+    return _get_wsgi_environ().get(key, None)
 
 
 def request_method():
@@ -174,7 +203,6 @@ def username_password():
         return _digest_username_password(credentials)
     return (None, None)
 
-# ssl methods -----------------------------------------------------------------
 
 def ssl_client_cert():
     """
@@ -182,9 +210,8 @@ def ssl_client_cert():
     @rtype: str or None
     @return: pem encoded cert
     """
-    return web.ctx.environ.get('SSL_CLIENT_CERT', None)
+    return _get_wsgi_environ().get('SSL_CLIENT_CERT', None)
 
-# uri path functions ----------------------------------------------------------
 
 def uri_path():
     """
@@ -216,6 +243,7 @@ def extend_uri_path(suffix, prefix=None):
         suffix = urllib.pathname2url(suffix.encode('utf-8'))
     path = os.path.normpath(os.path.join(prefix, suffix))
     return ensure_ending_slash(path)
+
 
 def sub_uri_path(*args):
     """
@@ -270,7 +298,6 @@ def ensure_ending_slash(uri_or_path):
         uri_or_path += '/'
     return uri_or_path
 
-# response functions ----------------------------------------------------------
 
 def header(hdr, value, unique=True):
     """
@@ -296,7 +323,6 @@ def header(hdr, value, unique=True):
             web.ctx.headers.remove(p)
     web.ctx.headers.append((hdr, value))
 
-# status functions ------------------------------------------------------------
 
 def _status(code):
     """
@@ -389,6 +415,7 @@ def status_not_implemented():
     Set the status reponse code to not implemented
     """
     _status(httplib.NOT_IMPLEMENTED)
+
 
 def status_partial():
     """

--- a/server/pulp/server/webservices/middleware/framework_router.py
+++ b/server/pulp/server/webservices/middleware/framework_router.py
@@ -4,40 +4,79 @@ import logging
 
 from django.core.urlresolvers import resolve, Resolver404
 
+from pulp.server.webservices.http import _thread_local
+
+
 _LOG = logging.getLogger(__name__)
 
 
 class FrameworkRoutingMiddleware(object):
     """
-    Route requests to Django if it has a matching URL, otherwise call webPy.
+    Route requests to Django if it has a matching URL, otherwise call web.py.
+
+    Generally for more info on how WSGI is implemented in Python see [0].
+
+    [0]: https://www.python.org/dev/peps/pep-3333/
     """
 
     def __init__(self, webpy_wsgi, django_wsgi):
+        """
+        Initializes a FrameworkRoutingMiddleware object with a webpy_wsgi and a django_wsgi stack.
+
+        :param webpy_wsgi: A WSGI object for web.py
+        :type webpy_wsgi: A WSGI compatible object
+        :param django_wsgi: A WSGI object for Django
+        :type django_wsgi: A WSGI compatible object
+        """
         self.webpy_wsgi = webpy_wsgi
         self.django_wsgi = django_wsgi
 
     def __call__(self, environ, start_response):
         """
-        A WSGI call that provides switching capabilities between Django and WebPy.
+        A WSGI call that provides switching capabilities between Django and web.py.
 
         It supports a header named 'WebFrameworkSwitch' which can be set to 'django' or 'webpy'. It
         will check this header first and route the request accordingly.
 
-        The defualt behavior is to inspect if Django supports the requested URL. If it does, the
+        The default behavior is to inspect if Django supports the requested URL. If it does, the
         request is routed to Django. If it is not, it is routed to the web.py call stack.
         """
         # First check if the client is specifying the framework to use
         if 'HTTP_WEBFRAMEWORKSWITCH' in environ:
             if environ['HTTP_WEBFRAMEWORKSWITCH'] == 'django':
-                return self.django_wsgi(environ, start_response)
+                return self._handle_with_django(environ, start_response)
             else:
-                return self.webpy_wsgi(environ, start_response)
+                return self._handle_with_webpy(environ, start_response)
 
-        # This is the start of the defualt behavior
+        # This is the start of the default behavior
         try:
             resolve(environ['PATH_INFO'], urlconf='pulp.server.webservices.urls')
         except Resolver404:
             pass
         else:
-            return self.django_wsgi(environ, start_response)
+            return self._handle_with_django(environ, start_response)
+        return self._handle_with_webpy(environ, start_response)
+
+    def _handle_with_django(self, environ, start_response):
+        """
+        Stores the WSGI environment within thread-local data, and then have Django handle it.
+
+        Having the wsgi_environ present in thread-local data will allow older authorization and
+        authentication code written for web.py to still have access to everything it needs while
+        handling a Django request which doesn't store the environment for you.
+        """
+        _thread_local.wsgi_environ = environ
+        return self.django_wsgi(environ, start_response)
+
+    def _handle_with_webpy(self, environ, start_response):
+        """
+        Removes the WSGI environment from thread-local data, and then have web.py handle it.
+
+        Removing it ensures the older authorization and authentication code written for web.py will
+        use the same code paths as before.
+        """
+        try:
+            del _thread_local.wsgi_environ
+        except AttributeError:
+            pass
         return self.webpy_wsgi(environ, start_response)

--- a/server/pulp/server/webservices/views/tasks.py
+++ b/server/pulp/server/webservices/views/tasks.py
@@ -1,29 +1,12 @@
 from django.http import HttpResponse
 from django.views.generic import View
 
+from pulp.server.auth import authorization
+from pulp.server.webservices.controllers.decorators import auth_required
+
 
 class TasksView(View):
 
+    @auth_required(authorization.READ)
     def get(self, request, *args, **kwargs):
-        return HttpResponse("""{
-    "glossary": {
-        "title": "example glossary",
-		"GlossDiv": {
-            "title": "S",
-			"GlossList": {
-                "GlossEntry": {
-                    "ID": "SGML",
-					"SortAs": "SGML",
-					"GlossTerm": "Standard Generalized Markup Language",
-					"Acronym": "SGML",
-					"Abbrev": "ISO 8879:1986",
-					"GlossDef": {
-                        "para": "A meta-markup language, used to create markup languages such as DocBook.",
-						"GlossSeeAlso": ["GML", "XML"]
-                    },
-					"GlossSee": "markup"
-                }
-            }
-        }
-    }
-}""", content_type="application/json")
+        return HttpResponse("""{"foo": "bar"}""", content_type="application/json")


### PR DESCRIPTION
This PR introduces thread unique tracking of the WSGI environ, and updates the auth decorators to use the stored WSGI environment instead of web.ctx.environ if the request is being served by Django. Existing web.py should continue to work the same as before.

Also updates some PEP8 compliance changes within all modules touched.
