### PR TITLE
1159303 - delete agent queues on consumer unregistration.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -25,6 +25,10 @@
 %define pulp_systemd 0
 %endif
 
+# Required gofer version
+%global gofer_version 2.5
+
+
 # ---- Pulp Platform -----------------------------------------------------------
 
 Name: pulp
@@ -277,8 +281,8 @@ Requires: mod_ssl
 Requires: openssl
 Requires: nss-tools
 Requires: python-ldap
-Requires: python-gofer >= 2.3
-Requires: python-gofer-qpid >= 2.3
+Requires: python-gofer >= %{gofer_version}
+Requires: python-gofer-qpid >= %{gofer_version}
 Requires: crontabs
 Requires: acl
 Requires: mod_wsgi >= 3.4-1.pulp
@@ -562,9 +566,9 @@ Group: Development/Languages
 Requires: python-%{name}-bindings = %{pulp_version}
 Requires: python-%{name}-agent-lib = %{pulp_version}
 Requires: %{name}-consumer-client = %{pulp_version}
-Requires: python-gofer >= 2.3
-Requires: python-gofer-qpid >= 2.3
-Requires: gofer >= 2.3
+Requires: python-gofer >= %{gofer_version}
+Requires: python-gofer-qpid >= %{gofer_version}
+Requires: gofer >= %{gofer_version}
 Requires: m2crypto
 
 %description agent

--- a/server/pulp/server/agent/direct/pulpagent.py
+++ b/server/pulp/server/agent/direct/pulpagent.py
@@ -19,6 +19,7 @@ Agent request flow:
 from logging import getLogger
 
 from gofer.proxy import Agent
+from gofer.messaging import Queue, NotFound
 
 
 log = getLogger(__name__)
@@ -75,6 +76,23 @@ class PulpAgent(object):
 
         admin = agent.Admin()
         admin.cancel(criteria=criteria)
+
+    @staticmethod
+    def delete_queue(url, name):
+        """
+        Purge and delete the agent queue.
+        :param url: The broker URL.
+        :type url: str
+        :param name: The queue name.
+        :type name: str
+        """
+        try:
+            queue = Queue(name)
+            queue.purge(url)
+            queue.delete(url)
+        except NotFound:
+            # queue may not exist
+            pass
 
 
 # --- Agent Capabilities -----------------------------------------------------


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1159303

The NotFound exception is new in gofer 2.5 which contains support for amqp 1.0 (proton).  We can delay merging until that work is complete and gofer 2.5 is released.