### PR TITLE
1171278 - additional helper method for finding units

### DIFF
--- a/server/pulp/plugins/conduits/mixins.py
+++ b/server/pulp/plugins/conduits/mixins.py
@@ -221,6 +221,33 @@ class SearchUnitsMixin(object):
             logger.exception('Exception from server requesting all units of type [%s]' % type_id)
             raise self.exception_class(e), None, sys.exc_info()[2]
 
+    def find_unit_by_unit_key(self, type_id, unit_key):
+        """
+        Finds a unit based on its unit key. If more than one unit comes back,
+        an exception will be raised.
+
+        @param type_id: indicates the type of units being retrieved
+        @type  type_id: str
+        @param unit_key: the unit key for the unit
+        @type  unit_key: dict
+
+        @return: a single unit
+        @rtype:  L{Unit}
+        """
+        content_query_manager = manager_factory.content_query_manager()
+        try:
+            # this call returns a unit or raises MissingResource
+            existing_unit = content_query_manager.get_content_unit_by_keys_dict(type_id, unit_key)
+            type_def = types_db.type_definition(type_id)
+            plugin_unit = common_utils.to_plugin_unit(existing_unit, type_def)
+            return plugin_unit
+        except MissingResource:
+            return None
+        except Exception, e:
+            logger.exception('Exception from server requesting unit of type [%s] with key [%s]'
+                             % (type_id, unit_key))
+            raise self.exception_class(e), None, sys.exc_info()[2]
+
 
 class ImporterScratchPadMixin(object):
 

--- a/server/test/unit/test_conduit_mixins.py
+++ b/server/test/unit/test_conduit_mixins.py
@@ -263,6 +263,49 @@ class SearchUnitsMixinTests(unittest.TestCase):
         self.assertRaises(mixins.ImporterConduitException, self.mixin.search_all_units,
                           't', 'fake-criteria')
 
+    @mock.patch('pulp.plugins.types.database.type_definition')
+    @mock.patch('pulp.server.managers.content.query.ContentQueryManager.'
+                'get_content_unit_by_keys_dict')
+    def test_find_unit_by_unit_key(self, mock_get_unit, mock_type_def):
+        # Setup
+        pulp_unit = {'id': 'fake-unit-id', 'another-unit-key-field': 'fake',
+                     'other_field': '1234'}
+        mock_get_unit.return_value = pulp_unit
+
+        mock_type_def.return_value = {
+            'id' : 'mock-type-def',
+            'unit_key' : ['id', 'another-unit-key-field']
+        }
+
+        # Test
+        unit = self.mixin.find_unit_by_unit_key('type-1', {'id': 'not-used-for-mock'})
+
+        # Verify
+        self.assertEqual(1, mock_get_unit.call_count)
+        self.assertEqual(unit.unit_key, {'id': 'fake-unit-id', 'another-unit-key-field': 'fake'})
+        self.assertEqual(unit.metadata, {'other_field': '1234'})
+
+    @mock.patch('pulp.server.managers.content.query.ContentQueryManager.'
+                'get_content_unit_by_keys_dict')
+    def test_find_unit_by_unit_key_not_found(self, mock_get_unit):
+        # Setup
+        mock_get_unit.side_effect = MissingResource()
+
+        # Test
+        unit = self.mixin.find_unit_by_unit_key('type-1', {'id': 'not-used-for-mock'})
+
+        # Verify
+        self.assertEqual(unit, None)
+
+    @mock.patch('pulp.server.managers.content.query.ContentQueryManager.'
+                'get_content_unit_by_keys_dict')
+    def test_find_unit_by_unit_key_other_exception(self, mock_get_unit):
+        # Setup
+        mock_get_unit.side_effect = RuntimeError("boom!")
+
+        # Test/Verify
+        self.assertRaises(mixins.ImporterConduitException, self.mixin.find_unit_by_unit_key,
+                          'type-1', {'id': 'not-used'})
 
 class ImporterScratchPadMixinTests(unittest.TestCase):
 


### PR DESCRIPTION
The fix for RHBZ 1171278 in pulp_rpm needs to be able to find a unit based on the
unit key, regardless of which repo its in. This patch adds
`find_unit_by_unit_key` to the SearchUnitsMixin to facilitiate this.

**NOTE**: this should not be merged until after 2.4.4 is released!