### PR TITLE
1172745 - celerybeat service incorrectly reports broker on startup.

### DIFF
--- a/server/etc/default/upstart_pulp_celerybeat
+++ b/server/etc/default/upstart_pulp_celerybeat
@@ -18,3 +18,4 @@ PYTHONIOENCODING="UTF-8"
 # Please do not edit any of the settings below this mark in this file!
 ######################################################################
 CELERYBEAT_SCHEDULER="pulp.server.async.scheduler.Scheduler"
+CELERYBEAT_APP="pulp.server.async.celery_instance.celery"

--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -259,7 +259,7 @@ _chuid () {
 
 start_beat () {
     echo "Starting ${SCRIPT_NAME}..."
-    _chuid --scheduler=$CELERYBEAT_SCHEDULER $CELERYBEAT_OPTS $DAEMON_OPTS --detach \
+    _chuid --app=CELERYBEAT_APP --scheduler=$CELERYBEAT_SCHEDULER $CELERYBEAT_OPTS $DAEMON_OPTS --detach \
                 --pidfile="$CELERYBEAT_PID_FILE"
 }
 

--- a/server/usr/lib/systemd/system/pulp_celerybeat.service
+++ b/server/usr/lib/systemd/system/pulp_celerybeat.service
@@ -6,7 +6,7 @@ After=network.target
 EnvironmentFile=/etc/default/pulp_celerybeat
 User=apache
 WorkingDirectory=/var/lib/pulp/celery/
-ExecStart=/usr/bin/celery beat --scheduler=pulp.server.async.scheduler.Scheduler
+ExecStart=/usr/bin/celery beat --app=pulp.server.async.celery_instance.celery --scheduler=pulp.server.async.scheduler.Scheduler
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1172745
Issue consisted in the fact that celerybeat was using the unconfigured
celery app. That's why the broker string was incorrect. By adding --app
option it will use the configured app and the startup info will be correct.