### PR TITLE
port to gofer 2.1.

### DIFF
--- a/agent/etc/gofer/plugins/pulpplugin.conf
+++ b/agent/etc/gofer/plugins/pulpplugin.conf
@@ -1,5 +1,6 @@
 [main]
 enabled=1
+plugin=pulp.agent.gofer.pulpplugin
 
 [messaging]
 uuid=

--- a/agent/pulp/agent/gofer/pulpplugin.py
+++ b/agent/pulp/agent/gofer/pulpplugin.py
@@ -64,14 +64,13 @@ def setup_plugin():
     scheme = cfg.messaging.scheme
     host = cfg.messaging.host or cfg.server.host
     port = cfg.messaging.port
-    url = '%s://%s:%s' % (scheme, host, port)
-    plugin_conf = plugin.cfg()
-    plugin_conf.messaging.url = url
-    plugin_conf.messaging.uuid = get_agent_id()
-    plugin_conf.messaging.cacert = cfg.messaging.cacert
-    plugin_conf.messaging.clientcert = cfg.messaging.clientcert or \
+    adapter = cfg.messaging.transport
+    url = '%s+%s://%s:%s' % (adapter, scheme, host, port)
+    plugin.cfg.messaging.url = url
+    plugin.cfg.messaging.uuid = get_agent_id()
+    plugin.cfg.messaging.cacert = cfg.messaging.cacert
+    plugin.cfg.messaging.clientcert = cfg.messaging.clientcert or \
         os.path.join(cfg.filesystem.id_cert_dir, cfg.filesystem.id_cert_filename)
-    plugin_conf.messaging.transport = cfg.messaging.transport
     plugin.authenticator = Authenticator()
     log.info('plugin configuration updated')
 

--- a/docs/user-guide/broker-settings.rst
+++ b/docs/user-guide/broker-settings.rst
@@ -227,9 +227,9 @@ Pulp Server <--> Pulp Consumer Agent and Pulp Server <--> Pulp Worker communicat
 work with RabbitMQ, although it does not receive the same amount of testing by Pulp developers.
 
 For a Pulp Server or Pulp Consumer Agent to use RabbitMQ, you'll need to install the
-``python-gofer-amqplib`` package on each Server or Consumer. This can be done by running:
+``python-gofer-amqp`` package on each Server or Consumer. This can be done by running:
 
-    ``sudo yum install python-gofer-amqplib``
+    ``sudo yum install python-gofer-amqp``
 
 Enable RabbitMQ support for Pulp Server <--> Pulp Consumer Agent communication by
 uncommenting and updating the ``transport`` setting in ``[messaging]`` to ``rabbitmq``. Below is an

--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -363,7 +363,7 @@ specific consumer dependencies with one command by running:
 
      For RabbitMQ installations, install the Pulp consumer client and agent packages without any
      Qpid specific dependencies using ``sudo yum groupinstall pulp-consumer``. You may need to
-     install additional RabbitMQ dependencies manually including the ``python-gofer-amqplib``
+     install additional RabbitMQ dependencies manually including the ``python-gofer-amqp``
      package.
 
 

--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -85,9 +85,8 @@ DIR_CONSUMER_EXTENSIONS = '/usr/lib/pulp/consumer/extensions/'
 DIR_PLUGINS = '/usr/lib/pulp/plugins'
 
 LINKS = [
-    # Consumer Configuration
+    # agent configuration
     ('agent/etc/gofer/plugins/pulpplugin.conf', '/etc/gofer/plugins/pulpplugin.conf'),
-    ('agent/pulp/agent/gofer/pulpplugin.py', '/usr/lib/gofer/plugins/pulpplugin.py'),
 ]
 
 # We only support Python >= 2.6 for the server code

--- a/pulp.spec
+++ b/pulp.spec
@@ -124,7 +124,6 @@ mkdir -p %{buildroot}/%{_usr}/lib/%{name}/consumer/extensions
 mkdir -p %{buildroot}/%{_usr}/lib/%{name}/agent
 mkdir -p %{buildroot}/%{_usr}/lib/%{name}/agent/handlers
 mkdir -p %{buildroot}/%{_var}/log/%{name}/
-mkdir -p %{buildroot}/%{_libdir}/gofer/plugins
 mkdir -p %{buildroot}/%{_bindir}
 %if 0%{?rhel} >= 6 || 0%{?fedora} >= 19
 mkdir -p %{buildroot}/%{_mandir}/man1
