### PR TITLE
Make auth required easy to mock

### DIFF
--- a/server/pulp/server/auth/authorization.py
+++ b/server/pulp/server/auth/authorization.py
@@ -1,19 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Copyright © 2010-2011 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 """
 Utility functions to manage permissions and roles in pulp.
 """
+
 import logging
 
 _log = logging.getLogger(__name__)
@@ -34,12 +24,14 @@ def _operations_not_granted_by_roles(resource, operations, roles):
     """
     Filter a list of operations on a resource, removing the operations that
     are granted to the resource by any role in a given list of roles
+
     @type resource: str
     @param resource: pulp resource
     @type operations: list or tuple of int's
     @param operations: operations pertaining to the resource
     @type roles: list or tuple of L{pulp.server.db.model.Role} instances
     @param roles: list of roles
+
     @rtype: list of int's
     @return: list of operations on resource not granted by the roles
     """
@@ -52,3 +44,28 @@ def _operations_not_granted_by_roles(resource, operations, roles):
             if operation in permissions[resource]:
                 culled_ops.remove(operation)
     return culled_ops
+
+
+def _lookup_operation_name(operation_value):
+    """
+    Returns the human readable name for a given operation numerical value.
+
+    :param operation_value: The operation value
+    :type operation_value: int
+
+    :return: The human readable name as a string corresponding to the given
+             operation numerical value.
+    :raises: KeyError if operation_value does not have a corresponding name.
+    """
+    if operation_value == CREATE:
+        return 'CREATE'
+    if operation_value == READ:
+        return 'READ'
+    if operation_value == UPDATE:
+        return 'UPDATE'
+    if operation_value == DELETE:
+        return 'DELETE'
+    if operation_value == EXECUTE:
+        return 'EXECUTE'
+    msg_string = 'Could not find a valid name for authorization value %s'
+    raise KeyError(msg_string % operation_value)

--- a/server/pulp/server/webservices/controllers/decorators.py
+++ b/server/pulp/server/webservices/controllers/decorators.py
@@ -134,23 +134,99 @@ def is_consumer_authorized(resource, consumerid, operation):
     return False
 
 
-def auth_required(operation=None, super_user_only=False):
+def _verify_auth(self, operation, super_user_only, method, *args, **kwargs):
     """
-    Controller method wrapper that authenticates users based on various
-    credentials and then checks their authorization before allowing the
-    controller to be accessed.
+    Internal method for checking authentication and authorization. This code
+    is kept outside of the decorator which calls it so that it can be mocked.
+    This allows for the decorator itself which calls here to have assertions
+    made about the operation and super_user values set in the view code.
 
-    A None for the operation means not to check authorization, only check
+    An operation of None means not to check authorization; only check
     authentication.
 
     The super_user_only flag set to True means that only members of the
     built in SuperUsers role are authorized.
 
     :type operation: int or None
-    :param operation: the operation a user needs permission for
+    :param operation: The operation a user needs permission for, or None to
+                      skip authorization.
 
     :type super_user_only: bool
-    :param super_user_only: only authorize a user if they are a super user
+    :param super_user_only: Only authorize a user if they are a super user.
+    """
+    # Check Authentication
+
+    # Run through each registered and enabled auth function
+    is_consumer = False
+    registered_auth_functions = [check_preauthenticated,
+                                 password_authentication,
+                                 user_cert_authentication,
+                                 consumer_cert_authentication,
+                                 oauth_authentication]
+
+    user_authenticated = False
+    for authenticate_user in registered_auth_functions:
+        if authenticate_user == oauth_authentication:
+            userid, is_consumer = authenticate_user()
+        else:
+            userid = authenticate_user()
+
+        if userid is not None:
+            user_authenticated = True
+            if authenticate_user == consumer_cert_authentication:
+                is_consumer = True
+            break
+
+    if not user_authenticated:
+        raise PulpCodedAuthenticationException(error_code=error_codes.PLP0025)
+
+    # Check Authorization
+
+    principal_manager = factory.principal_manager()
+    user_query_manager = factory.user_query_manager()
+
+    if super_user_only and not user_query_manager.is_superuser(userid):
+        raise PulpCodedAuthenticationException(error_code=error_codes.PLP0029, user=userid)
+    # if the operation is None, don't check authorization
+    elif operation is not None:
+        if is_consumer:
+            if is_consumer_authorized(http.resource_path(), userid, operation):
+                # set default principal = SYSTEM
+                principal_manager.set_principal()
+            else:
+                raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026, user=userid,
+                                                       operation=operation)
+        elif user_query_manager.is_authorized(http.resource_path(), userid, operation):
+            user = user_query_manager.find_by_login(userid)
+            principal_manager.set_principal(user)
+        else:
+            raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026, user=userid,
+                                                   operation=operation)
+
+    # Authentication and authorization succeeded. Call method and then clear principal.
+    value = method(self, *args, **kwargs)
+    principal_manager.clear_principal()
+    return value
+
+
+def auth_required(operation=None, super_user_only=False):
+    """
+    View method wrapper that authenticates users based on various credentials
+    and then checks their authorization before allowing the view to be
+    accessed.
+
+    An operation of None means not to check authorization; only check
+    authentication.
+
+    The super_user_only flag set to True means that only members of the
+    built in SuperUsers role are authorized.
+
+    :type operation: int or None
+    :param operation: The operation a user needs permission for or None to
+                      skip authorization.
+
+    :type super_user_only: bool
+    :param super_user_only: Only authorize a user if they are a super user.
     """
     def _auth_required(method):
         """
@@ -158,60 +234,23 @@ def auth_required(operation=None, super_user_only=False):
         """
         @wraps(method)
         def _auth_decorator(self, *args, **kwargs):
