### PR TITLE
1186420 - fixed reading cert_t for custom SSL config

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -52,7 +52,11 @@ allow celery_t pulp_cert_t:dir { getattr search };
 allow celery_t pulp_cert_t:file { read write getattr open };
 
 # custom SSL certificates reading
-miscfiles_read_generic_certs(celery_t)
+ifdef(`distro_rhel6', `
+    miscfiles_read_certs(celery_t)
+',`
+    miscfiles_read_generic_certs(celery_t)
+')
 
 ######################################
 


### PR DESCRIPTION
This fixes my previous commit. I've tested this on RHEL6 and RHEL7. Modern
Fedoras should go well as well.