### PR TITLE
BZ1120671 - scheduled sync now have repo id and action associated with them in the task list

### DIFF
--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -6,6 +6,7 @@ import logging
 import platform
 import threading
 import time
+import uuid
 
 from celery import beat
 from celery.result import AsyncResult
@@ -422,6 +423,9 @@ class Scheduler(beat.Scheduler):
         :type kwargs:       dict
         :return:
         """
+
+        if entry == 'dispatch_sync_with_auto_publish':
+            inner_task_id = str(uuid.uuid4())
         result = super(Scheduler, self).apply_async(entry, publisher, **kwargs)
         if isinstance(entry, ScheduleEntry) and entry._scheduled_call.failure_threshold:
             has_failure = bool(entry._scheduled_call.consecutive_failures)

--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -423,10 +423,19 @@ class Scheduler(beat.Scheduler):
         :type kwargs:       dict
         :return:
         """
-
-        if entry == 'dispatch_sync_with_auto_publish':
-            inner_task_id = str(uuid.uuid4())
-        result = super(Scheduler, self).apply_async(entry, publisher, **kwargs)
+        if entry.task == 'pulp.server.tasks.repository.dispatch_sync_with_auto_publish':
+            task_id = str(uuid.uuid4())
+            # The apply_async method from the base class saves the ScheduleEntry object to the
+            # the database.  The first time the task_id will not be present, but on all subsequent
+            # run, the previous task_id needs to be replaced with a new one.
+            if len(entry.args) > 1:
+                entry.args[1] = task_id
+            else:
+                entry.args.append(task_id)
+            super(Scheduler, self).apply_async(entry, publisher, **kwargs)
+            result = AsyncResult(task_id)
+        else:
+            result = super(Scheduler, self).apply_async(entry, publisher, **kwargs)
         if isinstance(entry, ScheduleEntry) and entry._scheduled_call.failure_threshold:
             has_failure = bool(entry._scheduled_call.consecutive_failures)
             self._failure_watcher.add(result.id, entry.name, has_failure)

--- a/server/pulp/server/managers/repo/sync.py
+++ b/server/pulp/server/managers/repo/sync.py
@@ -26,7 +26,7 @@ from gettext import gettext as _
 
 from celery import task
 
-from pulp.common import dateutils, constants
+from pulp.common import dateutils, constants, tags
 from pulp.plugins.loader import api as plugin_api
 from pulp.plugins.loader import exceptions as plugin_exceptions
 from pulp.plugins.conduits.repo_sync import RepoSyncConduit
@@ -116,6 +116,21 @@ class RepoSyncManager(object):
 
         # auto publish call has been moved to a dependent call in a multiple
         # call execution through the coordinator
+
+    @staticmethod
+    def get_sync_task_tags(repo_id):
+        """
+        This method returns tags used for dispatching sync_with_auto_publish task
+
+        :param repo_id: id of the repository to sync
+        :type repo_id: str
+        :return: List of tags describing a sync on repo_id
+        :rtype: list
+        """
+
+        task_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, repo_id),
+                     tags.action_tag('sync')]
+        return task_tags
 
     @staticmethod
     def _get_importer_instance_and_config(repo_id):

--- a/server/pulp/server/managers/schedule/repo.py
+++ b/server/pulp/server/managers/schedule/repo.py
@@ -16,7 +16,7 @@ from pulp.server.db.model.dispatch import ScheduledCall
 from pulp.server.db.model.repository import RepoImporter, RepoDistributor
 from pulp.server.managers import factory as managers_factory
 from pulp.server.managers.schedule import utils
-from pulp.server.tasks.repository import sync_with_auto_publish, publish
+from pulp.server.tasks.repository import dispatch_sync_with_auto_publish, publish
 
 
 _PUBLISH_OPTION_KEYS = ('override_config',)
@@ -72,7 +72,7 @@ class RepoSyncScheduleManager(object):
         utils.validate_keys(sync_options, _SYNC_OPTION_KEYS)
         utils.validate_initial_schedule_options(schedule, failure_threshold, enabled)
 
-        task = sync_with_auto_publish.name
+        task = dispatch_sync_with_auto_publish.name
         args = [repo_id]
         kwargs = {'overrides': sync_options['override_config']}
         resource = RepoImporter.build_resource_tag(repo_id, importer_id)

