### PR TITLE
1174353 - improving performance of "pulp-admin tasks list

### DIFF
--- a/client_admin/pulp/client/admin/tasks.py
+++ b/client_admin/pulp/client/admin/tasks.py
@@ -70,8 +70,7 @@ class BaseTasksSection(PulpCliSection):
 
         self.context.prompt.render_title('Tasks')
 
-        response = self.retrieve_tasks(**kwargs)
-        task_objects = response.response_body
+        task_objects = self.retrieve_tasks(**kwargs)
 
         # Easy out clause
         if len(task_objects) is 0:
@@ -81,7 +80,7 @@ class BaseTasksSection(PulpCliSection):
         # Parse each task object into a document to be displayed using the
         # prompt utilities
         task_documents = []
-        for task in response.response_body:
+        for task in task_objects:
 
             # Interpret task values
             state, start_time, finish_time, result = self.parse_state(task)
@@ -240,10 +239,18 @@ class BaseTasksSection(PulpCliSection):
         """
         raise NotImplementedError()
 
+
 class AllTasksSection(BaseTasksSection):
+    FIELDS = ('tags', 'task_id', 'state', 'start_time', 'finish_time')
+
     def retrieve_tasks(self, **kwargs):
-        response = self.context.server.tasks.get_all_tasks()
-        return response
+        """
+        :return:    list of pulp.bindings.responses.Task instances
+        :rtype:     list
+        """
+        tasks = self.context.server.tasks_search.search(fields=self.FIELDS)
+        return tasks
+
 
 class RepoTasksSection(BaseTasksSection):
     def __init__(self, context, name, description):
@@ -252,6 +259,10 @@ class RepoTasksSection(BaseTasksSection):
         self.list_command.create_option('--repo-id', _('identifies the repository to display'), required=True)
 
     def retrieve_tasks(self, **kwargs):
+        """
+        :return:    list of pulp.bindings.responses.Task instances
+        :rtype:     list
+        """
         repo_id = kwargs['repo-id']
         response = self.context.server.tasks.get_repo_tasks(repo_id)
-        return response
+        return response.response_body

--- a/client_admin/test/unit/test_pulp_tasks_extension.py
+++ b/client_admin/test/unit/test_pulp_tasks_extension.py
@@ -47,8 +47,25 @@ EXAMPLE_CALL_REPORT = {
     'id': '5390931b3de3a3290f57e32f'
 }
 
+# "pulp-admin tasks list" requests only the fields it needs, and this is an
+# example response.
+EXAMPLE_LIST_REPORT = {
+    '_href': '/pulp/api/v2/tasks/b2308412-5149-424d-9b04-85a8d6e03067/',
+    'task_id': 'c54742d4-9f8b-11e1-9837-00508d977dff',
+    'tags': [
+        'pulp:repository:f16',
+        'pulp:action:sync'
+    ],
+    'finish_time': '2014-06-05T15:56:12Z',
+    '_ns': 'task_status',
+    'start_time': None,
+    'state': 'waiting',
+    '_id': {
+        '$oid': '5390931b81a97875924cc0d1'
+    },
+    'id': '5390931b3de3a3290f57e32f'
+}
 
-# -- tests --------------------------------------------------------------------
 
 class AllTasksTests(base_builtins.PulpClientTests):
 
@@ -69,7 +86,7 @@ class AllTasksTests(base_builtins.PulpClientTests):
 
     def test_list(self):
         # Setup
-        self.server_mock.request.return_value = (200, [copy.copy(EXAMPLE_CALL_REPORT)])
+        self.server_mock.request.return_value = (200, [copy.copy(EXAMPLE_LIST_REPORT)])
 
         # Test
         self.all_tasks_section.list()


### PR DESCRIPTION
pulp-admin now specifies which fields it wants, which drastically reduces the
amount of data that gets transfered.

https://bugzilla.redhat.com/show_bug.cgi?id=1174353
