### PR TITLE
1182322 - handle case where PLAIN is used with saslwrapper

### DIFF
--- a/deps/python-kombu/1182322.patch
+++ b/deps/python-kombu/1182322.patch
@@ -1,0 +1,89 @@
+From dc29334139966aa9a0224fb98feb395294e065f2 Mon Sep 17 00:00:00 2001
+From: Chris Duryee <cduryee@redhat.com>
+Date: Wed, 14 Jan 2015 21:32:29 +0000
+Subject: [PATCH] Add additional string to check for when connecting to qpid
+
+When we connect to qpid, we need to ensure that we skip to the next SASL
+mechanism if the current mechanism fails. Otherwise, we will keep retrying the
+connection with a non-working mech.
+
+This patch adds an additional string that is returned when PLAIN is not
+available, but python-saslwrapper is installed.
+
+Conflicts:
+        kombu/tests/transport/test_qpid.py
+        kombu/transport/qpid.py
+---
+ kombu/tests/transport/test_qpid.py | 29 ++++++++++++++++++++++++++++-
+ kombu/transport/qpid.py            |  8 +++++++-
+ 2 files changed, 35 insertions(+), 2 deletions(-)
+
+diff --git a/kombu/tests/transport/test_qpid.py b/kombu/tests/transport/test_qpid.py
+index 390e09c..fb338f9 100644
+--- a/kombu/tests/transport/test_qpid.py
++++ b/kombu/tests/transport/test_qpid.py
+@@ -373,7 +373,34 @@ class TestConnectionInit(ExtraAssertionsMixin, ConnectionTestBase):
+     @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
+     @patch(QPID_MODULE + '.sys.exc_info')
+     @patch(QPID_MODULE + '.qpid')
+-    def test__init_mutates_ConnError_by_code(self, mock_qpid, mock_exc_info):
++    def test_connection__init__mutates_ConnError_by_message2(self, mock_qpid,
++                                                            mock_exc_info):
++        """
++        Test for PLAIN connection via python-saslwrapper, sans cyrus-sasl-plain
++
++        This test is specific for what is returned when we attempt to connect
++        with PLAIN mech and python-saslwrapper is installed, but cyrus-sasl-plain is
++        not installed.
++        """
++        my_conn_error = MockException()
++        my_conn_error.text = 'Error in sasl_client_start (-4) SASL(-4): no mechanism available'
++        mock_qpid.messaging.Connection.establish.side_effect = my_conn_error
++        mock_exc_info.return_value = ('a', 'b', None)
++        try:
++            self.conn = Connection(**self.connection_options)
++        except AuthenticationFailure as error:
++            exc_info = sys.exc_info()
++            self.assertTrue(not isinstance(error, MockException))
++            self.assertTrue(exc_info[1] is 'b')
++            self.assertTrue(exc_info[2] is None)
++        else:
++            self.fail('ConnectionError type was not mutated correctly')
++
++    @patch(QPID_MODULE + '.ConnectionError', new=(MockException, ))
++    @patch(QPID_MODULE + '.sys.exc_info')
++    @patch(QPID_MODULE + '.qpid')
++    def test_connection__init__mutates_ConnError_by_code(self, mock_qpid,
++                                                         mock_exc_info):
+         my_conn_error = MockException()
+         my_conn_error.code = 320
+         my_conn_error.text = 'someothertext'
+diff --git a/kombu/transport/qpid.py b/kombu/transport/qpid.py
+index 474fe73..acf7807 100644
+--- a/kombu/transport/qpid.py
++++ b/kombu/transport/qpid.py
+@@ -1274,14 +1274,20 @@ class Connection(object):
+                 )
+                 break
+             except ConnectionError as conn_exc:
++                # if we get one of these errors, do not raise an exception.
++                # Raising will cause the connection to be retried. Instead,
++                # just continue on to the next mech.
+                 coded_as_auth_failure = getattr(conn_exc, 'code', None) == 320
+                 contains_auth_fail_text = \
+                     'Authentication failed' in conn_exc.text
+                 contains_mech_fail_text = \
+                     'sasl negotiation failed: no mechanism agreed' \
+                     in conn_exc.text
++                contains_mech_unavail_text = 'no mechanism available' \
++                    in conn_exc.text
+                 if coded_as_auth_failure or \
+-                        contains_auth_fail_text or contains_mech_fail_text:
++                        contains_auth_fail_text or contains_mech_fail_text or \
++                        contains_mech_unavail_text:
+                     logger.debug(
+                         'Unable to connect to qpid with SASL mechanism %s',
+                         sasl_mech,
+-- 
+2.1.0
+

--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.24
-Release:        3.pulp%{?dist}
+Release:        4.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages
@@ -20,6 +20,7 @@ License:        BSD and Python
 URL:            http://pypi.python.org/pypi/%{srcname}
 Source0:        http://pypi.python.org/packages/source/k/%{srcname}/%{srcname}-%{version}.tar.gz
 Patch0:         1174361.patch
+Patch1:         1182322.patch
 BuildArch:      noarch
 
 BuildRequires:  python2-devel
@@ -111,6 +112,8 @@ This subpackage is for python3
 
 %prep
 %setup -q -n %{srcname}-%{version}
+%patch0 -p1
+%patch1 -p1
 
 # manage requirements on rpm base
 sed -i 's/>=1.0.13,<1.1.0/>=1.3.0/' requirements/default.txt
@@ -167,6 +170,9 @@ popd
 %endif # with_python3
 
 %changelog
+* Wed Jan 14 2015 Chris Duryee <cduryee@redhat.com> 3.0.24-4.pulp
+- add a patch for RHBZ #1182322
+
 * Mon Jan 05 2015 Chris Duryee <cduryee@redhat.com> 3.0.24-3.pulp
 - Conditionally require python-unittest2 >= 0.8.0 (cduryee@redhat.com)
 


### PR DESCRIPTION
There is an error string we did not handle correctly when PLAIN sasl mech was
used, python-saslwrapper was installed, and cyrus-sasl-plain was *not*
installed.

This patch contains a patch to Pulp's python-kombu to handle this scenario.