### PR TITLE
Run flake8 in run-tests.py.

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -11,6 +11,16 @@ from pulp.devel.test_runner import run_tests
 PROJECT_DIR = os.path.dirname(__file__)
 subprocess.call(['find', PROJECT_DIR, '-name', '*.pyc', '-delete'])
 
+# Check for style
+config_file = os.path.join(PROJECT_DIR, 'flake8.cfg')
+# These paths should all pass PEP-8 checks
+paths_to_check = [
+    'server/pulp/server/tasks/',
+    'server/test/unit/server/']
+paths_to_check = [os.path.join(PROJECT_DIR, p) for p in paths_to_check]
+command = ['flake8', '--config', config_file]
+command.extend(paths_to_check)
+flake8_exit_code = subprocess.call(command)
 
 PACKAGES = [
     os.path.dirname(__file__),
@@ -37,4 +47,6 @@ TESTS_NON_RHEL5 = [
 dir_safe_all_platforms = [os.path.join(os.path.dirname(__file__), x) for x in TESTS_ALL_PLATFORMS]
 dir_safe_non_rhel5 = [os.path.join(os.path.dirname(__file__), x) for x in TESTS_NON_RHEL5]
 
-sys.exit(run_tests(PACKAGES, dir_safe_all_platforms, dir_safe_non_rhel5))
+tests_exit_code = run_tests(PACKAGES, dir_safe_all_platforms, dir_safe_non_rhel5)
+
+sys.exit(flake8_exit_code or tests_exit_code)


### PR DESCRIPTION
This commit adds support for flake8 to run-tests.py. It currently only
checks the files that I've already made sure were PEP-8 to catch PEP-8
regressions.