### PR TITLE
1184187 - Causes all platform tests to use pulp_unittest

### DIFF
--- a/server/pulp/server/initialization.py
+++ b/server/pulp/server/initialization.py
@@ -2,13 +2,9 @@
 
 from gettext import gettext as _
 import logging
-import sys
-
-# It is important that we initialize the DB connection early
-from pulp.server.db import connection as db_connection
-db_connection.initialize()
 
 from pulp.plugins.loader import api as plugin_api
+from pulp.server.db import connection as db_connection
 from pulp.server.managers import factory as manager_factory
 
 
@@ -27,6 +23,8 @@ def initialize():
     global _IS_INITIALIZED
     if _IS_INITIALIZED:
         return
+
+    db_connection.initialize()
 
     # This is here temporarily, so that we can run the monkey patches for qpid and stuff
     import kombu.transport.qpid

--- a/server/pulp/server/maintenance/monthly.py
+++ b/server/pulp/server/maintenance/monthly.py
@@ -14,12 +14,8 @@ from celery import task
 
 from pulp.common.tags import action_tag
 from pulp.server.async.tasks import Task
-from pulp.server.db import connection
 from pulp.server.managers.consumer.applicability import RepoProfileApplicabilityManager
 
-
-# This module is generally called from the pulp-monthly script, so let's set up the DB connection
-connection.initialize()
 
 @task
 def queue_monthly_maintenance():

--- a/server/test/unit/server/managers/schedule/test_utils.py
+++ b/server/test/unit/server/managers/schedule/test_utils.py
@@ -24,7 +24,7 @@ from pulp.server.db.model.dispatch import ScheduledCall
 from pulp.server.managers.schedule import utils
 
 
-initialize()
+initialize(name='pulp_unittest')
 
 
 class TestGet(unittest.TestCase):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1184187

**The Problem**
At test run time, unexpected calls to db.connection.initialize() will read the production database. This wasn't a problem before, but with commit 70274cf9be047708da930b25f93c9d3f4feb7f78 mongo starts to cache the most recent call to mongoengine.connect() as the working 'default' database. This effectively ties the tests to the production DB once one of these unexpected calls to db.connection.initialize() occurs. The unit tests liberally drop collections which causes the production database to be dropped.

**The Solution**
In the case of initialization.py, having the db.connection.initialize() call occur at the method level instead of the module level provides the connection when it is needed for production code while the tests sidestep the additional unexpected call to db.connection.initialize().

Tasks contained in monthly.py are exclusively dispatched by celerybeat and run by celery workers both of which will have already called db.connection.initialize(). I believe in that case getting rid of it was the right thing to do.

In test_utils.py specifying the unittest database name causes test in that module to use the correct name even though another call to db.connection.initialize() is occurring.

**How do I know this fixes it?**
This fix causes the reproducer script attached to the bug shows '39' both before and after the unit tests are run. That means at least one collection that was being deleted before is now not being deleted. I also temporarily raise an Exception if name == 'pulp_database' in db.connection.initialize() and all tests pass without exception.

**How do I know this will work?**
I also hand tested it with Pulp and was able to sync and publish.

**This is a quick fix**
This change does not come with unittests because a more comprehensive fix is being planned to have only entry points call initialize. All calls to db.connection.initialize() will likely be removed with that change.
