### PR TITLE
1190794 - Fixes release note formatting on 2.6.0 release note

### DIFF
--- a/docs/user-guide/release-notes/2.6.x.rst
+++ b/docs/user-guide/release-notes/2.6.x.rst
@@ -102,7 +102,7 @@ Rest API Changes
   has been added.
 
 * A new API call is added to search profile attributes for all consumer profiles using the
-  Search API.``/pulp/api/v2/consumers/profile/search/``. With this API call all the unit profiles
+  Search API. ``/pulp/api/v2/consumers/profile/search/``. With this API call all the unit profiles
   can be retrieved at one time instead of querying each consumer through
   ``/v2/consumers/<consumer_id>/profiles/``. It is also possible to query for a single package
   across all consumers.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1190794

I manually rebuilt the docs with the RTD sphinx theme and it this change fixed it.