### PR TITLE
Adds middleware to parse the body into json

### DIFF
--- a/server/pulp/server/webservices/middleware/parse_body.py
+++ b/server/pulp/server/webservices/middleware/parse_body.py
@@ -1,0 +1,16 @@
+import json
+
+
+class ParseBodyMiddleware(object):
+
+    def process_request(self, request):
+        """
+        Parse body as json, and save the json as body_as_json attribute on request object.
+
+        :param request: A django WSGI request object from the Django middleware
+        :type request: django.core.handlers.wsgi.WSGIRequest
+        """
+        try:
+            request.body_as_json = json.loads(request.body)
+        except ValueError:
+            request.body_as_json = {}

--- a/server/pulp/server/webservices/settings.py
+++ b/server/pulp/server/webservices/settings.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = (
 MIDDLEWARE_CLASSES = (
     'django.middleware.http.ConditionalGetMiddleware',
     'pulp.server.webservices.middleware.exception.DjangoExceptionHandlerMiddleware',
+    'pulp.server.webservices.middleware.parse_body.ParseBodyMiddleware',
     'pulp.server.webservices.middleware.postponed.DjangoPostponedOperationMiddleware',
     'django.middleware.common.CommonMiddleware',
 )

--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -1,5 +1,3 @@
-import json
-
 from django.views.generic import View
 
 from pulp.common import tags
@@ -14,13 +12,7 @@ class RepoSync(View):
 
     @auth_required(EXECUTE)
     def post(self, request, repo_id):
-
-        # Params
-        try:
-            params = json.loads(request.body)
-        except ValueError:
-            params = {}
-        overrides = params.get('override_config', None)
+        overrides = request.body_as_json.get('override_config', None)
 
         # Check for repo existence and let the missing resource bubble up
         manager_factory.repo_query_manager().get_repository(repo_id)


### PR DESCRIPTION
Adds a middleware that parses the request body as JSON and silences a ValueError. The parsed JSON is attached to the request as the body_as_json. The repositories sync Django code was updated to show how this is used.