+            """
+            Calls the internal method which provides the authorization and
+            authentication.
 
-            # Check Authentication
+            :param args: The positional arguments to be passed to the wrapped
+                         view.
+            :type args: tuple
 
-            # Run through each registered and enabled auth function
-            is_consumer = False
-            registered_auth_functions = [check_preauthenticated,
-                                         password_authentication,
-                                         user_cert_authentication,
-                                         consumer_cert_authentication,
-                                         oauth_authentication]
+            :param kwargs: The keyword arguments to be passed to the wrapped
+                           view.
+            :type kwargs: dict
 
-            user_authenticated = False
-            for authenticate_user in registered_auth_functions:
-                if authenticate_user == oauth_authentication:
-                    userid, is_consumer = authenticate_user()
-                else:
-                    userid = authenticate_user()
-
-                if userid is not None:
-                    user_authenticated = True
-                    if authenticate_user == consumer_cert_authentication:
-                        is_consumer = True
-                    break
-
-            if not user_authenticated:
-                raise PulpCodedAuthenticationException(error_code=error_codes.PLP0025)
-
-            # Check Authorization
-
-            principal_manager = factory.principal_manager()
-            user_query_manager = factory.user_query_manager()
-
-            if super_user_only and not user_query_manager.is_superuser(userid):
-                raise PulpCodedAuthenticationException(error_code=error_codes.PLP0029, user=userid)
-            # if the operation is None, don't check authorization
-            elif operation is not None:
-                if is_consumer:
-                    if is_consumer_authorized(http.resource_path(), userid, operation):
-                        # set default principal = SYSTEM
-                        principal_manager.set_principal()
-                    else:
-                        raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026, user=userid,
-                                                               operation=operation)
-                elif user_query_manager.is_authorized(http.resource_path(), userid, operation):
-                    user = user_query_manager.find_by_login(userid)
-                    principal_manager.set_principal(user)
-                else:
-                    raise PulpCodedAuthenticationException(error_code=error_codes.PLP0026, user=userid,
-                                                           operation=operation)
-
-            # Authentication and authorization succeeded. Call method and then clear principal.
-            value = method(self, *args, **kwargs)
-            principal_manager.clear_principal()
-            return value
+            :raises: An Authorization or Authentication exception if either
+                     is invalid.
+            :returns: The result of the wrapped view method.
+            """
+            return _verify_auth(self, operation, super_user_only, method, *args, **kwargs)
 
         return _auth_decorator
     return _auth_required

