### PR TITLE
Print helpful messages before starting the flake8

### DIFF
--- a/devel/pulp/devel/test_runner.py
+++ b/devel/pulp/devel/test_runner.py
@@ -74,6 +74,7 @@ def run_tests(packages, tests_all_platforms, tests_non_rhel5,
             flake8_command = ['flake8', '--max-line-length=100', '--ignore=E401',
                               '--exclude=.ropeproject,docs,playpen,pulp-dev.py']
             flake8_command.extend(flake8_paths)
+            print "Running flake8"
             flake8_exit_code = subprocess.call(flake8_command)
 
     else:
@@ -93,5 +94,6 @@ def run_tests(packages, tests_all_platforms, tests_non_rhel5,
     if arguments.xunit_file:
         args.extend(['--xunit-file', '../test/' + arguments.xunit_file])
 
+    print "Running Unit Tests"
     # Call the test process, and return its exit code
     return subprocess.call(args) or flake8_exit_code

--- a/server/pulp/server/managers/auth/cert/certificate.py
+++ b/server/pulp/server/managers/auth/cert/certificate.py
@@ -8,6 +8,7 @@ replacement of full wrapper but instead and extension.
 from datetime import datetime as dt
 import os
 import re
+import sys
 
 from M2Crypto import X509
 
@@ -936,7 +937,6 @@ class Bundle(object):
         return '\n'.join(s)
 
 
-import sys
 if __name__ == '__main__':
     for path in sys.argv[1:]:
         print path


### PR DESCRIPTION
Print messages before starting flake8 and the unit tests to make it easier to follow the jenkins log files