### PR TITLE
1145723 - touch and chown log file before writing to it

### DIFF
--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -265,11 +265,9 @@ start_beat () {
 
 # this function implements the fix for bz #1145723
 write_log_message () {
+  touch $CELERYBEAT_LOG_FILE && chown $CELERYD_USER $CELERYBEAT_LOG_FILE
   echo -n `date "+%Y-%m-%d %T"` >> $CELERYBEAT_LOG_FILE
   echo " $1" >> $CELERYBEAT_LOG_FILE
-  # it is possible that we are the first to touch this file. If so, fix
-  # permissions.
-  chown $CELERYD_USER $CELERYBEAT_LOG_FILE
 }
 
 

--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -235,17 +235,16 @@ write_log_message () {
     for i in "${CELERYD_NODES_ARRAY[@]}"
     do
       local log_file="`dirname $CELERYD_LOG_FILE`/${i}.log"
+      touch $log_file && chown $CELERYD_USER $log_file
       echo -n `date "+%Y-%m-%d %T"` >> $log_file
       echo " $1" >> $log_file
     done
   else
     local log_file="`dirname $CELERYD_LOG_FILE`/${CELERYD_NODES}.log"
+    touch $log_file && chown $CELERYD_USER $log_file
     echo -n `date "+%Y-%m-%d %T"` >> $log_file
     echo " $1" >> $log_file
   fi
-  # it is possible that we are the first to touch this file. If so, fix
-  # permissions.
-  chown $CELERYD_USER $log_file
 }
 
 start_workers () {


### PR DESCRIPTION
The previous fix for RHBZ #1145723 did not work properly for freshly installed
systems with more than one Pulp worker. In these cases, only the last log file
would get its permissions set properly because the ``chown`` command was done
outside of the loop over each worker.

This patch moves the ``chown`` inside the loop. I also moved it above the log
file writing operation in a few other places to make the ``chown`` command more
obvious.