### PR TITLE
1185401 - added reading of cert_t for custom SSL config

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -51,6 +51,9 @@ ifndef(`distro_rhel6', `
 allow celery_t pulp_cert_t:dir { getattr search };
 allow celery_t pulp_cert_t:file { read write getattr open };
 
+# custom SSL certificates reading
+miscfiles_read_generic_certs(celery_t)
+
 ######################################
 
 allow celery_t var_run_t:file { write getattr read create unlink open };


### PR DESCRIPTION
In Katello we configure pulp with custom CA/key that has system-wide label of
cert_t already. This patch adds reading capabilities to Pulp for all files
marked as cert_t to support this kind of configuration.