### PR TITLE
add read the docs theme to sphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,13 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
+
+try:
+    import sphinx_rtd_theme
+except ImportError:
+    sphinx_rtd_theme = False
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -92,7 +98,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme' if sphinx_rtd_theme else 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -100,7 +106,7 @@ html_theme = 'default'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()] if sphinx_rtd_theme else []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
Backported from https://github.com/pulp/pulp/pull/1362.

This change uses the sphinx_rtd_theme if it is installed, otherwise it uses the default. This makes it simpler to make docs changes in 2.6.

The theme is available with pip:

    pip install sphinx_rtd_theme