### PR TITLE
1175512 - Fixes mongoengine database args to use correct database

### DIFF
--- a/server/pulp/server/db/connection.py
+++ b/server/pulp/server/db/connection.py
@@ -46,6 +46,14 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
         if seeds is None:
             seeds = config.config.get('database', 'seeds')
 
+        if seeds != '':
+            first_seed = seeds.split(',')[0]
+            seed = first_seed.strip().split(':')
+            if len(seed) == 2:
+                connection_kwargs.update({'host': seed[0], 'port': int(seed[1])})
+            else:
+                connection_kwargs.update({'host': seed[0]})
+
         if max_pool_size is None:
             # we may want to make this configurable, but then again, we may not
             max_pool_size = _DEFAULT_MAX_POOL_SIZE
@@ -71,14 +79,25 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
             connection_kwargs['ssl_cert_reqs'] = ssl.CERT_REQUIRED if verify_ssl else ssl.CERT_NONE
             connection_kwargs['ssl_ca_certs'] = config.config.get('database', 'ca_path')
 
-        _logger.debug(_('Attempting Database connection with seeds = %s') % seeds)
+        # If username & password have been specified in the database config,
+        # attempt to authenticate to the database
+        username = config.config.get('database', 'username')
+        password = config.config.get('database', 'password')
+        if username and password:
+            _logger.debug(_('Attempting username and password authentication.'))
+            connection_kwargs['username'] = username
+            connection_kwargs['password'] = password
+        elif (username and not password) or (password and not username):
+            raise Exception(_("The server config specified username/password authentication but "
+                            "is missing either the username or the password"))
+
         _logger.debug(_('Connection Arguments: %s') % connection_kwargs)
 
         # Wait until the Mongo database is available
         mongo_retry_timeout_seconds_generator = itertools.chain([1, 2, 4, 8, 16], itertools.repeat(32))
         while True:
             try:
-                _CONNECTION = mongoengine.connect(seeds, **connection_kwargs)
+                _CONNECTION = mongoengine.connect(name, **connection_kwargs)
             except mongoengine.connection.ConnectionError as e:
                 next_delay = min(mongo_retry_timeout_seconds_generator.next(), max_timeout)
                 msg = _(
@@ -90,19 +109,6 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
             time.sleep(next_delay)
 
         _DATABASE = getattr(_CONNECTION, name)
-
-        # If username & password have been specified in the database config,
-        # attempt to authenticate to the database
-        username = config.config.get('database', 'username')
-        password = config.config.get('database', 'password')
-        if username and password:
-            _logger.debug(_('Database authentication enabled, attempting username/password'
-                            ' authentication.'))
-            _DATABASE.authenticate(username, password)
-        elif (username and not password) or (password and not username):
-            raise Exception(_("The server config specified username/password authentication but "
-                            "is missing either the username or the password"))
-
         _DATABASE.add_son_manipulator(NamespaceInjector())
 
         # Query the collection names to ensure that we are authenticated properly
@@ -117,11 +123,6 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
         if db_version_tuple < db_min_version_tuple:
             raise RuntimeError(_("Pulp requires Mongo version %s, but DB is reporting version %s") %
                                (MONGO_MINIMUM_VERSION, db_version))
-
-        _logger.debug(
-            _("Database connection established with: seeds = %(seeds)s, name = %(name)s") %
-            {'seeds': seeds, 'name': name}
-        )
 
     except Exception, e:
         _logger.critical(_('Database initialization failed: %s') % str(e))


### PR DESCRIPTION
The issue is that the pulp setting `seeds` was being used as the database name. It connected to MongoDB because the mongoengine defaults for host and port are the same as pulp and MongoDB. I also reviewed all the connection parameters and consolidated authentication with how mongoengine expects it. I then updated all the tests which I believe cover all the necessary cases.

This was continuing to use the correct database name for non mongoengine models because they use PulpCollection which is where the existing Pulp code specifies the database name. What we're doing with mongoengine is much simpler so that is good.

I hand tested that the existing non mongoengine collections will continue to auto create and use the correct database.

This adjusts the mongoengine connection to work with one seed. Multi-seed testing is [a different issue](https://rally1.rallydev.com/#/7675694122d/detail/userstory/26229270474) that should be looked at soon. Mongoengine needs more testing with multi-seed configurations to do it effectively.

I also ran the [tests on all platforms and it passed](https://pulp-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/unittest-pulp/52/).
