### PR TITLE
1154790 - inject node strategy into the options.

### DIFF
--- a/nodes/parent/pulp_node/profilers/nodes.py
+++ b/nodes/parent/pulp_node/profilers/nodes.py
@@ -1,24 +1,12 @@
-# Copyright (c) 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 from gettext import gettext as _
 
 from pulp.plugins.profiler import Profiler
 from pulp.server.config import config as pulp_conf
+from pulp.server.managers import factory as managers
 
 from pulp_node import constants
 from pulp_node.config import read_config
 
-
-# --- plugin loading ---------------------------------------------------------
 
 def entry_point():
     """
@@ -29,23 +17,23 @@ def entry_point():
     return NodeProfiler, {}
 
 
-# --- plugins ----------------------------------------------------------------
-
 class NodeProfiler(Profiler):
 
     @classmethod
     def metadata(cls):
+        """
+        Plugin metadata.
+        :return: The plugin metadata.
+        :rtype: dict
+        """
         return {
             'id': constants.PROFILER_ID,
             'display_name': _('Nodes Profiler'),
             'types': [constants.NODE_SCOPE, constants.REPOSITORY_SCOPE]
         }
 
-    def update_units(self, consumer, units, options, config, conduit):
-        self._inject_parent_settings(options)
-        return units
-
-    def _inject_parent_settings(self, options):
+    @staticmethod
+    def _inject_parent_settings(options):
         """
         Inject the parent settings into the options.
         Add the pulp server host and port information to the options.
@@ -65,3 +53,55 @@ class NodeProfiler(Profiler):
             constants.NODE_CERTIFICATE: node_certificate,
         }
         options[constants.PARENT_SETTINGS] = settings
+
+    @staticmethod
+    def _inject_strategy(consumer_id, options):
+        """
+        Inject the node-level synchronization strategy.
+        :param consumer_id: The consumer ID.
+        :type consumer_id: str
+        :param options: The update options.
+        :type options: dict
+        """
+        manager = managers.consumer_manager()
+        consumer = manager.get_consumer(consumer_id)
+        strategy = consumer['notes'].get(constants.STRATEGY_NOTE_KEY)
+        options[constants.STRATEGY_KEYWORD] = strategy
+
+    def update_units(self, consumer, units, options, config, conduit):
+        """
+        Translate the specified content units to be updated.
+        The specified content units are intended to be updated on the
+        specified consumer.  It is requested that the profiler translate
+        the units as needed.  If any of the content units cannot be translated,
+        an exception should be raised by the profiler.  The translation itself,
+        depends on the content unit type and is completely up to the Profiler.
+        Translation into an empty list is not considered an error condition and
+        will be interpreted by the caller as meaning that no content needs to be
+        updated.
+
+        @see: Unit Translation examples in class documentation.
+
+        :param consumer: A consumer.
+        :type consumer: pulp.plugins.model.Consumer
+
+        :param units: A list of content units to be updated.
+        :type units: list of: { type_id:<str>, unit_key:<dict> }
+
+        :param options: Update options; based on unit type.
+        :type options: dict
+
+        :param config: plugin configuration
+        :type config: pulp.plugins.config.PluginCallConfiguration
+
+        :param conduit: provides access to relevant Pulp functionality
+        :type conduit: pulp.plugins.conduits.profiler.ProfilerConduit
+
+        :return: The translated units
+        :rtype: list of: { type_id:<str>, unit_key:<dict> }
+
+        :raises: InvalidUnitsRequested - if one or more of the units cannot be updated
+        """
+        self._inject_parent_settings(options)
+        self._inject_strategy(consumer.id, options)
+        return units


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1154790

The _node-level_ synchronization strategy controls how the node repositories are synchronized.  The default is mirror.  The _node-level_  is specified at node activation in the consumer notes (I know, it sucks).  The problem was, the _node-level_ was not being passed to the node during synchronization.

Most of the nodes tests need to be added or replaced.  I rewrite the unit test for the profiler.  We'll deal with the rest when nodes is revised.

Test pass with 100%.

```
pulp_node.profilers                                                   0      0   100%
```
