### PR TITLE
do not throw exception information away

### DIFF
--- a/client_lib/pulp/client/extensions/exceptions.py
+++ b/client_lib/pulp/client/extensions/exceptions.py
@@ -123,8 +123,10 @@ class ExceptionHandler:
         # The following keys may be present to further classify the exception:
         # property_names - values for these properties were invalid
         # missing_property_names - required properties that were not specified
-
-        if 'property_names' in e.extra_data:
+        if 'error' in e.extra_data:
+            self._display_coded_error(e.extra_data.get('error'))
+            return CODE_BAD_REQUEST
+        elif 'property_names' in e.extra_data:
             msg = _('The values for the following properties were invalid: %(p)s')
             msg = msg % {'p' : ', '.join(e.extra_data['property_names'])}
         elif 'missing_property_names' in e.extra_data:
@@ -141,6 +143,19 @@ class ExceptionHandler:
 
         self.prompt.render_failure_message(msg)
         return CODE_BAD_REQUEST
+
+    def _display_coded_error(self, e):
+        """
+        Recursively render a coded error and the errors contained by it.
+
+        :param e: error to display
+        :type  e: dictionary containing error information.
+        """
+        malformed_msg = _('Request error does not contain a description, '
+                          'please check client logs for more information.')
+        self.prompt.render_failure_message('%s' % (e.get('description', malformed_msg)))
+        for suberror in e.get('sub_errors', []):
+            self._display_coded_error(suberror)
 
     def handle_not_found(self, e):
         """

--- a/server/pulp/server/managers/repo/distributor.py
+++ b/server/pulp/server/managers/repo/distributor.py
@@ -167,18 +167,14 @@ class RepoDistributorManager(object):
         transfer_repo.working_dir = common_utils.distributor_working_dir(distributor_type_id, repo_id)
         config_conduit = RepoConfigConduit(distributor_type_id)
 
-        try:
-            result = distributor_instance.validate_config(transfer_repo, call_config, config_conduit)
+        result = distributor_instance.validate_config(transfer_repo, call_config, config_conduit)
 
-            # For backward compatibility with plugins that don't yet return the tuple
-            if isinstance(result, bool):
-                valid_config = result
-                message = None
-            else:
-                valid_config, message = result
-        except Exception, e:
-            logger.exception('Exception received from distributor [%s] while validating config' % distributor_type_id)
-            raise PulpDataException(e.args), None, sys.exc_info()[2]
+        # For backward compatibility with plugins that don't yet return the tuple
+        if isinstance(result, bool):
+            valid_config = result
+            message = None
+        else:
+            valid_config, message = result
 
         if not valid_config:
             raise PulpDataException(message)

--- a/server/test/unit/test_repo_distributor_manager.py
+++ b/server/test/unit/test_repo_distributor_manager.py
@@ -237,7 +237,7 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         try:
             self.distributor_manager.add_distributor('rohan', 'mock-distributor', {}, True)
             self.fail('Exception expected')
-        except exceptions.PulpDataException:
+        except Exception, e:
             pass
 
         # Cleanup


### PR DESCRIPTION
Pulp caught exceptions (Exception) and then reraised as a PulpDataException. Additionally, errors are sometimes thown that contain other errors inside e.extra_data. This information was thrown away and could not be used.

Solution renders all error data recursively and allows the exception to bubble up rather than reraising as a different exception.

Reopened from https://github.com/pulp/pulp/pull/1392

This is necessary for the right information to get back to the user after we merge https://github.com/pulp/pulp_docker/pull/52