### PR TITLE
1183700 - Update pulp.spec to overwrite Celery related init scripts

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -322,9 +322,9 @@ Pulp provides replication, access, and accounting for software repositories.
 %if %{pulp_systemd} == 0
 # Install the init scripts
 %defattr(755,root,root,-)
-%config %{_initddir}/pulp_celerybeat
-%config %{_initddir}/pulp_workers
-%config %{_initddir}/pulp_resource_manager
+%{_initddir}/pulp_celerybeat
+%{_initddir}/pulp_workers
+%{_initddir}/pulp_resource_manager
 %else
 # Install the systemd unit files
 %defattr(-,root,root,-)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1183700

This will cause pulp-server to overwrite the pulp_celerybeat, pulp_workers, and pulp_resource_manager Upstart scripts. I tested rebuild Pulp with this new spec file and the build worked.