--- a/server/test/unit/server/auth/test_authorization.py
+++ b/server/test/unit/server/auth/test_authorization.py
@@ -1,0 +1,31 @@
+import unittest
+
+from pulp.server.auth import authorization
+
+
+class TestAuthorization(unittest.TestCase):
+
+    def test_module_level_attributes(self):
+        """
+        Assert that the expected module level variables are correct.
+        """
+        self.assertEqual(authorization.CREATE, 0)
+        self.assertEqual(authorization.READ, 1)
+        self.assertEqual(authorization.UPDATE, 2)
+        self.assertEqual(authorization.DELETE, 3)
+        self.assertEqual(authorization.EXECUTE, 4)
+        expected_op_names = ['CREATE', 'READ', 'UPDATE', 'DELETE', 'EXECUTE']
+        self.assertEqual(authorization.OPERATION_NAMES, expected_op_names)
+
+    def test__lookup_operation_name(self):
+        """
+        Test the _lookup_operation_name function
+        """
+        _lookup = authorization._lookup_operation_name
+        self.assertEqual(_lookup(0), 'CREATE')
+        self.assertEqual(_lookup(1), 'READ')
+        self.assertEqual(_lookup(2), 'UPDATE')
+        self.assertEqual(_lookup(3), 'DELETE')
+        self.assertEqual(_lookup(4), 'EXECUTE')
+        invalid_operation_value = 1000
+        self.assertRaises(KeyError, _lookup, invalid_operation_value)

--- a/server/test/unit/server/webservices/views/base.py
+++ b/server/test/unit/server/webservices/views/base.py
@@ -1,0 +1,102 @@
+from pulp.server.auth import authorization
+
+
+def _assert_auth_decorator_general(required_operation):
+    """
+    Returns a method that asserts a future call to the returned method uses
+    the required_operation specified here.
+
+    This is a helper method to make it easier to mock the @auth_required
+    decorator. The returned function should be used to mock the
+    pulp.server.webservices.controllers.decorators._verify_auth function
+    which is called as part of the @auth_required decorator codepath.
+
+    An AssertionError will be raised if the @auth_required decorator is not
+    called with the required_operation specified. required_operation may also
+    be None to specify no authorization operations but require authentication.
+
+    NOTE: This side-steps authorization and authentication altogether.
+    Since this is to be used exclusively by the unit tests that is OK.
+
+    :type required_operation: int or None
+    :param required_operation: An operation from
+                               pulp.server.auth.authorization that needs to
+                               be used in a future call to @auth_required.
+                               The operation can also be None.
+
+    :return: A function that can be used to mock the _verify_auth method. An
+             AssertionError will be raised if the @auth_required decorator
+             does not have the correct authorization. The returned function
+             causes authorization and authentication to be skipped completely.
+    """
+    def _specific_auth_assertions(self, operation, super_user_only, method,
+                                  *args, **kwargs):
+        if required_operation != operation:
+            _lookup = authorization._lookup_operation_name
+            msg = "Expected authorization requirement of %s, but instead " \
+                  "got %s"
+            try:
+                required_name = _lookup(required_operation)
+            except KeyError:
+                required_name = None
+            try:
+                actual_name = _lookup(operation)
+            except KeyError:
+                actual_name = None
+            raise AssertionError(msg % (required_name, actual_name))
+        return method(self, *args, **kwargs)
+    return _specific_auth_assertions
+
+
+def assert_auth_CREATE():
+    """
+    Customizes the _assert_auth_decorator_general to be CREATE specific.
+
+    :return: The function returned by _assert_auth_decorator_general
+    """
+    return _assert_auth_decorator_general(authorization.CREATE)
+
+
+def assert_auth_READ():
+    """
+    Customizes the _assert_auth_decorator_general to be READ specific.
+
+    :return: The function returned by _assert_auth_decorator_general
+    """
+    return _assert_auth_decorator_general(authorization.READ)
+
+
+def assert_auth_UPDATE():
+    """
+    Customizes the _assert_auth_decorator_general to be UPDATE specific.
+
+    :return: The function returned by _assert_auth_decorator_general
+    """
+    return _assert_auth_decorator_general(authorization.UPDATE)
+
+
+def assert_auth_DELETE():
+    """
+    Customizes the _assert_auth_decorator_general to be DELETE specific.
+
+    :return: The function returned by _assert_auth_decorator_general
+    """
+    return _assert_auth_decorator_general(authorization.DELETE)
+
+
+def assert_auth_EXECUTE():
+    """
+    Customizes the _assert_auth_decorator_general to be EXECUTE specific.
+
+    :return: The function returned by _assert_auth_decorator_general
+    """
+    return _assert_auth_decorator_general(authorization.EXECUTE)
+
+
+def assert_auth_NONE():
+    """
+    Customizes the _assert_auth_decorator_general to use no operation.
+
+    :return: The function returned by _assert_auth_decorator_general
+    """
+    return _assert_auth_decorator_general(None)


### PR DESCRIPTION
This PR will allow auth_required statement able to easily have assertions made about them.

Docs on how to use this can be found here:  https://fedorahosted.org/pulp/wiki/ReplacewebpywithDjango#UnitTesting