### PR TITLE
Do not log the length of the database password.

### DIFF
--- a/server/pulp/server/db/connection.py
+++ b/server/pulp/server/db/connection.py
@@ -94,7 +94,7 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
 
         shadow_connection_kwargs = copy.deepcopy(connection_kwargs)
         if connection_kwargs.get('password'):
-            shadow_connection_kwargs['password'] = '*'*len(shadow_connection_kwargs['password'])
+            shadow_connection_kwargs['password'] = '*****'
         _logger.debug(_('Connection Arguments: %s') % shadow_connection_kwargs)
 
         # Wait until the Mongo database is available


### PR DESCRIPTION
This commit also fixes several unit tests that were assuming that the database was
local and unauthenticated.