@@ -238,7 +237,6 @@ cp client_consumer/etc/bash_completion.d/pulp-consumer %{buildroot}/%{_sysconfdi
 # Agent
 rm -rf %{buildroot}/%{python_sitelib}/%{name}/agent/gofer
 cp agent/etc/gofer/plugins/pulpplugin.conf %{buildroot}/%{_sysconfdir}/gofer/plugins
-cp -R agent/pulp/agent/gofer/pulpplugin.py %{buildroot}/%{_libdir}/gofer/plugins
 
 # Ghost
 touch %{buildroot}/%{_sysconfdir}/pki/%{name}/consumer/consumer-cert.pem
@@ -280,8 +278,8 @@ Requires: mod_ssl
 Requires: openssl
 Requires: nss-tools
 Requires: python-ldap
-Requires: python-gofer >= 1.4.0
-Requires: python-gofer-qpid >= 1.4.0
+Requires: python-gofer >= 2.3
+Requires: python-gofer-qpid >= 2.3
 Requires: crontabs
 Requires: acl
 Requires: mod_wsgi >= 3.4-1.pulp
@@ -564,9 +562,9 @@ Group: Development/Languages
 Requires: python-%{name}-bindings = %{pulp_version}
 Requires: python-%{name}-agent-lib = %{pulp_version}
 Requires: %{name}-consumer-client = %{pulp_version}
-Requires: python-gofer >= 1.4.0
-Requires: python-gofer-qpid >= 1.4.0
-Requires: gofer >= 1.4.0
+Requires: python-gofer >= 2.3
+Requires: python-gofer-qpid >= 2.3
+Requires: gofer >= 2.3
 Requires: m2crypto
 
 %description agent
@@ -578,7 +576,6 @@ on a defined interval.
 %defattr(-,root,root,-)
 %config(noreplace) %{_sysconfdir}/%{name}/agent/agent.conf
 %{_sysconfdir}/gofer/plugins/pulpplugin.conf
-%{_libdir}/gofer/plugins/pulpplugin.*
 %doc README LICENSE COPYRIGHT
 
 # --- Selinux ---------------------------------------------------------------------

--- a/server/pulp/server/agent/auth.py
+++ b/server/pulp/server/agent/auth.py
@@ -84,7 +84,7 @@ class Authenticator(object):
         if not self.enabled:
             return
         try:
-            consumer_id = document.any['consumer_id']
+            consumer_id = document.data['consumer_id']
             key = self.get_key(consumer_id)
             if not key.verify(digest, signature):
                 raise ValidationFailed()

--- a/server/pulp/server/agent/direct/pulpagent.py
+++ b/server/pulp/server/agent/direct/pulpagent.py
@@ -1,16 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2011 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 """
 Contains (proxy) classes that represent the pulp agent.
 The purpose of the proxy is the insulate pulp from the implementation
@@ -79,12 +66,13 @@ class PulpAgent(object):
         :type task_id: str
         """
         criteria = {'match': {'task_id': task_id}}
+
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             authenticator=context.authenticator,
-            transport=context.transport,
-            async=True)
+            wait=0)
+
         admin = agent.Admin()
         admin.cancel(criteria=criteria)
 
@@ -106,12 +94,11 @@ class Consumer(object):
         :type context: pulp.server.agent.context.Context
         """
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator,
-            transport=context.transport,
-            async=True)
+            wait=0)
         consumer = agent.Consumer()
         consumer.unregistered()
 
@@ -129,13 +116,12 @@ class Consumer(object):
         :type options: dict
         """
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator,
-            transport=context.transport,
-            ctag=context.reply_queue,
-            any=context.details)
+            reply=context.reply_queue,
+            data=context.details)
         consumer = agent.Consumer()
         consumer.bind(bindings, options)
 
@@ -152,13 +138,12 @@ class Consumer(object):
         :type options: dict
         """
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator,
-            transport=context.transport,
-            ctag=context.reply_queue,
-            any=context.details)
+            reply=context.reply_queue,
+            data=context.details)
         consumer = agent.Consumer()
         consumer.unbind(bindings, options)
 
@@ -181,13 +166,12 @@ class Content(object):
         :type options: dict
         """
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator,
-            transport=context.transport,
-            ctag=context.reply_queue,
-            any=context.details)
+            reply=context.reply_queue,
+            data=context.details)
         content = agent.Content()
         content.install(units, options)
 
