### PR TITLE
Working directories for tasks

### DIFF
--- a/common/pulp/common/error_codes.py
+++ b/common/pulp/common/error_codes.py
@@ -80,6 +80,7 @@ PLP0029 = Error("PLP0029",
 PLP0030 = Error("PLP0030", _("Authentication with username %(user)s failed: invalid username or password"), ['user'])
 PLP0031 = Error("PLP0031", _("Content source %(id)s could not be found at %(url)s"), ['id', 'url'])
 PLP0032 = Error("PLP0032", _("Task %(task_id)s encountered one or more failures during execution."), ['task_id'])
+PLP0033 = Error("PLP0033", _("Working Directory requested outside of asynchronous task. "), [])
 # Create a section for general validation errors (PLP1000 - PLP2999)
 # Validation problems should be reported with a general PLP1000 error with a more specific
 # error message nested inside of it.

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -297,3 +297,12 @@ Resource names should always start with ``/v2`` and end with a trailing ``/``.  
 following command will add a permission to ``test-user`` to create repositories::
 
     pulp-admin auth permission grant --resource /v2/repositories/ --login test-user -o create 
+
+Pulp workers not starting due to Permission Denied Exception
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pulp workers attempt create working directory on startup. The path for working directories is
+defined by the `working_directory` config in `server` section of `/etc/pulp/server.conf`. The
+default value is `/var/cache/pulp`. Any user defined path needs to be owned by user and group
+`apache`. If running with SELinux in Enforcing mode, the path also needs to have
+`system_u:object_r:pulp_var_cache_t` security context. 

--- a/docs/user-guide/tuning.rst
+++ b/docs/user-guide/tuning.rst
@@ -162,6 +162,12 @@ The directories `/etc/pki/pulp` and `/var/lib/pulp` need to be shared across
 each server that hosts workers, as well as all httpd servers. This is typically
 done via NFS.
 
+Each worker has its own working directory. The default path is `/var/cache/pulp/`,
+however, it can be modified by editing the `working_directory` config value in
+`server` section of `/etc/pulp/server.conf`. The path needs to be owned by user
+and group `apache`. If running with SELinux in Enforcing mode, the path also needs
+to have `system_u:object_r:pulp_var_cache_t` security context.  
+
 Pulp and Mongo Database
 ^^^^^^^^^^^^^^^^^^^^^^^
 Pulp uses Mongo to manage repository information as well as content metadata.

--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -44,6 +44,7 @@ DIRS = [
     '/var/lib/pulp_client/admin/extensions',
     '/var/lib/pulp_client/consumer',
     '/var/lib/pulp_client/consumer/extensions',
+    '/var/cache/pulp',
 ]
 
 # We only support Python >= 2.6 for the server code

--- a/pulp.spec
+++ b/pulp.spec
@@ -178,6 +178,7 @@ mkdir -p %{buildroot}/%{_var}/lib/%{name}/uploads
 mkdir -p %{buildroot}/%{_var}/lib/%{name}/published
 mkdir -p %{buildroot}/%{_var}/lib/%{name}/static
 mkdir -p %{buildroot}/%{_var}/www
+mkdir -p %{buildroot}/%{_var}/cache/%{name}
 
 # Configuration
 cp -R server/etc/pulp/* %{buildroot}/%{_sysconfdir}/%{name}
@@ -355,6 +356,7 @@ Pulp provides replication, access, and accounting for software repositories.
 %config(noreplace) %{_sysconfdir}/%{name}/server.conf
 # - apache:apache
 %defattr(-,apache,apache,-)
+%{_var}/cache/%{name}/
 %dir %{_var}/log/%{name}
 %{_var}/lib/%{name}/
 %{_var}/www/pub

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -60,6 +60,7 @@
 # debugging_mode:   boolean; toggles Pulp's debugging capabilities
 # log_level:        The desired logging level. Options are: CRITICAL, ERROR, WARNING, INFO, DEBUG,
 #                   and NOTSET. Pulp will default to INFO.
+# working_directory:path to where pulp workers can create working directories needed to complete tasks
 [server]
 # server_name: server_hostname
 # key_url: /pulp/gpg
@@ -68,6 +69,7 @@
 # default_password: admin
 # debugging_mode: false
 # log_level: INFO
+# working_directory: /var/cache/pulp
 
 
 # = Authentication =

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -77,6 +77,7 @@ _default_values = {
         'log_level': 'INFO',
         'key_url': '/pulp/gpg',
         'ks_url': '/pulp/ks',
+        'working_directory': '/var/cache/pulp'
     },
     'tasks': {
         'broker_url': 'qpid://guest@localhost/',

--- a/server/pulp/server/managers/content/upload.py
+++ b/server/pulp/server/managers/content/upload.py
@@ -214,8 +214,7 @@ class ContentUploadManager(object):
         call_config = PluginCallConfiguration(plugin_config, repo_importer['config'],
                                               override_config)
         transfer_repo = repo_common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = repo_common_utils.importer_working_dir(
-            repo_importer['importer_type_id'], repo_id, mkdir=True)
+        transfer_repo.working_dir = repo_common_utils.get_working_directory()
 
         file_path = ContentUploadManager._upload_file_path(upload_id)
 

--- a/server/pulp/server/managers/repo/_common.py
+++ b/server/pulp/server/managers/repo/_common.py
@@ -2,26 +2,25 @@
 Contains functionality common across all repository-related managers.
 
 = Working Directories =
-Working directories are as staging or temporary file storage by importers
-and distributors. Each directory is unique to the repository and plugin
-combination.
+Working directories are used as staging or temporary file storage by importers and distributors.
+Now that this work is performed inside of celery tasks, each celery worker gets a working
+directory. Each task executed by a worker is able to get a working directory inside the workers
+root working directory.
 
-The directory structure for plugin working directories is as follows:
-<pulp_storage>/working/<repo_id>/[importers|distributors]/<plugin_type_id>
-
-For example, for importer "foo" and repository "bar":
-/var/lib/pulp/working/bar/importers/foo
-
-The rationale is to simplify cleanup on repository delete; the repository's
-working directory is simply deleted.
+The root of the working directories is specified with 'working_directory' setting in
+/etc/pulp/server.conf.  The default value is /var/cache/pulp
 """
 
 import os
+import shutil
 
-from pulp.common import dateutils
-from pulp.server import config as pulp_config
+from celery import task
+
+from pulp.common import dateutils, error_codes
 from pulp.plugins.model import Repository, RelatedRepository, RepositoryGroup, \
     RelatedRepositoryGroup
+from pulp.server import config as pulp_config
+from pulp.server.exceptions import PulpCodedException
 
 
 def _ensure_tz_specified(time_stamp):
@@ -79,82 +78,6 @@ def to_related_repo(repo_data, configs):
     return r
 
 
-def repository_working_dir(repo_id, mkdir=True):
-    """
-    Determines the repository's working directory. Individual plugin working
-    directories will be placed under this. If the mkdir argument is set to true,
-    the directory will be created as part of this call.
-
-    See the module-level docstrings for more information on the directory
-    structure.
-
-    @param mkdir: if true, this call will create the directory; otherwise the
-                  full path will just be generated
-    @type  mkdir: bool
-
-    @return: full path on disk
-    @rtype:  str
-    """
-    working_dir = os.path.join(_repo_working_dir(), repo_id)
-
-    if mkdir and not os.path.exists(working_dir):
-        os.makedirs(working_dir)
-
-    return working_dir
-
-
-def importer_working_dir(importer_type_id, repo_id, mkdir=True):
-    """
-    Determines the working directory for an importer to use for a repository.
-    If the mkdir argument is set to true, the directory will be created as
-    part of this call.
-
-    See the module-level docstrings for more information on the directory
-    structure.
-
-    @param mkdir: if true, this call will create the directory; otherwise the
-                  full path will just be generated
-    @type  mkdir: bool
-
-    @return: full path on disk to the directory the importer can use for the
-             given repository
-    @rtype:  str
-    """
-    repo_working_dir = repository_working_dir(repo_id, mkdir)
-    working_dir = os.path.join(repo_working_dir, 'importers', importer_type_id)
-
-    if mkdir and not os.path.exists(working_dir):
-        os.makedirs(working_dir)
-
-    return working_dir
-
-
-def distributor_working_dir(distributor_type_id, repo_id, mkdir=True):
-    """
-    Determines the working directory for a distributor to use for a repository.
-    If the mkdir argument is set to true, the directory will be created as
-    part of this call.
-
-    See the module-level docstrings for more information on the directory
-    structure.
-
-    @param mkdir: if true, this call will create the directory; otherwise the
-                  full path will just be generated
-    @type  mkdir: bool
-
-    @return: full path on disk to the directory the distributor can use for the
-             given repository
-    @rtype:  str
-    """
-    repo_working_dir = repository_working_dir(repo_id, mkdir)
-    working_dir = os.path.join(repo_working_dir, 'distributors', distributor_type_id)
-
-    if mkdir and not os.path.exists(working_dir):
-        os.makedirs(working_dir)
-
-    return working_dir
-
-
 def to_transfer_repo_group(group_data):
     """
     Converts the given database representation of a repository group into a
@@ -192,85 +115,98 @@ def to_related_repo_group(group_data, configs):
     return g
 
 
-def repo_group_working_dir(group_id, mkdir=True):
+def _working_dir_root(worker_name):
     """
-    Determines the repo group's working directory. Individual plugin working
-    directories will be placed under this. If the mkdir argument is set to
-    true, the directory will be created as part of this call.
+    Returns the path to the working directory of a worker
 
-    @param group_id: identifies the repo group
-    @type  group_id: str
-
-    @param mkdir: if true, the call will create the directory; otherwise the
-                  full path will just be generated and returned
-    @type  mkdir: bool
-
-    @return: full path on disk
-    @rtype:  str
+    :param worker_name:     Name of worker for which path is requested
+    :type  name:            basestring
+    :return working_directory setting from server config
+    :rtype  str
     """
-    working_dir = os.path.join(_repo_group_working_dir(), group_id)
-
-    if mkdir and not os.path.exists(working_dir):
-        os.makedirs(working_dir)
-
-    return working_dir
-
-
-def group_importer_working_dir(importer_type_id, group_id, mkdir=True):
-    """
-    Determines the working directory for an importer to use for a repository
-    group. If the mkdir argument is set to true, the directory will be created
-    as part of this call.
-
-    @param mkdir: if true, the call will create the directory; otherwise the
-                  full path will just be generated and returned
-    @type  mkdir: bool
-
-    @return: full path on disk
-    @rtype:  str
-    """
-    group_working_dir = repo_group_working_dir(group_id, mkdir)
-    working_dir = os.path.join(group_working_dir, 'importers', importer_type_id)
-
-    if mkdir and not os.path.exists(working_dir):
-        os.makedirs(working_dir)
-
-    return working_dir
-
-
-def group_distributor_working_dir(distributor_type_id, group_id, mkdir=True):
-    """
-    Determines the working directory for an importer to use for a repository
-    group. If the mkdir argument is set to true, the directory will be created
-    as part of this call.
-
-    @param mkdir: if true, the call will create the directory; otherwise the
-                  full path will just be generated and returned
-    @type  mkdir: bool
-
-    @return: full path on disk
-    @rtype:  str
-    """
-    group_working_dir = repo_group_working_dir(group_id, mkdir)
-    working_dir = os.path.join(group_working_dir, 'distributors', distributor_type_id)
-
-    if mkdir and not os.path.exists(working_dir):
-        os.makedirs(working_dir)
-
-    return working_dir
-
-
-def _working_dir_root():
-    storage_dir = pulp_config.config.get('server', 'storage_dir')
-    dir_root = os.path.join(storage_dir, 'working')
+    working_dir = pulp_config.config.get('server', 'working_directory')
+    dir_root = os.path.join(working_dir, worker_name)
     return dir_root
 
 
-def _repo_working_dir():
-    dir = os.path.join(_working_dir_root(), 'repos')
-    return dir
+def create_worker_working_directory(worker_name):
+    """
+    Creates a working directory inside the working_directory as specified in /etc/pulp/server.conf
+    default path for working_directory is /var/cache/pulp
+
+    :param worker_name:     Name of worker that uses the working directory created
+    :type  name:            basestring
+    :return Path to the working directory for a worker
+    :rtype  str
+    """
+    working_dir_root = _working_dir_root(worker_name)
+    os.mkdir(working_dir_root)
 
 
-def _repo_group_working_dir():
-    dir = os.path.join(_working_dir_root(), 'repo_groups')
-    return dir
+def delete_worker_working_directory(worker_name):
+    """
+    Deletes a working directory inside the working_directory as specified in /etc/pulp/server.conf
+    default path for working_directory is /var/cache/pulp
+
+    :param worker_name:     Name of worker that uses the working directory being deleted
+    :type  name:            basestring
+    """
+    working_dir_root = _working_dir_root(worker_name)
+    if os.path.exists(working_dir_root):
+        shutil.rmtree(working_dir_root)
+
+
+def _working_directory_path():
+    """
+    Gets the path for a task's working directory inside a workers working directory
+
+    @return: full path on disk to the working directory for current task
+    @rtype:  str
+    """
+    current_task = task.current
+    if (current_task and current_task.request and current_task.request.id and
+            current_task.request.hostname):
+        worker_name = current_task.request.hostname
+        task_id = current_task.request.id
+        worker_dir_root = _working_dir_root(worker_name)
+        working_dir_root = os.path.join(worker_dir_root, task_id)
+    else:
+        return None
+
+    return working_dir_root
+
+
+def get_working_directory():
+    """
+    Creates a working directory with task id as name. This directory resides inside a particular
+    worker's working directory. The 'working_directory' setting in [server] section of
+    /etc/pulp/server.conf defines the local path to the root of working directories. The directory
+    is created only once per task. The path to the existing working directory is returned for all
+    subsequent calls for that task.
+
+    @return: full path on disk to the working directory for current task
+    @rtype:  str
+    """
+    working_dir_root = _working_directory_path()
+
+    if working_dir_root:
+        if os.path.exists(working_dir_root):
+            return working_dir_root
+        os.mkdir(working_dir_root)
+        return working_dir_root
+    else:
+        # If path is None, this method is called outside of an asynchronous task
+        raise PulpCodedException(error_codes.PLP0033)
+
+
+def delete_working_directory():
+    """
+    Deletes working directory for a particular task.
+
+    @return: None
+    @rtype:  None
+    """
+    working_dir_root = _working_directory_path()
+
+    if working_dir_root and os.path.exists(working_dir_root):
+        shutil.rmtree(working_dir_root)

--- a/server/pulp/server/managers/repo/cud.py
+++ b/server/pulp/server/managers/repo/cud.py
@@ -6,9 +6,7 @@ or distributor configuration.
 
 from gettext import gettext as _
 import logging
-import os
 import re
-import shutil
 import sys
 
 from celery import task
@@ -23,7 +21,6 @@ from pulp.server.exceptions import (DuplicateResource, InvalidValue, MissingReso
                                     PulpExecutionException)
 from pulp.server.tasks import repository
 import pulp.server.managers.factory as manager_factory
-import pulp.server.managers.repo._common as common_utils
 
 
 _REPO_ID_REGEX = re.compile(r'^[.\-_A-Za-z0-9]+$')  # letters, numbers, underscore, hyphen
@@ -230,16 +227,6 @@ class RepoManager(object):
             except Exception, e:
                 _logger.exception('Error received removing distributor [%s] from repo [%s]' % (
                     repo_distributor['id'], repo_id))
-                error_tuples.append(e)
-
-        # Delete the repository working directory
-        repo_working_dir = common_utils.repository_working_dir(repo_id, mkdir=False)
-        if os.path.exists(repo_working_dir):
-            try:
-                shutil.rmtree(repo_working_dir)
-            except Exception, e:
-                _logger.exception('Error while deleting repo working dir [%s] for repo [%s]' % (
-                    repo_working_dir, repo_id))
                 error_tuples.append(e)
 
         # Database Updates

--- a/server/pulp/server/managers/repo/dependency.py
+++ b/server/pulp/server/managers/repo/dependency.py
@@ -71,8 +71,7 @@ class DependencyManager(object):
         # Package for the importer call
         call_config = PluginCallConfiguration(plugin_config, repo_importer['config'], options)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.importer_working_dir(
-            repo_importer['importer_type_id'], repo_id, mkdir=True)
+        transfer_repo.working_dir = common_utils.get_working_directory()
 
         conduit = DependencyResolutionConduit(repo_id, repo_importer['id'])
 

--- a/server/pulp/server/managers/repo/distributor.py
+++ b/server/pulp/server/managers/repo/distributor.py
@@ -152,8 +152,7 @@ class RepoDistributorManager(object):
         # Let the distributor plugin verify the configuration
         call_config = PluginCallConfiguration(plugin_config, clean_config)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.distributor_working_dir(distributor_type_id,
-                                                                         repo_id)
+
         config_conduit = RepoConfigConduit(distributor_type_id)
 
         result = distributor_instance.validate_config(transfer_repo, call_config, config_conduit)
@@ -227,8 +226,7 @@ class RepoDistributorManager(object):
         call_config = PluginCallConfiguration(plugin_config, repo_distributor['config'])
 
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.distributor_working_dir(distributor_type_id,
-                                                                         repo_id)
+        transfer_repo.working_dir = common_utils.get_working_directory()
 
         distributor_instance.distributor_removed(transfer_repo, call_config)
 
@@ -296,8 +294,7 @@ class RepoDistributorManager(object):
         # Let the distributor plugin verify the configuration
         call_config = PluginCallConfiguration(plugin_config, merged_config)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.distributor_working_dir(distributor_type_id,
-                                                                         repo_id)
+        transfer_repo.working_dir = common_utils.get_working_directory()
         config_conduit = RepoConfigConduit(distributor_type_id)
 
         try:
@@ -364,8 +361,7 @@ class RepoDistributorManager(object):
         # Let the distributor plugin verify the configuration
         call_config = PluginCallConfiguration(plugin_config, repo_distributor['config'])
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.distributor_working_dir(distributor_type_id,
-                                                                         repo_id)
+        transfer_repo.working_dir = common_utils.get_working_directory()
 
         try:
             payload = distributor_instance.create_consumer_payload(transfer_repo, call_config,

--- a/server/pulp/server/managers/repo/group/cud.py
+++ b/server/pulp/server/managers/repo/group/cud.py
@@ -168,7 +168,7 @@ class RepoGroupManager(object):
             RepoGroupDistributorManager.remove_distributor(group_id, distributor['id'])
 
         # Delete the working directory for the group
-        working_dir = common_utils.repo_group_working_dir(group_id)
+        working_dir = common_utils.get_working_directory()
         if os.path.exists(working_dir):
             try:
                 shutil.rmtree(working_dir)

--- a/server/pulp/server/managers/repo/group/distributor.py
+++ b/server/pulp/server/managers/repo/group/distributor.py
@@ -145,8 +145,7 @@ class RepoGroupDistributorManager(object):
         # Let the plugin validate the configuration
         call_config = PluginCallConfiguration(plugin_config, clean_config)
         transfer_group = common_utils.to_transfer_repo_group(group)
-        transfer_group.working_dir = common_utils.distributor_working_dir(distributor_type_id,
-                                                                          repo_group_id)
+        transfer_group.working_dir = common_utils.get_working_directory()
 
         config_conduit = RepoConfigConduit(distributor_type_id)
 
@@ -218,8 +217,7 @@ class RepoGroupDistributorManager(object):
 
         call_config = PluginCallConfiguration(plugin_config, distributor['config'])
         transfer_group = common_utils.to_transfer_repo_group(group)
-        transfer_group.working_dir = common_utils.distributor_working_dir(distributor_type_id,
-                                                                          repo_group_id)
+        transfer_group.working_dir = common_utils.get_working_directory()
 
         try:
             distributor_instance.distributor_removed(transfer_group, call_config)
@@ -268,8 +266,7 @@ class RepoGroupDistributorManager(object):
         # Request the distributor validate the new configuration
         call_config = PluginCallConfiguration(plugin_config, merged_config)
         transfer_group = common_utils.to_transfer_repo_group(group)
-        transfer_group.working_dir = common_utils.group_distributor_working_dir(distributor_type_id,
-                                                                                repo_group_id)
+        transfer_group.working_dir = common_utils.get_working_directory()
         config_conduit = RepoConfigConduit(distributor_type_id)
 
         # Request the plugin validate the configuration

--- a/server/pulp/server/managers/repo/group/publish.py
+++ b/server/pulp/server/managers/repo/group/publish.py
@@ -52,8 +52,7 @@ class RepoGroupPublishManager(object):
         call_config = PluginCallConfiguration(plugin_config, distributor['config'],
                                               publish_config_override)
         transfer_group = common_utils.to_transfer_repo_group(group)
-        transfer_group.working_dir = common_utils.group_distributor_working_dir(distributor_type_id,
-                                                                                group_id)
+        transfer_group.working_dir = common_utils.get_working_directory()
 
         # TODO: Add events for group publish start/complete
         RepoGroupPublishManager._do_publish(transfer_group, distributor_id, distributor_instance,

--- a/server/pulp/server/managers/repo/importer.py
+++ b/server/pulp/server/managers/repo/importer.py
@@ -110,7 +110,6 @@ class RepoImporterManager(object):
         # Let the importer plugin verify the configuration
         call_config = PluginCallConfiguration(plugin_config, clean_config)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.importer_working_dir(importer_type_id, repo_id)
 
         # Remove old importer if one exists
         try:
@@ -169,7 +168,6 @@ class RepoImporterManager(object):
         # Let the importer plugin verify the configuration
         call_config = PluginCallConfiguration(plugin_config, clean_config)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.importer_working_dir(importer_type_id, repo_id)
 
         result = importer_instance.validate_config(transfer_repo, call_config)
 
@@ -217,7 +215,6 @@ class RepoImporterManager(object):
         call_config = PluginCallConfiguration(plugin_config, repo_importer['config'])
 
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.importer_working_dir(importer_type_id, repo_id)
 
         importer_instance.importer_removed(transfer_repo, call_config)
 
@@ -275,7 +272,7 @@ class RepoImporterManager(object):
         # Let the importer plugin verify the configuration
         call_config = PluginCallConfiguration(plugin_config, merged_config)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.importer_working_dir(importer_type_id, repo_id)
+        transfer_repo.working_dir = common_utils.get_working_directory()
 
         try:
             result = importer_instance.validate_config(transfer_repo, call_config)

--- a/server/pulp/server/managers/repo/publish.py
+++ b/server/pulp/server/managers/repo/publish.py
@@ -73,8 +73,7 @@ class RepoPublishManager(object):
         call_config = PluginCallConfiguration(distributor_config, repo_distributor['config'],
                                               publish_config_override)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.distributor_working_dir(
-            repo_distributor['distributor_type_id'], repo_id, mkdir=True)
+        transfer_repo.working_dir = common_utils.get_working_directory()
 
         # Fire events describing the publish state
         fire_manager = manager_factory.event_fire_manager()

--- a/server/pulp/server/managers/repo/sync.py
+++ b/server/pulp/server/managers/repo/sync.py
@@ -85,8 +85,7 @@ class RepoSyncManager(object):
         call_config = PluginCallConfiguration(importer_config, repo_importer['config'],
                                               sync_config_override)
         transfer_repo = common_utils.to_transfer_repo(repo)
-        transfer_repo.working_dir = common_utils.importer_working_dir(
-            repo_importer['importer_type_id'], repo_id, mkdir=True)
+        transfer_repo.working_dir = common_utils.get_working_directory()
 
         # Fire an events around the call
         fire_manager = manager_factory.event_fire_manager()

--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -249,12 +249,10 @@ class RepoUnitAssociationManager(object):
 
         # Convert the two repos into the plugin API model
         transfer_dest_repo = common_utils.to_transfer_repo(dest_repo)
-        transfer_dest_repo.working_dir = common_utils.importer_working_dir(
-            dest_repo_importer['importer_type_id'], dest_repo['id'], mkdir=True)
+        transfer_dest_repo.working_dir = common_utils.get_working_directory()
 
         transfer_source_repo = common_utils.to_transfer_repo(source_repo)
-        transfer_source_repo.working_dir = common_utils.importer_working_dir(
-            source_repo_importer['importer_type_id'], source_repo['id'], mkdir=True)
+        transfer_source_repo.working_dir = common_utils.get_working_directory()
 
         # Invoke the importer
         importer_instance, plugin_config = plugin_api.get_importer_by_id(
@@ -488,8 +486,7 @@ def remove_from_importer(repo_id, transfer_units):
     repo_importer = importer_manager.get_importer(repo_id)
 
     transfer_repo = common_utils.to_transfer_repo(repo)
-    transfer_repo.working_dir = common_utils.importer_working_dir(repo_importer['importer_type_id'],
-                                                                  repo_id, mkdir=True)
+    transfer_repo.working_dir = common_utils.get_working_directory()
 
     # Retrieve the plugin instance to invoke
     importer_instance, plugin_config = plugin_api.get_importer_by_id(

--- a/server/selinux/server/pulp-celery.fc
+++ b/server/selinux/server/pulp-celery.fc
@@ -1,2 +1,4 @@
 # Pulp uses Celery, and this applies the celery_exec_t context to the celery binary
 /usr/bin/celery -- gen_context(system_u:object_r:celery_exec_t,s0)
+# Pulp celery workers need to manage temporary files in /var/cache/pulp
+/var/cache/pulp(/.*)? gen_context(system_u:object_r:pulp_var_cache_t,s0)

--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -5,8 +5,12 @@ type celery_t;
 type celery_exec_t;
 init_daemon_domain(celery_t, celery_exec_t)
 
+type pulp_var_cache_t;
+files_type(pulp_var_cache_t)
+
 require {
         type celery_t;
+        type pulp_var_cache_t;
         type pulp_cert_t;
         type puppet_etc_t;
         type var_run_t;
@@ -14,7 +18,7 @@ require {
         class file { lock rename write setattr getattr read create unlink open };
         class process { setsched signal signull };
         class tcp_socket { connect create getattr getopt read setopt shutdown write };
-        class lnk_file { create };
+        class lnk_file { create read getattr unlink};
         class netlink_route_socket { bind create getattr nlmsg_read write read };
         class udp_socket { ioctl create getattr connect write read };
         class unix_dgram_socket { create connect };
@@ -57,6 +61,16 @@ ifdef(`distro_rhel6', `
 ',`
     miscfiles_read_generic_certs(celery_t)
 ')
+
+######################################
+#
+# Pulp workers need temporary working directories to perform various tasks.  This policy allows
+# management of files and directories. The default root directory is /var/cache/pulp.
+#
+
+allow celery_t pulp_var_cache_t:lnk_file { create read getattr unlink };
+manage_dirs_pattern(celery_t, pulp_var_cache_t, pulp_var_cache_t)
+manage_files_pattern(celery_t, pulp_var_cache_t, pulp_var_cache_t)
 
 ######################################
 

--- a/server/selinux/server/relabel.sh
+++ b/server/selinux/server/relabel.sh
@@ -8,6 +8,7 @@
 /sbin/restorecon -i -R /usr/bin/pulp-consumer
 /sbin/restorecon -i -R /var/lib/pulp
 /sbin/restorecon -i -R /var/log/pulp
+/sbin/restorecon -i -R /var/cache/pulp
 
 # Relabel the celery binary
 /sbin/restorecon -i -R /usr/bin/celery

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -805,11 +805,14 @@ class TestGetCurrentTaskId(unittest.TestCase):
 
 class TestCleanupOldWorker(unittest.TestCase):
 
+    @mock.patch('pulp.server.managers.repo._common.create_worker_working_directory')
     @mock.patch('pulp.server.async.tasks._delete_worker')
-    def test_assert_calls__delete_worker_synchronously(self, mock__delete_worker):
+    def test_assert_calls__delete_worker_synchronously(self, mock__delete_worker,
+                                                       mock__create_worker_working_directory):
         sender = mock.Mock()
         tasks.cleanup_old_worker(sender=sender)
         mock__delete_worker.assert_called_once_with(sender.hostname, normal_shutdown=True)
+        mock__create_worker_working_directory.assert_called_once_with(sender.hostname)
 
 
 class TestScheduledTasks(unittest.TestCase):

--- a/server/test/unit/server/managers/repo/group/test_publish.py
+++ b/server/test/unit/server/managers/repo/group/test_publish.py
@@ -1,3 +1,5 @@
+import mock
+
 from ..... import base
 from pulp.common import dateutils
 from pulp.devel import mock_plugins
@@ -9,7 +11,10 @@ from pulp.server.managers import factory as manager_factory
 
 
 class RepoGroupPublishManagerTests(base.PulpServerTests):
-    def setUp(self):
+
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def setUp(self, mock_get_working_directory):
         super(RepoGroupPublishManagerTests, self).setUp()
         mock_plugins.install()
 
@@ -35,7 +40,9 @@ class RepoGroupPublishManagerTests(base.PulpServerTests):
         RepoGroupDistributor.get_collection().remove()
         RepoGroupPublishResult.get_collection().remove()
 
-    def test_publish(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish(self, mock_get_working_directory):
         # Setup
         summary = 'summary'
         details = 'details'
@@ -85,7 +92,9 @@ class RepoGroupPublishManagerTests(base.PulpServerTests):
         # Clean Up
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.publish_group.return_value = None
 
-    def test_publish_with_plugin_exception(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_with_plugin_exception(self, mock_get_working_directory):
         # Setup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.publish_group.side_effect = Exception()
 
@@ -106,7 +115,9 @@ class RepoGroupPublishManagerTests(base.PulpServerTests):
         # Clean Up
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.publish_group.side_effect = None
 
-    def test_publish_with_plugin_failure_report(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_with_plugin_failure_report(self, mock_get_working_directory):
         # Setup
         summary = 'summary'
         details = 'details'
@@ -126,7 +137,9 @@ class RepoGroupPublishManagerTests(base.PulpServerTests):
         # Clean Up
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.publish_group.return_value = None
 
-    def test_publish_with_plugin_no_report(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_with_plugin_no_report(self, mock_get_working_directory):
         # Test
         self.publish_manager.publish(self.group_id, self.distributor_id)
 
@@ -135,7 +148,9 @@ class RepoGroupPublishManagerTests(base.PulpServerTests):
         self.assertEqual(1, len(history_entries))
         self.assertEqual(history_entries[0]['result'], RepoGroupPublishResult.RESULT_SUCCESS)
 
-    def test_last_publish(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_last_publish(self, mock_get_working_directory):
         # Setup
         self.publish_manager.publish(self.group_id, self.distributor_id)
 

--- a/server/test/unit/server/managers/repo/test_common.py
+++ b/server/test/unit/server/managers/repo/test_common.py
@@ -1,8 +1,12 @@
 import datetime
 import unittest
 
+import mock
+
 from pulp.common import dateutils
-from pulp.server.managers.repo._common import to_transfer_repo, _ensure_tz_specified
+from pulp.server.managers.repo._common import to_transfer_repo, _ensure_tz_specified,\
+    get_working_directory, delete_working_directory, create_worker_working_directory,\
+    delete_worker_working_directory
 
 
 class TestToTransferRepo(unittest.TestCase):
@@ -59,3 +63,75 @@ class TestEnsureTzSpecified(unittest.TestCase):
         dt = datetime.datetime.now(dateutils.local_tz())
         new_date = _ensure_tz_specified(dt)
         self.assertEquals(new_date.tzinfo, dateutils.utc_tz())
+
+
+class TestWorkingDirectory(unittest.TestCase):
+
+    @mock.patch('os.mkdir')
+    @mock.patch('pulp.server.config.config.get')
+    def test_create_worker_working_directory(self, mock_pulp_config_get, mock_mkdir):
+        mock_pulp_config_get.return_value = '/var/cache/pulp'
+        create_worker_working_directory('test-worker')
+        mock_pulp_config_get.assert_called_with('server', 'working_directory')
+        mock_mkdir.assert_called_with('/var/cache/pulp/test-worker')
+
+    @mock.patch('shutil.rmtree')
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('pulp.server.config.config.get')
+    def test_delete_worker_working_directory(self, mock_pulp_config_get, mock_path_exists,
+                                             mock_rmtree):
+        mock_pulp_config_get.return_value = '/var/cache/pulp'
+        delete_worker_working_directory('test-worker')
+        mock_pulp_config_get.assert_called_with('server', 'working_directory')
+        mock_path_exists.assert_called_with('/var/cache/pulp/test-worker')
+        mock_rmtree.assert_called_with('/var/cache/pulp/test-worker')
+
+    @mock.patch('celery.task.current')
+    @mock.patch('os.path.exists', return_value=False)
+    @mock.patch('os.mkdir')
+    @mock.patch('pulp.server.config.config.get')
+    def test_get_working_directory_new(self, mock_pulp_config_get, mock_mkdir, mock_path_exists,
+                                       mock_celery_current_task):
+        mock_pulp_config_get.return_value = '/var/cache/pulp'
+        mock_celery_current_task.request = mock.Mock(id='mock-task-id', hostname='mock-host')
+        working_directory_path = get_working_directory()
+        mock_pulp_config_get.assert_called_with('server', 'working_directory')
+        mock_mkdir.assert_called_with('/var/cache/pulp/mock-host/mock-task-id')
+        self.assertEqual(working_directory_path, '/var/cache/pulp/mock-host/mock-task-id')
+
+    @mock.patch('celery.task.current')
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('os.mkdir')
+    @mock.patch('pulp.server.config.config.get')
+    def test_get_working_directory_existing(self, mock_pulp_config_get, mock_mkdir,
+                                            mock_path_exists, mock_celery_current_task):
+        mock_pulp_config_get.return_value = '/var/cache/pulp'
+        mock_celery_current_task.request = mock.Mock(id='mock-task-id', hostname='mock-host')
+        working_directory_path = get_working_directory()
+        mock_pulp_config_get.assert_called_with('server', 'working_directory')
+        self.assertFalse(mock_mkdir.called, 'os.mkdir should not have been called')
+        self.assertEqual(working_directory_path, '/var/cache/pulp/mock-host/mock-task-id')
+
+    @mock.patch('celery.task.current')
+    @mock.patch('os.path.exists', return_value=True)
+    @mock.patch('shutil.rmtree')
+    @mock.patch('pulp.server.config.config.get')
+    def test_delete_working_directory_existing(self, mock_pulp_config_get, mock_rmtree,
+                                               mock_path_exists, mock_celery_current_task):
+        mock_pulp_config_get.return_value = '/var/cache/pulp'
+        mock_celery_current_task.request = mock.Mock(id='mock-task-id', hostname='mock-host')
+        delete_working_directory()
+        mock_pulp_config_get.assert_called_with('server', 'working_directory')
+        mock_rmtree.assert_called_with('/var/cache/pulp/mock-host/mock-task-id')
+
+    @mock.patch('celery.task.current')
+    @mock.patch('os.path.exists', return_value=False)
+    @mock.patch('shutil.rmtree')
+    @mock.patch('pulp.server.config.config.get')
+    def test_delete_working_directory_non_existing(self, mock_pulp_config_get, mock_rmtree,
+                                                   mock_path_exists, mock_celery_current_task):
+        mock_pulp_config_get.return_value = '/var/cache/pulp'
+        mock_celery_current_task.request = mock.Mock(id='mock-task-id', hostname='mock-host')
+        delete_working_directory()
+        mock_pulp_config_get.assert_called_with('server', 'working_directory')
+        self.assertFalse(mock_rmtree.called, "Nothing should be removed.")

--- a/server/test/unit/server/managers/repo/test_cud.py
+++ b/server/test/unit/server/managers/repo/test_cud.py
@@ -342,7 +342,9 @@ class RepoManagerTests(base.ResourceReservationTests):
         except exceptions.MissingResource, e:
             self.assertTrue('fake repo' == e.resources['resource_id'])
 
-    def test_delete_with_plugins(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_delete_with_plugins(self, mock_get_working_directory):
         """
         Tests that deleting a repo that has importers and distributors configured deletes them as
         well.
@@ -375,7 +377,7 @@ class RepoManagerTests(base.ResourceReservationTests):
         self.assertEqual(1, mock_plugins.MOCK_IMPORTER.importer_removed.call_count)
         self.assertEqual(2, mock_plugins.MOCK_DISTRIBUTOR.distributor_removed.call_count)
 
-        repo_working_dir = common_utils.repository_working_dir('doomed', mkdir=False)
+        repo_working_dir = common_utils.get_working_directory()
         self.assertTrue(not os.path.exists(repo_working_dir))
 
     def test_delete_with_plugin_error(self):
@@ -451,10 +453,13 @@ class RepoManagerTests(base.ResourceReservationTests):
         except exceptions.MissingResource, e:
             self.assertTrue('not-there' == e.resources['resource_id'])
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.async.tasks.resources.get_worker_for_reservation')
     @mock.patch('pulp.server.tasks.repository.distributor_update.apply_async_with_reservation',
                 side_effect=repository.distributor_update.apply_async_with_reservation)
-    def test_update_repo_and_plugins(self, distributor_update, mock_get_worker_for_reservation):
+    def test_update_repo_and_plugins(self, distributor_update, mock_get_worker_for_reservation,
+                                     mock_get_working_directory):
         """
         Tests the aggregate call to update a repo and its plugins.
         """

--- a/server/test/unit/server/managers/repo/test_publish.py
+++ b/server/test/unit/server/managers/repo/test_publish.py
@@ -53,9 +53,11 @@ class RepoSyncManagerTests(base.PulpServerTests):
         mock_publish_task.assert_called_with(RESOURCE_REPOSITORY_TYPE, repo_id, tags=tags,
                                              kwargs=kwargs)
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.managers.event.fire.EventFireManager.fire_repo_publish_started')
     @mock.patch('pulp.server.managers.event.fire.EventFireManager.fire_repo_publish_finished')
-    def test_publish(self, mock_finished, mock_started):
+    def test_publish(self, mock_finished, mock_started, mock_get_working_directory):
         """
         Tests publish under normal conditions when everything is configured
         correctly.
@@ -112,7 +114,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         self.assertEqual(1, mock_finished.call_count)
         self.assertEqual('repo-1', mock_finished.call_args[0][0]['repo_id'])
 
-    def test_publish_failure_report(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_failure_report(self, mock_get_working_directory):
         """
         Tests a publish call that indicates a graceful failure.
         """
@@ -148,7 +152,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.reset()
 
-    def test_publish_with_config_override(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_with_config_override(self, mock_get_working_directory):
         """
         Tests a publish when passing in override values.
         """
@@ -236,7 +242,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         except publish_manager.MissingResource, e:
             self.assertTrue('repo' == e.resources['repository'])
 
-    def test_publish_with_error(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_with_error(self, mock_get_working_directory):
         """
         Tests a publish when the plugin raises an error.
         """
@@ -374,7 +382,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         self.assertRaises(MissingResource, self.publish_manager.last_publish, 'repo-1',
                           'random-dist')
 
-    def test_publish_no_plugin_report(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_no_plugin_report(self, mock_get_working_directory):
         """
         Tests publishing against a sloppy plugin that doesn't return a report.
         """

--- a/server/test/unit/server/managers/repo/test_sync.py
+++ b/server/test/unit/server/managers/repo/test_sync.py
@@ -84,11 +84,14 @@ class RepoSyncManagerTests(base.PulpServerTests):
         mock_sync_task.assert_called_with(RESOURCE_REPOSITORY_TYPE, repo_id, tags=tags,
                                           kwargs=kwargs)
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.managers.repo.publish.RepoPublishManager.queue_publish')
     @mock.patch('pulp.server.managers.repo.publish.RepoPublishManager.auto_distributors')
     @mock.patch('pulp.server.managers.event.fire.EventFireManager.fire_repo_sync_started')
     @mock.patch('pulp.server.managers.event.fire.EventFireManager.fire_repo_sync_finished')
-    def test_sync(self, mock_finished, mock_started, mock_auto_distributors, mock_queue_publish):
+    def test_sync(self, mock_finished, mock_started, mock_auto_distributors, mock_queue_publish,
+                  mock_get_working_directory):
         """
         Tests sync under normal conditions where everything is configured
         correctly. No importer config is specified.
@@ -153,7 +156,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         self.assertTrue(isinstance(report, TaskResult))
         self.assertEqual(report.spawned_tasks, [{'task_id': 'abc123'}])
 
-    def test_sync_with_graceful_fail(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_sync_with_graceful_fail(self, mock_get_working_directory):
         # Setup
         sync_config = {'bruce': 'hulk', 'tony': 'ironman'}
         self.repo_manager.create_repo('repo-1')
@@ -178,7 +183,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.reset()
 
-    def test_sync_with_sync_config_override(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_sync_with_sync_config_override(self, mock_get_working_directory):
         """
         Tests a sync when passing in an individual config of override options.
         """
@@ -271,7 +278,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         self.assertRaises(repo_sync_manager.PulpExecutionException, self.sync_manager.sync,
                           'good-repo')
 
-    def test_sync_with_error(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_sync_with_error(self, mock_get_working_directory):
         """
         Tests a sync when the plugin raises an error.
         """
@@ -338,7 +347,9 @@ class RepoSyncManagerTests(base.PulpServerTests):
         self.assertEqual('repo', MockRepoPublishManager.repo_id)
         self.assertEqual({}, MockRepoPublishManager.base_progress_report)
 
-    def test_sync_no_plugin_report(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_sync_no_plugin_report(self, mock_get_working_directory):
         """
         Tests synchronizing against a sloppy plugin that doesn't return a sync report.
         """

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -142,7 +142,9 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         for unit in repo_units:
             self.assertTrue(unit['unit_id'] in ids)
 
-    def test_unassociate_by_id(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_unassociate_by_id(self, mock_get_working_directory):
         """
         Tests removing an association that exists by its unit ID.
         """
@@ -171,7 +173,9 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.manager.unassociate_unit_by_id(self.repo_id, 'type-1', 'unit-1', OWNER_TYPE_USER,
                                             'admin')
 
-    def test_associate_from_repo_no_criteria(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_associate_from_repo_no_criteria(self, mock_get_working_directory):
         # Setup
         source_repo_id = 'source-repo'
         dest_repo_id = 'dest-repo'
@@ -226,7 +230,9 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         # Clean Up
         manager_factory.principal_manager().set_principal(principal=None)
 
-    def test_associate_from_repo_with_criteria(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_associate_from_repo_with_criteria(self, mock_get_working_directory):
         # Setup
         source_repo_id = 'source-repo'
         dest_repo_id = 'dest-repo'
@@ -316,7 +322,9 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.assertRaises(exceptions.MissingResource,
                           self.manager.associate_from_repo, source_repo_id, dest_repo_id)
 
-    def test_associate_from_repo_importer_error(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_associate_from_repo_importer_error(self, mock_get_working_directory):
         # Setup
         source_repo_id = 'source-repo'
         dest_repo_id = 'dest-repo'
@@ -457,7 +465,9 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
 
         mock_call.assert_called_once_with(self.repo_id, 'type-1', 2)
 
-    def test_unassociate_all(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_unassociate_all(self, mock_get_working_directory):
         """
         Tests unassociating multiple units in a single call.
         """
@@ -496,8 +506,10 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.assertTrue(unit_coll.find_one({'repo_id': self.repo_id, 'unit_type_id': 'type-2',
                                             'unit_id': 'unit-2'}) is not None)
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.managers.repo.cud.RepoManager.update_unit_count')
-    def test_unassociate_by_id_calls_update_unit_count(self, mock_call):
+    def test_unassociate_by_id_calls_update_unit_count(self, mock_call, mock_get_working_directory):
         self.manager.associate_unit_by_id(
             self.repo_id, self.unit_type_id, self.unit_id, OWNER_TYPE_USER, 'admin')
         self.manager.unassociate_unit_by_id(
@@ -535,8 +547,10 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.assertFalse(self.manager.association_exists(self.repo_id, 'type-1', 'unit-1'))
         self.assertEqual(mock_count.call_count, 1)
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.managers.repo.cud.RepoManager.update_last_unit_removed')
-    def test_unassociate_via_criteria(self, mock_call):
+    def test_unassociate_via_criteria(self, mock_call, mock_get_working_directory):
         self.manager.associate_unit_by_id(self.repo_id, self.unit_type_id, self.unit_id,
                                           OWNER_TYPE_USER, 'admin')
         self.manager.associate_unit_by_id(self.repo_id, self.unit_type_id, self.unit_id_2,

--- a/server/test/unit/server/webservices/controllers/test_consumers.py
+++ b/server/test/unit/server/webservices/controllers/test_consumers.py
@@ -39,7 +39,7 @@ class ConsumerTest(base.PulpWebserviceTests):
     DISTRIBUTOR_TYPE_ID = 'mock-distributor'
 
     def setUp(self):
-        base.PulpWebserviceTests.setUp(self)
+        super(ConsumerTest, self).setUp()
         Consumer.get_collection().remove(safe=True)
         Repo.get_collection().remove(safe=True)
         RepoDistributor.get_collection().remove(safe=True)
@@ -48,7 +48,7 @@ class ConsumerTest(base.PulpWebserviceTests):
         mock_plugins.install()
 
     def tearDown(self):
-        base.PulpWebserviceTests.tearDown(self)
+        super(ConsumerTest, self).tearDown()
         Consumer.get_collection().remove(safe=True)
         Repo.get_collection().remove(safe=True)
         RepoDistributor.get_collection().remove(safe=True)
@@ -142,7 +142,9 @@ class ConsumerTest(base.PulpWebserviceTests):
         self.assertEquals(bindings[0]['distributor_id'], self.DISTRIBUTOR_ID)
         self.assertEquals(bindings[0]['consumer_actions'], [])
 
-    def test_get_bindings_consumer_repo(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get_bindings_consumer_repo(self, mock_get_working_directory):
         """
         Test that it is possible to retrieve all bindings for a specific consumer on
         to a specific repository
@@ -716,7 +718,9 @@ class BindTest(base.PulpWebserviceTests):
         manager = factory.consumer_manager()
         manager.register(self.CONSUMER_ID)
 
-    def test_get_bind(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get_bind(self, mock_get_working_directory):
         # Setup
         self.populate()
         # Test
@@ -739,7 +743,9 @@ class BindTest(base.PulpWebserviceTests):
         self.assertEqual(body['_href'].count(self.REPO_ID), 1)
         self.assertEqual(body['_href'].count(self.DISTRIBUTOR_ID), 1)
 
-    def test_get_bind_by_consumer(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get_bind_by_consumer(self, mock_get_working_directory):
         # Setup
         self.populate()
         # Test
@@ -762,7 +768,9 @@ class BindTest(base.PulpWebserviceTests):
         self.assertEquals(bind['details'], self.PAYLOAD)
         self.assertEquals(bind['type_id'], self.DISTRIBUTOR_TYPE_ID)
 
-    def test_get_bind_by_consumer_and_repo(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get_bind_by_consumer_and_repo(self, mock_get_working_directory):
         # Setup
         self.populate()
         # Test

--- a/server/test/unit/test_dependency_manager.py
+++ b/server/test/unit/test_dependency_manager.py
@@ -11,6 +11,8 @@
 # have received a copy of GPLv2 along with this software; if not, see
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
+import mock
+
 import base
 from pulp.devel import mock_plugins
 
@@ -60,7 +62,9 @@ class DependencyManagerTests(base.PulpServerTests):
 
         mock_plugins.MOCK_IMPORTER.resolve_dependencies.return_value = None
 
-    def test_resolve_dependencies_by_unit(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_resolve_dependencies_by_unit(self, mock_get_working_directory):
         # Setup
         report = 'dep report'
         mock_plugins.MOCK_IMPORTER.resolve_dependencies.return_value = report
@@ -97,7 +101,9 @@ class DependencyManagerTests(base.PulpServerTests):
         # Test
         self.assertRaises(MissingResource, self.manager.resolve_dependencies_by_units, 'empty', [], {})
 
-    def test_resolve_dependencies_by_criteria(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_resolve_dependencies_by_criteria(self, mock_get_working_directory):
         # Setup
         report = 'dep report'
         mock_plugins.MOCK_IMPORTER.resolve_dependencies.return_value = report

--- a/server/test/unit/test_distributor_scratchpad_mixin.py
+++ b/server/test/unit/test_distributor_scratchpad_mixin.py
@@ -35,7 +35,9 @@ class DistributorScratchpadMixinTests(base.PulpServerTests):
 
         Repo.get_collection().remove()
 
-    def setUp(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def setUp(self, mock_get_working_directory):
         super(DistributorScratchpadMixinTests, self).setUp()
         mock_plugins.install()
 

--- a/server/test/unit/test_repo_distributor_manager.py
+++ b/server/test/unit/test_repo_distributor_manager.py
@@ -119,7 +119,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         self.assertTrue('dist_1' in dist_ids)
         self.assertTrue('dist_2' in dist_ids)
 
-    def test_add_distributor_replace_existing(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_add_distributor_replace_existing(self, mock_get_working_directory):
         """
         Tests adding a distributor under the same ID as an existing distributor.
         """
@@ -283,8 +285,10 @@ class RepoDistributorManagerTests(base.PulpServerTests):
 
     # -- remove ---------------------------------------------------------------
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.managers.schedule.repo.RepoPublishScheduleManager.delete_by_distributor_id')
-    def test_remove_distributor(self, mock_delete_schedules):
+    def test_remove_distributor(self, mock_delete_schedules, mock_get_working_directory):
         """
         Tests removing an existing distributor from a repository.
         """
@@ -330,7 +334,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
 
     # -- update ---------------------------------------------------------------
 
-    def test_update_distributor_config(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_distributor_config(self, mock_get_working_directory):
         """
         Tests the successful case of updating a distributor's config.
         """
@@ -360,7 +366,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         call_config = mock_plugins.MOCK_DISTRIBUTOR.validate_config.call_args[0][1]
         self.assertEqual(expected_config, call_config.repo_plugin_config)
 
-    def test_update_auto_publish(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_auto_publish(self, mock_get_working_directory):
         # Setup
         self.repo_manager.create_repo('test-repo')
         config = {'key': 'value'}
@@ -372,7 +380,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         repo_dist = RepoDistributor.get_collection().find_one({'repo_id': 'test-repo'})
         self.assertFalse(repo_dist['auto_publish'])
 
-    def test_update_invalid_auto_publish(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_invalid_auto_publish(self, mock_get_working_directory):
         # Setup
         self.repo_manager.create_repo('test-repo')
         config = {'key': 'value'}
@@ -410,7 +420,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         except exceptions.MissingResource, e:
             self.assertTrue('missing' == e.resources['distributor'])
 
-    def test_update_validate_exception(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_validate_exception(self, mock_get_working_directory):
         """
         Tests updating a config when the plugin raises an exception during validate.
         """
@@ -432,7 +444,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_DISTRIBUTOR.validate_config.side_effect = None
 
-    def test_update_invalid_config(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_invalid_config(self, mock_get_working_directory):
         """
         Tests updating a config when the plugin indicates the config is invalid.
         """
@@ -454,7 +468,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_DISTRIBUTOR.validate_config.return_value = True
 
-    def test_update_invalid_config_backward_compatibility(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_invalid_config_backward_compatibility(self, mock_get_working_directory):
         """
         Tests updating a config when the plugin indicates the config is invalid.
         """
@@ -478,7 +494,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
 
     # -- payload --------------------------------------------------------------
 
-    def test_create_bind_payload(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_create_bind_payload(self, mock_get_working_directory):
         # Setup
         repo_id = 'repo-a'
         distributor_id = 'dist-1'
@@ -510,7 +528,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         self.assertRaises(exceptions.MissingResource, self.distributor_manager.create_bind_payload,
                           'missing', 'also missing', 'irrelevant')
 
-    def test_create_bind_payload_distributor_error(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_create_bind_payload_distributor_error(self, mock_get_working_directory):
         # Setup
         self.repo_manager.create_repo('repo-a')
         self.distributor_manager.add_distributor('repo-a', 'mock-distributor', {}, True,
@@ -658,7 +678,9 @@ class RepoDistributorManagerTests(base.PulpServerTests):
 
     # -- publish schedules -----------------------------------------------------
 
-    def test_publish_schedule(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_publish_schedule(self, mock_get_working_directory):
 
         # setup
         repo_id = 'scheduled_repo'

--- a/server/test/unit/test_repo_group_controller.py
+++ b/server/test/unit/test_repo_group_controller.py
@@ -290,7 +290,9 @@ class RepoGroupResourceTests(base.PulpWebserviceTests):
         # Verify
         self.assertEqual(404, status)
 
-    def test_delete(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_delete(self, mock_get_working_directory):
         # Setup
         group_id = 'doomed'
         self.manager.create_repo_group(group_id)
@@ -365,7 +367,9 @@ class RepoGroupDistributorsTests(base.PulpWebserviceTests):
         RepoGroup.get_collection().remove()
         RepoGroupDistributor.get_collection().remove()
 
-    def test_get(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get(self, mock_get_working_directory):
         # Setup
         group_id = 'dist-group'
         self.manager.create_repo_group(group_id)
@@ -395,7 +399,9 @@ class RepoGroupDistributorsTests(base.PulpWebserviceTests):
         self.assertTrue(isinstance(body, list))
         self.assertEqual(0, len(body))
 
-    def test_post(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_post(self, mock_get_working_directory):
         # Setup
         group_id = 'group-1'
         self.manager.create_repo_group(group_id)
@@ -437,7 +443,9 @@ class RepoGroupDistributorTests(base.PulpWebserviceTests):
         RepoGroup.get_collection().remove()
         RepoGroupDistributor.get_collection().remove()
 
-    def test_get(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get(self, mock_get_working_directory):
         # Setup
         group_id = 'dist-group'
         self.manager.create_repo_group(group_id)
@@ -469,10 +477,13 @@ class RepoGroupDistributorTests(base.PulpWebserviceTests):
         # Verify
         self.assertEqual(404, status)
 
-    def test_delete(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_delete(self, mock_get_working_directory):
         # Setup
         group_id = 'group'
         distributor_id = 'created'
+
         self.manager.create_repo_group(group_id)
         self.distributor_manager.add_distributor(group_id, 'mock-group-distributor', {}, distributor_id=distributor_id)
 
@@ -504,7 +515,9 @@ class RepoGroupDistributorTests(base.PulpWebserviceTests):
         # Verify
         self.assertEqual(404, status)
 
-    def test_put(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_put(self, mock_get_working_directory):
         # Setup
         group_id = 'group-1'
         distributor_id = 'dist-1'
@@ -522,7 +535,9 @@ class RepoGroupDistributorTests(base.PulpWebserviceTests):
         found = RepoGroupDistributor.get_collection().find_one({'id' : distributor_id})
         self.assertEqual(found['config'], {'a' : 'A', 'b' : 'B'})
 
-    def test_put_extra_data(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_put_extra_data(self, mock_get_working_directory):
         # Setup
         group_id = 'group-1'
         distributor_id = 'dist-1'
@@ -569,9 +584,11 @@ class PublishActionTests(base.PulpWebserviceTests):
         RepoGroup.get_collection().remove()
         RepoGroupDistributor.get_collection().remove()
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.async.tasks.resources.get_worker_for_reservation')
     @mock.patch('pulp.server.webservices.controllers.repo_groups.publish')
-    def test_post(self, mock_publish, mock_get_worker_for_reservation):
+    def test_post(self, mock_publish, mock_get_worker_for_reservation, mock_get_working_directory):
         """
         Test that publish repo group creates a task for a worker.
         """

--- a/server/test/unit/test_repo_group_distributor_manager.py
+++ b/server/test/unit/test_repo_group_distributor_manager.py
@@ -12,6 +12,7 @@
 # http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 
 import base
+import mock
 
 from pulp.devel import mock_plugins
 from pulp.plugins.config import PluginCallConfiguration
@@ -45,7 +46,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
 
     # -- add ------------------------------------------------------------------
 
-    def test_add_distributor(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_add_distributor(self, mock_get_working_directory):
         # Setup
         config = {'a' : 'a', 'b' : None}
 
@@ -85,7 +88,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
         self.assertTrue(isinstance(call_group, RepositoryGroup))
         self.assertTrue(isinstance(call_config, PluginCallConfiguration))
 
-    def test_add_distributor_multiple_distributors(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_add_distributor_multiple_distributors(self, mock_get_working_directory):
         # Setup
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {})
 
@@ -96,7 +101,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
         all_distributors = list(RepoGroupDistributor.get_collection().find())
         self.assertEqual(2, len(all_distributors))
 
-    def test_add_distributor_replace_existing(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_add_distributor_replace_existing(self, mock_get_working_directory):
         # Setup
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d1')
 
@@ -136,7 +143,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
         except InvalidValue, e:
             self.assertTrue('distributor_type_id' in e.property_names)
 
-    def test_add_distributor_initialize_raises_error(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_add_distributor_initialize_raises_error(self, mock_get_working_directory):
         # Setup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.distributor_added.side_effect = Exception()
 
@@ -150,7 +159,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.distributor_added.side_effect = None
 
-    def test_add_distributor_validate_raises_error(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_add_distributor_validate_raises_error(self, mock_get_working_directory):
         # Setup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.validate_config.side_effect = Exception()
 
@@ -164,7 +175,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.validate_config.side_effect = None
 
-    def test_add_distributor_invalid_config(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_add_distributor_invalid_config(self, mock_get_working_directory):
         # Setup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.validate_config.return_value = False, 'foo'
 
@@ -177,7 +190,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
 
     # -- remove ---------------------------------------------------------------
 
-    def test_remove_distributor(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_remove_distributor(self, mock_get_working_directory):
         # Setup
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d1')
 
@@ -204,7 +219,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
             self.assertEqual(e.resources['repo_group'], 'bar')
             self.assertTrue('distributor' not in e.resources)
 
-    def test_remove_distributor_plugin_exception(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_remove_distributor_plugin_exception(self, mock_get_working_directory):
         # Setup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.distributor_removed.side_effect = Exception()
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d1')
@@ -221,7 +238,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
 
     # -- update ---------------------------------------------------------------
 
-    def test_update_distributor_config(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_distributor_config(self, mock_get_working_directory):
         # Setup
         orig = {'a' : 'a', 'b' : 'b', 'c' : 'c'}
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', orig, distributor_id='d1')
@@ -258,7 +277,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
             self.assertEqual(e.resources['repo_group'], self.group_id)
             self.assertEqual(e.resources['distributor'], 'foo')
 
-    def test_update_validate_exception(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_validate_exception(self, mock_get_working_directory):
         # Setup
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d1')
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.validate_config.side_effect = Exception('foo')
@@ -273,7 +294,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.validate_config.side_effect = None
 
-    def test_update_invalid_config(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_invalid_config(self, mock_get_working_directory):
         # Setup
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d1')
         mock_plugins.MOCK_GROUP_DISTRIBUTOR.validate_config.return_value = False, 'foo'
@@ -287,7 +310,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
 
     # -- scratchpad -----------------------------------------------------------
 
-    def test_get_set_scratchpad(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get_set_scratchpad(self, mock_get_working_directory):
         # Setup
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d1')
 
@@ -305,7 +330,9 @@ class RepoGroupDistributorManagerTests(base.PulpServerTests):
 
     # -- find -----------------------------------------------------------------
 
-    def test_find_distributors(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_find_distributors(self, mock_get_working_directory):
         # Setup
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d1')
         self.distributor_manager.add_distributor(self.group_id, 'mock-group-distributor', {}, distributor_id='d2')

--- a/server/test/unit/test_repo_group_manager.py
+++ b/server/test/unit/test_repo_group_manager.py
@@ -270,20 +270,15 @@ class RepoGroupCUDTests(RepoGroupTests):
         group = self.collection.find_one({'id': group_id})
         self.assertFalse(group['notes'])
 
-    def test_delete(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_delete(self, mock_get_working_directory):
         # Setup
         group_id = 'delete_me'
         self.manager.create_repo_group(group_id)
 
         group = self.collection.find_one({'id': group_id})
         self.assertFalse(group is None)
-
-        # Simulate the working dir being created by a plugin
-        working_dir = common_utils.repo_group_working_dir(group_id)
-        if os.path.exists(working_dir):
-            shutil.rmtree(working_dir)
-        os.makedirs(working_dir)
-        self.assertTrue(os.path.exists(working_dir))
 
         # Test
         self.manager.delete_repo_group(group_id)
@@ -292,10 +287,10 @@ class RepoGroupCUDTests(RepoGroupTests):
         group = self.collection.find_one({'id': group_id})
         self.assertTrue(group is None)
 
-        # Ensure the working dir was deleted
-        self.assertTrue(not os.path.exists(working_dir))
 
-    def test_delete_with_distributor(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_delete_with_distributor(self, mock_get_working_directory):
         # Setup
         group_id = 'doomed'
         self.manager.create_repo_group(group_id)

--- a/server/test/unit/test_repo_importer_manager.py
+++ b/server/test/unit/test_repo_importer_manager.py
@@ -123,7 +123,9 @@ class RepoManagerTests(base.PulpServerTests):
         self.assertRaises(exceptions.PulpCodedValidationException,
                           self.importer_manager.set_importer, 'real-repo', 'fake-importer', None)
 
-    def test_set_importer_with_existing(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_set_importer_with_existing(self, mock_get_working_directory):
         """
         Tests setting a different importer on a repo that already had one.
         """
@@ -261,8 +263,10 @@ class RepoManagerTests(base.PulpServerTests):
 
     # -- remove ---------------------------------------------------------------
 
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
     @mock.patch('pulp.server.managers.schedule.repo.RepoSyncScheduleManager.delete_by_importer_id')
-    def test_remove_importer(self, mock_delete_schedules):
+    def test_remove_importer(self, mock_delete_schedules, mock_get_working_directory):
         """
         Tests the successful case of removing an importer.
         """
@@ -310,7 +314,9 @@ class RepoManagerTests(base.PulpServerTests):
 
     # -- update ---------------------------------------------------------------
 
-    def test_update_importer_config(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_importer_config(self, mock_working_directory):
         """
         Tests the successful case of updating an importer's configuration.
         """
@@ -370,7 +376,9 @@ class RepoManagerTests(base.PulpServerTests):
         except exceptions.MissingResource:
             pass
 
-    def test_update_importer_plugin_exception(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_importer_plugin_exception(self, mock_get_working_directory):
         """
         Tests the appropriate exception is raised when the plugin throws an error during validation.
         """
@@ -391,7 +399,9 @@ class RepoManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_IMPORTER.validate_config.side_effect = None
 
-    def test_update_importer_invalid_config(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_importer_invalid_config(self, mock_get_working_directory):
         """
         Tests the appropriate exception is raised when the plugin indicates the config is invalid.
         """
@@ -412,7 +422,9 @@ class RepoManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_IMPORTER.validate_config.return_value = True
 
-    def test_update_importer_invalid_config_backward_compatibility(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_update_importer_invalid_config_backward_compatibility(self, mock_get_working_dir):
         """
         Tests the appropriate exception is raised when the plugin indicates the config is invalid.
         """

--- a/server/test/unit/test_repo_publish_conduit.py
+++ b/server/test/unit/test_repo_publish_conduit.py
@@ -92,7 +92,9 @@ class RepoGroupPublishConduitTests(base.PulpServerTests):
         RepoGroup.get_collection().remove()
         RepoGroupDistributor.get_collection().remove()
 
-    def setUp(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def setUp(self, mock_get_working_directory):
         super(RepoGroupPublishConduitTests, self).setUp()
         mock_plugins.install()
         manager_factory.initialize()

--- a/server/test/unit/test_repo_sync_conduit.py
+++ b/server/test/unit/test_repo_sync_conduit.py
@@ -45,7 +45,9 @@ class RepoSyncConduitTests(base.PulpServerTests):
         RepoContentUnit.get_collection().remove()
         Repo.get_collection().remove()
 
-    def setUp(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def setUp(self, mock_get_working_directory):
         super(RepoSyncConduitTests, self).setUp()
         mock_plugins.install()
         types_database.update_database([TYPE_1_DEF, TYPE_2_DEF])
@@ -74,7 +76,9 @@ class RepoSyncConduitTests(base.PulpServerTests):
         """
         str(self.conduit)
 
-    def test_get_remove_unit(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_get_remove_unit(self, mock_working_directory):
         """
         Tests retrieving units through the conduit and removing them.
         """
@@ -104,7 +108,9 @@ class RepoSyncConduitTests(base.PulpServerTests):
         db_unit = self.query_manager.get_content_unit_by_id(TYPE_1_DEF.id, unit_1.id)
         self.assertTrue(db_unit is not None)
 
-    def test_build_reports(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_build_reports(self, mock_get_working_directory):
         """
         Tests that the conduit correctly inserts the count values into the report.
         """

--- a/server/test/unit/test_server_managers_content_upload.py
+++ b/server/test/unit/test_server_managers_content_upload.py
@@ -13,6 +13,7 @@ import os
 import shutil
 
 import base
+import mock
 
 from pulp.devel import mock_plugins
 from pulp.plugins.conduits.upload import UploadConduit
@@ -158,15 +159,18 @@ class ContentUploadManagerTests(base.PulpServerTests):
         self.assertRaises(MissingResource, self.upload_manager.is_valid_upload, 'empty', 'mock-type')
         self.assertRaises(MissingResource, self.upload_manager.is_valid_upload, 'fake', 'mock-type')
 
-    def test_is_valid_upload_unsupported_type(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_is_valid_upload_unsupported_type(self, mock_get_working_directory):
         # Setup
         self.repo_manager.create_repo('repo-u')
         self.importer_manager.set_importer('repo-u', 'mock-importer', {})
-
         # Test
         self.assertRaises(PulpDataException, self.upload_manager.is_valid_upload, 'repo-u', 'fake-type')
 
-    def test_import_uploaded_unit(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_import_uploaded_unit(self, mock_get_working_directory):
         self.repo_manager.create_repo('repo-u')
         self.importer_manager.set_importer('repo-u', 'mock-importer', {})
 
@@ -209,7 +213,9 @@ class ContentUploadManagerTests(base.PulpServerTests):
         # Test
         self.assertRaises(MissingResource, self.upload_manager.import_uploaded_unit, 'fake', 'mock-type', {}, {}, 'irrelevant')
 
-    def test_import_uploaded_unit_importer_error(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_import_uploaded_unit_importer_error(self, mock_get_working_directory):
         # Setup
         self.repo_manager.create_repo('repo-u')
         self.importer_manager.set_importer('repo-u', 'mock-importer', {})
@@ -221,7 +227,10 @@ class ContentUploadManagerTests(base.PulpServerTests):
         # Test
         self.assertRaises(PulpExecutionException, self.upload_manager.import_uploaded_unit, 'repo-u', 'mock-type', {}, {}, upload_id)
 
-    def test_import_uploaded_unit_importer_error_reraise_pulp_exception(self):
+    @mock.patch('pulp.server.managers.repo._common.get_working_directory',
+                return_value="/var/cache/pulp/mock_worker/mock_task_id")
+    def test_import_uploaded_unit_importer_error_reraise_pulp_exception(self,
+                                                                        mock_get_working_dir):
         # Setup
         self.repo_manager.create_repo('repo-u')
         self.importer_manager.set_importer('repo-u', 'mock-importer', {})


### PR DESCRIPTION
This PR introduces a 'working_directory' config in /etc/pulp/server.conf in the [server] section. This is the path where each pulp worker can expect to have a directory with it's name.  Inside that worker's directory, each task will be able to create working directory for that task.   

Take note of the changes in server/pulp/server/managers/repo/cud.py.  I decided to remove this code because we no longer expect to have to clean up repository working directories outside of tasks.  Let me know if I am misunderstanding something.  

Still a work in progress because the spec file needs to be modified to create /var/cache/pulp and then tested with SELinux.