### PR TITLE
Fix agent plugin packaging.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -235,7 +235,6 @@ cp client_consumer/etc/bash_completion.d/pulp-consumer %{buildroot}/%{_sysconfdi
 %endif
 
 # Agent
-rm -rf %{buildroot}/%{python_sitelib}/%{name}/agent/gofer
 cp agent/etc/gofer/plugins/pulpplugin.conf %{buildroot}/%{_sysconfdir}/gofer/plugins
 
 # Ghost
@@ -576,6 +575,7 @@ on a defined interval.
 %files agent
 %defattr(-,root,root,-)
 %config(noreplace) %{_sysconfdir}/%{name}/agent/agent.conf
+%{python_sitelib}/%{name}/agent/gofer/
 %{_sysconfdir}/gofer/plugins/pulpplugin.conf
 %doc README LICENSE COPYRIGHT
 

--- a/server/pulp/server/agent/direct/services.py
+++ b/server/pulp/server/agent/direct/services.py
@@ -34,7 +34,7 @@ class Services(object):
 
     @staticmethod
     def start():
-        url = config.get('messaging', 'url')
+        url = Services.get_url()
         Services.reply_handler = ReplyHandler(url)
         Services.reply_handler.start()
         log.info(_('AMQP reply handler started'))
@@ -64,7 +64,6 @@ class ReplyHandler(Listener):
 
     REPLY_QUEUE = 'pulp.task'
 
-    # --- action post-processing ---------------------------------------------
 
     @staticmethod
     def _bind_succeeded(action_id, call_context):
@@ -123,6 +122,8 @@ class ReplyHandler(Listener):
         :type url: str
         """
         queue = Queue(ReplyHandler.REPLY_QUEUE)
+        queue.durable = True
+        queue.declare(url)
         self.consumer = ReplyConsumer(queue, url=url, authenticator=Authenticator())
 
     # --- agent replies ------------------------------------------------------


### PR DESCRIPTION
Fixes a variety of pulp 2.6 / gofer 2.4 integration issus:

- agent plugin not being installed in site-packages.
- pulp needs to explicitly declare the pulp.task queue (not longer implicitly created by gofer consumer)
- need to use the get_url() *workaround* when starting the reply consumer.  get_url() goes away in 3.0.