@@ -204,13 +188,12 @@ class Content(object):
         :type options: dict
         """
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator,
-            transport=context.transport,
-            ctag=context.reply_queue,
-            any=context.details)
+            reply=context.reply_queue,
+            data=context.details)
         content = agent.Content()
         content.update(units, options)
 
@@ -227,13 +210,12 @@ class Content(object):
         :type options: dict
         """
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator,
-            transport=context.transport,
-            ctag=context.reply_queue,
-            any=context.details)
+            reply=context.reply_queue,
+            data=context.details)
         content = agent.Content()
         content.uninstall(units, options)
 
@@ -251,10 +233,9 @@ class Profile(object):
         :type context: pulp.server.agent.context.Context
         """
         agent = Agent(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
-            authenticator=context.authenticator,
-            transport=context.transport)
+            authenticator=context.authenticator)
         profile = agent.Profile()
         profile.send()

--- a/server/pulp/server/db/migrations/0009_qpid_queues.py
+++ b/server/pulp/server/db/migrations/0009_qpid_queues.py
@@ -15,7 +15,7 @@ except ImportError:
     QPID_MESSAGING_AVAILABLE = False
 
 from pulp.server.config import config as pulp_conf
-from pulp.server.agent.direct.services import Services
+from pulp.server.agent.direct.services import ReplyHandler
 from pulp.server.db.model.consumer import Consumer
 
 
@@ -77,7 +77,7 @@ def _migrate_reply_queue(broker):
     :param broker: A qpidtools broker.
     :type broker: BrokerAgent
     """
-    name = Services.REPLY_QUEUE
+    name = ReplyHandler.REPLY_QUEUE
     queue = broker.getQueue(name)
     if not queue:
         # nothing to migrate

--- a/server/test/unit/server/agent/direct/test_agent.py
+++ b/server/test/unit/server/agent/direct/test_agent.py
@@ -33,10 +33,9 @@ class TestConsumerCapability(TestCase):
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_unregistered(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.secret = 'test-secret'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
 
         mock_agent = Mock()
@@ -51,22 +50,20 @@ class TestConsumerCapability(TestCase):
         # validation
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            url=context.url,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator,
-            transport=context.transport,
-            async=True)
+            wait=0)
 
         mock_consumer.unregistered.assert_called_with()
 
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_bind(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.secret = 'test-secret'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
         context.details = {'task_id': '4567'}
         context.reply_queue = 'pulp.task'
@@ -82,23 +79,21 @@ class TestConsumerCapability(TestCase):
         Consumer.bind(context, bindings, options)
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            ctag=context.reply_queue,
-            url=context.url,
-            transport=context.transport,
+            context.url,
+            context.route,
+            reply=context.reply_queue,
             secret=context.secret,
             authenticator=context.authenticator,
-            any=context.details)
+            data=context.details)
 
         mock_consumer.bind.assert_called_with(bindings, options)
 
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_unbind(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.secret = 'test-secret'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
         context.details = {'task_id': '4567'}
         context.reply_queue = 'pulp.task'
@@ -114,13 +109,12 @@ class TestConsumerCapability(TestCase):
         Consumer.unbind(context, bindings, options)
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            ctag=context.reply_queue,
-            url=context.url,
-            transport=context.transport,
+            context.url,
+            context.route,
+            reply=context.reply_queue,
             secret=context.secret,
             authenticator=context.authenticator,
-            any=context.details)
+            data=context.details)
 
         mock_consumer.unbind.assert_called_with(bindings, options)
 
@@ -130,10 +124,9 @@ class TestContentCapability(TestCase):
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_install(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.secret = 'test-secret'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
         context.details = {'task_id': '4567'}
         context.reply_queue = 'pulp.task'
@@ -149,23 +142,21 @@ class TestContentCapability(TestCase):
         Content.install(context, units, options)
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            ctag=context.reply_queue,
-            url=context.url,
-            transport=context.transport,
+            context.url,
+            context.route,
+            reply=context.reply_queue,
             secret=context.secret,
             authenticator=context.authenticator,
-            any=context.details)
+            data=context.details)
 
         mock_content.install.assert_called_with(units, options)
 
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_update(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.secret = 'test-secret'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
         context.details = {'task_id': '4567'}
         context.reply_queue = 'pulp.task'
@@ -181,23 +172,21 @@ class TestContentCapability(TestCase):
         Content.update(context, units, options)
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            ctag=context.reply_queue,
-            url=context.url,
-            transport=context.transport,
+            context.url,
+            context.route,
+            reply=context.reply_queue,
             secret=context.secret,
             authenticator=context.authenticator,
-            any=context.details)
+            data=context.details)
 
         mock_content.update.assert_called_with(units, options)
 
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_uninstall(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.secret = 'test-secret'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
         context.details = {'task_id': '4567'}
         context.reply_queue = 'pulp.task'
@@ -213,13 +202,12 @@ class TestContentCapability(TestCase):
         Content.uninstall(context, units, options)
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            ctag=context.reply_queue,
-            url=context.url,
-            transport=context.transport,
+            context.url,
+            context.route,
+            reply=context.reply_queue,
             secret=context.secret,
             authenticator=context.authenticator,
-            any=context.details)
+            data=context.details)
 
         mock_content.uninstall.assert_called_with(units, options)
 
