### PR TITLE
add ropeproject to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ tags
 
 # Sublime
 .codeintel
+
+#Rope
+.ropeproject


### PR DESCRIPTION
Rope is a tool used by vim/emacs for refactoring and ensuring imports. I use this, and would like it in the gitignore.