### PR TITLE
US3146 - Adds Django as a spec file dependency for pulp-server

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -290,6 +290,9 @@ Requires: genisoimage
 # RHEL6 ONLY
 %if 0%{?rhel} == 6
 Requires: nss >= 3.12.9
+Requires: Django14
+%else
+Requires: python-django >= 1.4.0
 %endif
 %if %{pulp_systemd} == 1
 Requires(post): systemd


### PR DESCRIPTION
I've hand built this on EL6 and EL7, and I ensured that for each:
1. It builds without error
2. That the resulting pulp-server has the right package name and version as a dependency

I only tested EL6 and EL7 and not the fedoras because the if statement in the spec file checks if EL6 and everything else is handled with an 'else' clause so all non-EL6 platforms should behave the same.
