### PR TITLE
165403 - deprecated cacert and cakey settings from server.conf

### DIFF
--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -95,6 +95,10 @@
 # cacert: full path to the CA certificate that will be used to sign consumer
 #     and admin identification certificates; this must match the value of
 #     SSLCACertificateFile in /etc/httpd/conf.d/pulp.conf
+#     Deprecated! - Please note that both cacert and cakey settings will be
+#     removed in the next major release since Pulp will not sign certificates.
+#     However, Pulp will continue to support client certificates generated
+#     by users through Apache and pulp-admin.
 #
 # cakey: path to the private key for the above CA certificate
 #
@@ -111,8 +115,8 @@
 #
 
 [security]
-# cacert: /etc/pki/pulp/ca.crt
-# cakey: /etc/pki/pulp/ca.key
+# cacert: /etc/pki/pulp/ca.crt  # Deprecated! See above description for details.
+# cakey: /etc/pki/pulp/ca.key  # Deprecated! See above description for details.
 # ssl_ca_certificate: /etc/pki/pulp/ssl_ca.crt  # Deprecated! See above description for details.
 # user_cert_expiration: 7
 # consumer_cert_expiration: 3650


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1165403