### PR TITLE
Revert "1174283 - bump python-requests to 2.4.3"

### DIFF
--- a/deps/python-nectar/python-nectar.spec
+++ b/deps/python-nectar/python-nectar.spec
@@ -16,7 +16,7 @@ BuildArch:      noarch
 BuildRequires:  python-setuptools
 
 Requires:       python-isodate >= 0.4.9
-Requires:       python-requests >= 2.4.3
+Requires:       python-requests >= 2.2.1
 
 %description
 Nectar is a download library that abstracts the workflow of making and tracking


### PR DESCRIPTION
Reverts pulp/pulp#1482

This change needs to be made in 2.6-testing rather than 2.6 dev. I cherry picked the commit back to 2.6-testing. This will pull the change out of 2.6-dev so the commit can merge forward normally, allowing git branch --contains to work as expected.