### PR TITLE
Adds fix for 1174361 to python-kombu and bumps release

### DIFF
--- a/deps/python-kombu/1174361.patch
+++ b/deps/python-kombu/1174361.patch
@@ -1,0 +1,53 @@
+From 807ce47b82d35f1ce7f425d2b988162fb11617d2 Mon Sep 17 00:00:00 2001
+From: Brian Bouterse <bmbouter@gmail.com>
+Date: Fri, 19 Dec 2014 14:10:38 -0500
+Subject: [PATCH] fixes celery/kombu#439 better handling for a purge of missing
+ Queue
+
+---
+ kombu/tests/transport/test_qpid.py | 5 +++++
+ kombu/transport/qpid.py            | 5 ++++-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/kombu/tests/transport/test_qpid.py b/kombu/tests/transport/test_qpid.py
+index eb7d8f5..390e09c 100644
+--- a/kombu/tests/transport/test_qpid.py
++++ b/kombu/tests/transport/test_qpid.py
+@@ -522,6 +522,11 @@ class TestChannelPurge(ChannelTestBase):
+         result = self.channel._purge(self.mock_queue)
+         self.assertEqual(result, 5)
+ 
++    @patch(QPID_MODULE + '.ChannelError', new=MockException)
++    def test_channel__purge_raises_channel_error_if_queue_does_not_exist(self):
++        self.mock_broker_agent.return_value.getQueue.return_value = None
++        self.assertRaises(MockException, self.channel._purge, self.mock_queue)
++
+ 
+ @case_no_python3
+ @case_no_pypy
+diff --git a/kombu/transport/qpid.py b/kombu/transport/qpid.py
+index ef88bc5..474fe73 100644
+--- a/kombu/transport/qpid.py
++++ b/kombu/transport/qpid.py
+@@ -62,7 +62,7 @@ try:
+ except ImportError:  # pragma: no cover
+     qpid = None
+ 
+-
++from kombu.exceptions import ChannelError
+ from kombu.five import Empty, items
+ from kombu.log import get_logger
+ from kombu.transport.virtual import Base64, Message
+@@ -503,6 +503,9 @@ class Channel(base.StdChannel):
+         :rtype: int
+         """
+         queue_to_purge = self._broker.getQueue(queue)
++        if queue_to_purge is None:
++            raise ChannelError("queue.purge: server channel error 404, message: "
++                               "NOT_FOUND - no queue '%s'" % queue)
+         message_count = queue_to_purge.values['msgDepth']
+         if message_count > 0:
+             queue_to_purge.purge(message_count)
+-- 
+1.9.3
+

--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.24
-Release:        1%{?dist}
+Release:        2.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages
@@ -19,6 +19,7 @@ Group:          Development/Languages
 License:        BSD and Python
 URL:            http://pypi.python.org/pypi/%{srcname}
 Source0:        http://pypi.python.org/packages/source/k/%{srcname}/%{srcname}-%{version}.tar.gz
+Patch0:         1174361.patch
 BuildArch:      noarch
 
 BuildRequires:  python2-devel


### PR DESCRIPTION
I've done scratch builds of this commit on koji, and they all passed except for FC21 which failed due to python-amqp not being 1.4.6. I am adding 1.4.6 to the fc21 builders, and will re-run all scratch builds. I will not merge unless they all pass.