@@ -229,10 +217,9 @@ class TestProfileCapability(TestCase):
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_send(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.secret = 'test-secret'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
 
         mock_agent = Mock()
@@ -243,9 +230,8 @@ class TestProfileCapability(TestCase):
         Profile.send(context)
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            url=context.url,
-            transport=context.transport,
+            context.url,
+            context.route,
             secret=context.secret,
             authenticator=context.authenticator)
 
@@ -257,9 +243,8 @@ class TestAdminCapability(TestCase):
     @patch('pulp.server.agent.direct.pulpagent.Agent')
     def test_send(self, mock_gofer_agent):
         context = Mock()
-        context.agent_id = '123'
+        context.route = '123'
         context.url = 'http://broker.com'
-        context.transport = 'qpid'
         context.authenticator = Mock()
 
         task_id = '5678'
@@ -274,10 +259,9 @@ class TestAdminCapability(TestCase):
         agent.cancel(context, task_id)
 
         mock_gofer_agent.assert_called_with(
-            context.agent_id,
-            url=context.url,
-            transport=context.transport,
+            context.url,
+            context.route,
             authenticator=context.authenticator,
-            async=True)
+            wait=0)
 
         mock_admin.cancel.assert_called_with(criteria=criteria)

--- a/server/test/unit/server/agent/test_auth.py
+++ b/server/test/unit/server/agent/test_auth.py
@@ -137,7 +137,7 @@ class TestAuthentication(TestCase):
         message = 'hello'
         consumer_id = 'test-consumer_id'
         document = Mock()
-        document.any = {'consumer_id': consumer_id}
+        document.data = {'consumer_id': consumer_id}
         key = RSA.load_key_bio(BIO.MemoryBuffer(RSA_KEY))
 
         mock_get.return_value = RSA.load_pub_key_bio(BIO.MemoryBuffer(RSA_PUB))
@@ -153,7 +153,7 @@ class TestAuthentication(TestCase):
         message = 'hello'
         consumer_id = 'test-consumer_id'
         document = Mock()
-        document.any = {'consumer_id': consumer_id}
+        document.data = {'consumer_id': consumer_id}
         key = RSA.load_key_bio(BIO.MemoryBuffer(OTHER_KEY))
 
         mock_get.return_value = RSA.load_pub_key_bio(BIO.MemoryBuffer(RSA_PUB))
@@ -170,7 +170,7 @@ class TestAuthentication(TestCase):
         mock_get.return_value.verify = Mock(return_value=False)
         consumer_id = 'test-consumer_id'
         document = Mock()
-        document.any = {'consumer_id': consumer_id}
+        document.data = {'consumer_id': consumer_id}
 
         # test
 

--- a/server/test/unit/server/agent/test_context.py
+++ b/server/test/unit/server/agent/test_context.py
@@ -15,21 +15,15 @@ from mock import patch
 
 from pulp.server.agent.auth import Authenticator
 from pulp.server.agent.context import Context
-from pulp.server.agent.direct.services import Services
-
-
-pulp_conf = {
-    'messaging': {
-        'url': 'http://broker'
-    }
-}
+from pulp.server.agent.direct.services import Services, ReplyHandler
 
 
 class TestContext(TestCase):
 
-    @patch('pulp.server.agent.context.pulp_conf', pulp_conf)
+    @patch('pulp.server.agent.context.Queue')
+    @patch('pulp.server.agent.direct.services.Services.get_url')
     @patch('pulp.server.agent.context.Authenticator.load')
-    def test_context(self, mock_load):
+    def test_context(self, mock_load, get_url, queue):
         _id = 'test-db_id'
         consumer = {'_id': _id, 'id': 'test-consumer', 'certificate': 'XXX'}
         details = {'task_id': '3456'}
@@ -40,12 +34,15 @@ class TestContext(TestCase):
 
         # validation
 
-        agent_id = 'pulp.agent.%s' % consumer['id']
+        route = 'pulp.agent.%s' % consumer['id']
 
