### PR TITLE
Ports middleware to Django, and adds repo sync view

### DIFF
--- a/server/pulp/server/webservices/http.py
+++ b/server/pulp/server/webservices/http.py
@@ -218,7 +218,10 @@ def uri_path():
     Return the current URI path
     @return: full current URI path
     """
-    return web.http.url(web.ctx.path)
+    if _is_django():
+        return unicode(_get_wsgi_environ()['REQUEST_URI'])
+    else:
+        return web.http.url(web.ctx.path)
 
 
 def extend_uri_path(suffix, prefix=None):

--- a/server/pulp/server/webservices/middleware/postponed.py
+++ b/server/pulp/server/webservices/middleware/postponed.py
@@ -14,6 +14,7 @@
 import logging
 
 from celery.result import AsyncResult
+from django.http.response import HttpResponse
 
 from pulp.server.async.tasks import TaskResult
 from pulp.server.compat import json, json_util, http_responses
@@ -22,6 +23,18 @@ from pulp.server.webservices import serialization
 
 
 _LOG = logging.getLogger(__name__)
+
+
+def _get_operation_postponed_body(exception):
+    report = exception.call_report
+    if isinstance(exception.call_report, AsyncResult):
+        report = TaskResult.from_async_result(exception.call_report)
+    serialized_call_report = report.serialize()
+    for task in serialized_call_report['spawned_tasks']:
+        href_obj = serialization.dispatch.task_result_href(task)
+        task.update(href_obj)
+
+    return json.dumps(serialized_call_report, default=json_util.default)
 
 
 class PostponedOperationMiddleware(object):
@@ -42,18 +55,21 @@ class PostponedOperationMiddleware(object):
             return self.app(environ, start_response)
 
         except OperationPostponed, e:
-            report = e.call_report
-            if isinstance(e.call_report, AsyncResult):
-                report = TaskResult.from_async_result(e.call_report)
-            serialized_call_report = report.serialize()
-            for task in serialized_call_report['spawned_tasks']:
-                href_obj = serialization.dispatch.task_result_href(task)
-                task.update(href_obj)
-
-            body = json.dumps(serialized_call_report, default=json_util.default)
+            body = _get_operation_postponed_body(e)
 
             self.headers['Content-Length'] = str(len(body))
             start_str = '%d %s' % (e.http_status_code, http_responses[e.http_status_code])
 
             start_response(start_str, [(k, v) for k, v in self.headers.items()])
             return [body]
+
+
+class DjangoPostponedOperationMiddleware(object):
+
+    def process_exception(self, request, exception):
+        if isinstance(exception, OperationPostponed):
+            body = _get_operation_postponed_body(exception)
+            status = exception.http_status_code
+            response_obj = HttpResponse(body, status=status, content_type="application/json")
+            response_obj['Content-Encoding'] = 'utf-8'
+            return response_obj

--- a/server/pulp/server/webservices/settings.py
+++ b/server/pulp/server/webservices/settings.py
@@ -21,6 +21,8 @@ INSTALLED_APPS = (
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.http.ConditionalGetMiddleware',
+    'pulp.server.webservices.middleware.exception.DjangoExceptionHandlerMiddleware',
+    'pulp.server.webservices.middleware.postponed.DjangoPostponedOperationMiddleware',
     'django.middleware.common.CommonMiddleware',
 )
 

--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import patterns, url
 
 from pulp.server.webservices.views.tasks import TasksView
+from pulp.server.webservices.views.repositories import RepoSync
 
 
 urlpatterns = patterns('',
     url(r'^v2/tasks/$', TasksView.as_view()),
+    url(r'^v2/repositories/(?P<repo_id>\w+)/actions/sync/$', RepoSync.as_view()),
 )

--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -1,0 +1,36 @@
+import json
+
+from django.views.generic import View
+
+from pulp.common import tags
+from pulp.server.auth.authorization import EXECUTE
+import pulp.server.exceptions as exceptions
+import pulp.server.managers.factory as manager_factory
+from pulp.server.tasks import repository
+from pulp.server.webservices.controllers.decorators import auth_required
+
+
+class RepoSync(View):
+
+    @auth_required(EXECUTE)
+    def post(self, request, repo_id):
+
+        # Params
+        try:
+            params = json.loads(request.body)
+        except ValueError:
+            params = {}
+        overrides = params.get('override_config', None)
+
+        # Check for repo existence and let the missing resource bubble up
+        manager_factory.repo_query_manager().get_repository(repo_id)
+
+        # Execute the sync asynchronously
+        task_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, repo_id),
+                     tags.action_tag('sync')]
+        async_result = repository.sync_with_auto_publish.apply_async_with_reservation(
+            tags.RESOURCE_REPOSITORY_TYPE, repo_id, [repo_id, overrides], {}, tags=task_tags)
+
+        # this raises an exception that is handled by the middleware,
+        # so no return is needed
+        raise exceptions.OperationPostponed(async_result)


### PR DESCRIPTION
This adds two new middleware packages for Django, and fixes one issue with the auth_required decorator. The DjangoExceptionHandlerMiddleware is done with a new codepath because a lot of the web.py code is web.py specific. The DjangoPostponedOperationMiddleware shares a codepath between Django and web.py.

To test these middlewares, the repo sync view was added, and that is working correctly also.
