### PR TITLE
1186420 - reading cert_t for custom SSL config

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -51,6 +51,9 @@ ifndef(`distro_rhel6', `
 allow celery_t pulp_cert_t:dir { getattr search };
 allow celery_t pulp_cert_t:file { read write getattr open };
 
+# custom SSL certificates reading
+miscfiles_read_generic_certs(celery_t)
+
 ######################################
 
 allow celery_t var_run_t:file { write getattr read create unlink open };


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1186420

Gives read permissions to all cert_t certs. Usually certs are kept with cert_t anyway so Celery should be allowed to read them.