### PR TITLE
update external deps file for docker and crane

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -10,5 +10,13 @@
     "qpid-qmf": {
         "version": "0.26-2",
         "platform": ["el6"]
+    },
+    "pulp-docker": {
+        "version": "0.2.2-1",
+        "platform": ["el6", "el7", "fc20", "fc21"]
+    },
+    "python-crane": {
+        "version": "0.2.2-1",
+        "platform": ["el6", "el7", "fc20", "fc21"]
     }
 }


### PR DESCRIPTION
In the past we had to tag pulp-docker and python-crane in manually to the
correct koji tag. This is a step that was frequently forgotten.

Instead, use external-deps.json which automatically pulls the correct versions
into the specificed tag.