### PR TITLE
create base for plugins view module

### DIFF
--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -1,10 +1,19 @@
 from django.conf.urls import patterns, url
 
+from pulp.server.webservices.views.plugins import (DistributorResourceView, DistributorsView,
+                                                   ImporterResourceView, ImportersView,
+                                                   TypeResourceView, TypesView)
 from pulp.server.webservices.views.tasks import TasksView
 from pulp.server.webservices.views.repositories import RepoSync
 
 
 urlpatterns = patterns('',
+    url(r'^v2/distributors/$', DistributorsView.as_view()),
+    url(r'^v2/distributors/(?P<distributor_type_id>[^/]+)/$', DistributorResourceView.as_view()),
+    url(r'^v2/plugins/importers/$', ImportersView.as_view()),
+    url(r'^v2/plugins/importers/(?P<importer_type_id>[^/]+)/$', ImporterResourceView.as_view()),
+    url(r'^v2/plugins/types/$', TypesView.as_view(), name='plugin_types'),
+    url(r'^v2/plugins/types/(?P<type_id>[^/]+)/$', TypeResourceView.as_view()),
     url(r'^v2/tasks/$', TasksView.as_view()),
     url(r'^v2/repositories/(?P<repo_id>\w+)/actions/sync/$', RepoSync.as_view()),
 )

--- a/server/pulp/server/webservices/views/plugins.py
+++ b/server/pulp/server/webservices/views/plugins.py
@@ -1,0 +1,32 @@
+import json
+
+from django.http import HttpResponse
+from django.views.generic import View
+
+from pulp.server.auth import authorization
+from pulp.server.managers import factory
+from pulp.server.webservices.controllers.decorators import auth_required
+
+
+class DistributorResourceView(View):
+    pass
+
+
+class DistributorsView(View):
+    pass
+
+
+class ImporterResourceView(View):
+    pass
+
+
+class ImportersView(View):
+    pass
+
+
+class TypeResourceView(View):
+    pass
+
+
+class TypesView(View):
+    pass

--- a/server/test/unit/server/webservices/test_urls.py
+++ b/server/test/unit/server/webservices/test_urls.py
@@ -1,0 +1,24 @@
+import unittest
+
+from django.core.urlresolvers import resolve, Resolver404
+
+
+class TestDjangoPluginsUrls(unittest.TestCase):
+
+    def test_match_distributor_resource_view(self):
+        pass
+
+    def test_match_distributors_view(self):
+        pass
+
+    def test_match_importer_resource_view(self):
+        pass
+
+    def test_match_importers_view(self):
+        pass
+
+    def test_match_type_resource_view(self):
+        pass
+
+    def test_match_types_view(self):
+        pass

--- a/server/test/unit/server/webservices/views/test_plugins.py
+++ b/server/test/unit/server/webservices/views/test_plugins.py
@@ -1,0 +1,33 @@
+import json
+import unittest
+
+import mock
+from django.http import HttpResponse, HttpResponseNotFound
+
+from pulp.server.webservices.views.plugins import (DistributorResourceView, DistributorsView,
+                                                   ImporterResourceView, ImportersView,
+                                                   TypeResourceView, TypesView)
+
+
+class TestDistributorResourceView(unittest.TestCase):
+    pass
+
+
+class TestDistributorsView(unittest.TestCase):
+    pass
+
+
+class TestImporterResourceView(unittest.TestCase):
+    pass
+
+
+class TestImportersView(unittest.TestCase):
+    pass
+
+
+class TestTypeResourceView(unittest.TestCase):
+    pass
+
+
+class TestTypesView(unittest.TestCase):
+    pass


### PR DESCRIPTION
Creates a skeleton for all of the plugin urls to be converted to django. Each url branch will branch from this to prevent merge conflicts.