### PR TITLE
Removes .pulp from python-kombu release field for 3.0.24

### DIFF
--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.24
-Release:        1.pulp%{?dist}
+Release:        1%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages
@@ -161,9 +161,6 @@ popd
 %endif # with_python3
 
 %changelog
-* Thu Dec 11 2014 Brian Bouterse 3.0.24-1.pulp
-- Updates python-kombu to 3.0.24 (bbouters@redhat.com)
-
 * Fri Sep 19 2014 Chris Duryee <cduryee@redhat.com> 3.0.15-13.pulp
 - 1124589 - python-kombu does not work with Qpid unless the user adjusts
   qpidd.conf (cduryee@redhat.com)

--- a/rel-eng/packages/python-kombu
+++ b/rel-eng/packages/python-kombu
@@ -1,1 +1,1 @@
-3.0.24-1.pulp deps/python-kombu/
+3.0.15-13.pulp deps/python-kombu/


### PR DESCRIPTION
Removes '.pulp' from the python-kombu release field and also negative commits the tito commit 6b2ebba6bfba08c064429fded625d3e0478676a0

It's right to not have '.pulp' in the release field because we are now using a vanilla dependency without any patches.

The tito commit 6b2ebba6bfba08c064429fded625d3e0478676a0 was never built on koji, so this negative commit should reset the state enough so that I can rerun tito tag and then build it right.