--- a/server/pulp/server/tasks/repository.py
+++ b/server/pulp/server/tasks/repository.py
@@ -241,7 +241,6 @@ def dispatch_sync_with_auto_publish(repo_id, task_id, overrides=None):
     """
 
     task_tags = managers.repo_sync_manager().get_sync_task_tags(repo_id)
+    kwargs = {'inner_task_id':task_id, 'tags': task_tags}
     sync_with_auto_publish.apply_async_with_reservation(RESOURCE_REPOSITORY_TYPE, repo_id,
-                                                        [repo_id, overrides],
-                                                        {'inner_task_id':task_id,
-                                                         'tags': task_tags})
+                                                        [repo_id, overrides], **kwargs)

--- a/server/pulp/server/webservices/controllers/repositories.py
+++ b/server/pulp/server/webservices/controllers/repositories.py
@@ -713,10 +713,9 @@ class RepoSync(JSONController):
         manager_factory.repo_query_manager().get_repository(repo_id)
 
         # Execute the sync asynchronously
-        task_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, repo_id),
-                     tags.action_tag('sync')]
+        task_tags = manager_factory.repo_sync_manager().get_sync_task_tags(repo_id)
         async_result = repository.sync_with_auto_publish.apply_async_with_reservation(
-            tags.RESOURCE_REPOSITORY_TYPE, repo_id, [repo_id, overrides], {}, tags=task_tags)
+            tags.RESOURCE_REPOSITORY_TYPE, repo_id, [repo_id, overrides], tags=task_tags)
 
         # this raises an exception that is handled by the middleware,
         # so no return is needed

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -487,6 +487,29 @@ class TestSchedulerApplyAsync(unittest.TestCase):
         # make sure the entry was added, because it has a failure threshold
         self.assertEqual(len(sched_instance._failure_watcher), 1)
 
+    @mock.patch('threading.Thread', new=mock.MagicMock())
+    @mock.patch.object(scheduler.Scheduler, 'setup_schedule')
+    @mock.patch('celery.beat.Scheduler.apply_async')
+    def test_dispatch_sync_with_auto_publish(self, mock_apply_async, mock_setup_schedule):
+        sched_instance = scheduler.Scheduler()
+        mock_entry = mock.MagicMock()
+        mock_entry.task = 'pulp.server.tasks.repository.dispatch_sync_with_auto_publish'
+        mock_entry.args = ['mock_repo_id']
+        ret = sched_instance.apply_async(mock_entry)
+        self.assertEqual(len(mock_entry.args), 2)
+
+    @mock.patch('threading.Thread', new=mock.MagicMock())
+    @mock.patch.object(scheduler.Scheduler, 'setup_schedule')
+    @mock.patch('celery.beat.Scheduler.apply_async')
+    def test_dispatch_sync_with_auto_publish_again(self, mock_apply_async, mock_setup_schedule):
+        sched_instance = scheduler.Scheduler()
+        mock_entry = mock.MagicMock()
+        mock_entry.task = 'pulp.server.tasks.repository.dispatch_sync_with_auto_publish'
+        mock_entry.args = ['mock_repo_id', 'mock_task_id']
+        ret = sched_instance.apply_async(mock_entry)
+        self.assertEqual(len(mock_entry.args), 2)
+        self.assertIsNot(mock_entry.args[1], 'mock_task_id')
+
 
 class TestEventMonitorRun(unittest.TestCase):
     class SleepException(Exception):

--- a/server/test/unit/server/managers/repo/test_sync.py
+++ b/server/test/unit/server/managers/repo/test_sync.py
@@ -6,7 +6,7 @@ import signal
 import mock
 
 from .... import base
-from pulp.common import dateutils, constants
+from pulp.common import dateutils, constants, tags
 from pulp.devel import mock_plugins
 from pulp.plugins.model import SyncReport
 from pulp.server.async import tasks
@@ -580,6 +580,15 @@ class RepoSyncManagerTests(base.PulpServerTests):
         # Verify
         self.assertEqual(dir, temp_dir + '/test-repo')
         self.assertTrue(os.path.exists(dir))
+
+    def test_get_sync_tags(self):
+        """
+        Test that we get correct tags for a repo sync
+        """
+        sync_tags = self.sync_manager.get_sync_task_tags('repo_id')
+        expected_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, 'repo_id'),
+                     tags.action_tag('sync')]
+        self.assertEqual(sync_tags, expected_tags)
 
 
 class TestDoSync(base.PulpServerTests):

--- a/server/test/unit/server/tasks/test_repository.py
+++ b/server/test/unit/server/tasks/test_repository.py
@@ -209,3 +209,11 @@ class TestRepositorySync(PulpCeleryTaskTests):
         result = repository.sync_with_auto_publish('foo', 'bar')
         self.assertTrue(isinstance(result, TaskResult))
         self.assertEquals(result.spawned_tasks, ['fish', ])
+
+    @patch('pulp.server.tasks.repository.managers')
+    @patch('pulp.server.tasks.repository.sync_with_auto_publish.apply_async_with_reservation')
+    def test_dispatch_sync_with_auto_publish(self, mock_apply_async_with_reservation,
+                                             mock_managers):
+        mock_managers.repo_sync_manager.return_value.sync.return_value = 'baz'
+        repository.dispatch_sync_with_auto_publish.__call__('mock_repo_id', 'mock_task_id')
+        self.assertTrue(mock_apply_async_with_reservation.called)


### PR DESCRIPTION
This PR introduces a dispatch_sync_with_auto_publish task. This task dispatched the actual sync_with_auto_publish task using apply_async_with_reservation. This mimics the behavior in the webservices controller responsible for repo syncs.