### PR TITLE
Remove fc21 from gofer builds

### DIFF
--- a/deps/gofer/dist_list.txt
+++ b/deps/gofer/dist_list.txt
@@ -1,1 +1,1 @@
-el5 el6 el7 fc20 fc21
+el5 el6 el7 fc20


### PR DESCRIPTION
This dep is provided by upstream Fedora (yay!)