-        self.assertEqual(context.agent_id, agent_id)
-        self.assertEqual(context.url, pulp_conf.get('messaging', 'url'))
+        queue.assert_called_once_with(route)
+        queue.return_value.declare.assert_called_once_with(context.url)
+
+        self.assertEqual(context.route, route)
+        self.assertEqual(context.url, get_url.return_value)
         self.assertEqual(context.secret, _id)
         self.assertEqual(context.details, details)
-        self.assertEqual(context.reply_queue, Services.REPLY_QUEUE)
+        self.assertEqual(context.reply_queue, ReplyHandler.REPLY_QUEUE)
         self.assertTrue(isinstance(context.authenticator, Authenticator))
         self.assertTrue(mock_load.called)

--- a/server/test/unit/server/db/migrations/test_migration_0009.py
+++ b/server/test/unit/server/db/migrations/test_migration_0009.py
@@ -15,7 +15,7 @@ from StringIO import StringIO
 
 from mock import patch, Mock, call
 
-from pulp.server.agent.direct.services import Services
+from pulp.server.agent.direct.services import ReplyHandler
 from pulp.server.db.migrate.models import MigrationModule
 
 
@@ -163,10 +163,10 @@ class TestMigrateReplyQueue(TestCase):
         migration._migrate_reply_queue(fake_broker)
 
         # validation
-        fake_broker.getQueue.assert_called_once_with(Services.REPLY_QUEUE)
-        expected_call = call(fake_broker, Services.REPLY_QUEUE)
+        fake_broker.getQueue.assert_called_once_with(ReplyHandler.REPLY_QUEUE)
+        expected_call = call(fake_broker, ReplyHandler.REPLY_QUEUE)
         self.mock_del_queue_catch_queue_in_use_exc.assert_has_calls(expected_call)
-        fake_broker.addQueue.assert_called_once_with(Services.REPLY_QUEUE, durable=True)
+        fake_broker.addQueue.assert_called_once_with(ReplyHandler.REPLY_QUEUE, durable=True)
 
     def test_migrate_reply_queue_arguments_is_exclusive_deletes_and_add_reply_queue(self):
         fake_queue = Mock()
@@ -182,10 +182,10 @@ class TestMigrateReplyQueue(TestCase):
         migration._migrate_reply_queue(fake_broker)
 
         # validation
-        fake_broker.getQueue.assert_called_with(Services.REPLY_QUEUE)
-        expected_call = call(fake_broker, Services.REPLY_QUEUE)
+        fake_broker.getQueue.assert_called_with(ReplyHandler.REPLY_QUEUE)
+        expected_call = call(fake_broker, ReplyHandler.REPLY_QUEUE)
         self.mock_del_queue_catch_queue_in_use_exc.assert_has_calls(expected_call)
-        fake_broker.addQueue.assert_called_with(Services.REPLY_QUEUE, durable=True)
+        fake_broker.addQueue.assert_called_with(ReplyHandler.REPLY_QUEUE, durable=True)
 
     def test_migrate_reply_queue_not_exclusive_does_not_delete_or_add_reply_queue(self):
         fake_queue = Mock()
@@ -201,7 +201,7 @@ class TestMigrateReplyQueue(TestCase):
         migration._migrate_reply_queue(fake_broker)
 
         # validation
-        fake_broker.getQueue.assert_called_with(Services.REPLY_QUEUE)
+        fake_broker.getQueue.assert_called_with(ReplyHandler.REPLY_QUEUE)
         self.assertTrue(not self.mock_del_queue_catch_queue_in_use_exc.called)
         self.assertTrue(not fake_broker.addQueue.called)
 
@@ -214,7 +214,7 @@ class TestMigrateReplyQueue(TestCase):
         migration._migrate_reply_queue(fake_broker)
 
         # validation
-        fake_broker.getQueue.assert_called_with(Services.REPLY_QUEUE)
+        fake_broker.getQueue.assert_called_with(ReplyHandler.REPLY_QUEUE)
         self.assertTrue(not self.mock_del_queue_catch_queue_in_use_exc.called)
         self.assertTrue(not fake_broker.addQueue.called)
 


### PR DESCRIPTION
Updated to work with gofer 2.3.  Latest upstream and in Fedora 21.
- improved support for multiple messaging adapters (formerly transports).
- standardized url which includes messaging adapter.  format: *adapter*+*scheme*://*user*:*password*@*host*:*port*/*virtual-host*  instead of the *transport* option.
- hundreds of new unit tests.