### PR TITLE
Add the Python plugins to external deps.

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -15,6 +15,10 @@
         "version": "0.2.2-1",
         "platform": ["el6", "el7", "fc20", "fc21"]
     },
+    "pulp-python": {
+        "version": "0.0.0-1",
+        "platform": ["el6", "el7", "fc20", "fc21"]
+    },
     "python-crane": {
         "version": "0.2.2-1",
         "platform": ["el6", "el7", "fc20", "fc21"]


### PR DESCRIPTION
This way, they can be included in the 2.6 betas.