### PR TITLE
1174283 - bump python-requests to 2.4.3

### DIFF
--- a/deps/python-nectar/python-nectar.spec
+++ b/deps/python-nectar/python-nectar.spec
@@ -16,7 +16,7 @@ BuildArch:      noarch
 BuildRequires:  python-setuptools
 
 Requires:       python-isodate >= 0.4.9
-Requires:       python-requests >= 2.2.1
+Requires:       python-requests >= 2.4.3
 
 %description
 Nectar is a download library that abstracts the workflow of making and tracking


### PR DESCRIPTION
[BZ-1174283](https://bugzilla.redhat.com/show_bug.cgi?id=1174283)

This change already [exists in nectar](https://github.com/pulp/nectar/blob/master/python-nectar.spec#L19), but it needs to be copied over to the pulp deps for building.