### PR TITLE
Adding back urls deleted because of compatibility issues.

### DIFF
--- a/server/pulp/server/webservices/controllers/consumer_groups.py
+++ b/server/pulp/server/webservices/controllers/consumer_groups.py
@@ -1,61 +1,8 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2012 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public License as
-# published by the Free Software Foundation; either version 2 of the License
-# (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied, including the
-# implied warranties of MERCHANTABILITY, NON-INFRINGEMENT, or FITNESS FOR A
-# PARTICULAR PURPOSE.
-# You should have received a copy of GPLv2 along with this software; if not,
-# see http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
-
 import web
 
-from pulp.server import exceptions as pulp_exceptions
-from pulp.server.auth import authorization
-from pulp.server.db.model.consumer import ConsumerGroup
-from pulp.server.exceptions import MissingResource
 from pulp.server.managers import factory as managers_factory
 from pulp.server.webservices import serialization
-from pulp.server.webservices.controllers.base import JSONController
-from pulp.server.webservices.controllers.decorators import auth_required
 from pulp.server.webservices.controllers.search import SearchController
-
-
-# consumer group collection ----------------------------------------------------
-
-class ConsumerGroupCollection(JSONController):
-
-    @auth_required(authorization.READ)
-    def GET(self):
-        collection = ConsumerGroup.get_collection()
-        cursor = collection.find({})
-        groups = []
-        for group in cursor:
-            group.update(serialization.link.child_link_obj(group['id']))
-            groups.append(group)
-        return self.ok(groups)
-
-    @auth_required(authorization.CREATE)
-    def POST(self):
-        group_data = self.params()
-        group_id = group_data.pop('id', None)
-        if group_id is None:
-            raise pulp_exceptions.MissingValue(['id'])
-        display_name = group_data.pop('display_name', None)
-        description = group_data.pop('description', None)
-        consumer_ids = group_data.pop('consumer_ids', None)
-        notes = group_data.pop('notes', None)
-        if group_data:
-            raise pulp_exceptions.InvalidValue(group_data.keys())
-        manager = managers_factory.consumer_group_manager()
-
-        group = manager.create_consumer_group(group_id, display_name, description, consumer_ids,
-                                              notes)
-        group.update(serialization.link.child_link_obj(group['id']))
-        return self.created(group['_href'], group)
 
 
 class ConsumerGroupSearch(SearchController):
@@ -63,6 +10,7 @@ class ConsumerGroupSearch(SearchController):
         super(ConsumerGroupSearch, self).__init__(
             managers_factory.consumer_group_query_manager().find_by_criteria)
 
+    # seems like the auth_required misses here. need to fix that in django
     def GET(self):
         items = self._get_query_results_from_get()
         for item in items:
@@ -74,45 +22,8 @@ class ConsumerGroupSearch(SearchController):
         for item in items:
             item.update(serialization.link.search_safe_link_obj(item['id']))
         return self.ok(items)
-
-
-def verify_group_resources(group_id, repo_id, distributor_id):
-    """
-    Confirm the group, repository, and distributor exist
-
-    :param group_id:        The consumer group id to verify the existence of
-    :type  group_id:        str
-    :param repo_id:         The repository id to confirm the existence of
-    :type  repo_id:         str
-    :param distributor_id:  The distributor id to confirm the existence of on the repository
-    :type  distributor_id:  str
-
-    :return: A dictionary of the missing resources
-    :rtype:  dict
-    """
-    missing_resources = {}
-
-    group_manager = managers_factory.consumer_group_query_manager()
-    repo_manager = managers_factory.repo_query_manager()
-    distributor_manager = managers_factory.repo_distributor_manager()
-    try:
-        group_manager.get_group(group_id)
-    except MissingResource:
-        missing_resources['group_id'] = group_id
-    repo = repo_manager.find_by_id(repo_id)
-    if repo is None:
-        missing_resources['repo_id'] = repo_id
-    try:
-        distributor_manager.get_distributor(repo_id, distributor_id)
-    except MissingResource:
-        missing_resources['distributor_id'] = distributor_id
-
-    return missing_resources
-
-
 _URLS = (
-    '/$', ConsumerGroupCollection,
-    '/search/$', ConsumerGroupSearch,  # resource search
+    '/search/$', ConsumerGroupSearch  # resource search
 )
 
 application = web.application(_URLS, globals())

--- a/server/pulp/server/webservices/controllers/contents.py
+++ b/server/pulp/server/webservices/controllers/contents.py
@@ -1,7 +1,7 @@
 from web.webapi import BadRequest
 import web
 
-from pulp.server.auth.authorization import CREATE, READ, UPDATE
+from pulp.server.auth.authorization import READ, UPDATE
 from pulp.server.content.sources.container import ContentContainer
 from pulp.server.db.model.criteria import Criteria
 from pulp.server.exceptions import MissingResource, OperationPostponed
@@ -129,27 +129,6 @@ class ContentUnitsSearch(SearchController):
         return self.ok(units)
 
 
-class UploadsCollection(JSONController):
-
-    # Scope: Collection
-    # GET:   Retrieve all upload request IDs
-    # POST:  Create a new upload request (and return the ID)
-
-    @auth_required(READ)
-    def GET(self):
-        upload_manager = factory.content_upload_manager()
-        upload_ids = upload_manager.list_upload_ids()
-
-        return self.ok({'upload_ids': upload_ids})
-
-    @auth_required(CREATE)
-    def POST(self):
-        upload_manager = factory.content_upload_manager()
-        upload_id = upload_manager.initialize_upload()
-        location = serialization.link.child_link_obj(upload_id)
-        return self.created(location['_href'], {'_href': location['_href'], 'upload_id': upload_id})
-
-
 class ContentSourceCollection(JSONController):
 
     @auth_required(READ)
@@ -244,7 +223,6 @@ class ContentSourceResource(JSONController):
 
 
 _URLS = ('/units/([^/]+)/search/$', ContentUnitsSearch,
-         '/uploads/$', UploadsCollection,
          '/sources/$', ContentSourceCollection,
          '/sources/action/(refresh)/$', ContentSourceCollection,
          '/sources/([^/]+)/$', ContentSourceResource,

--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -5,12 +5,13 @@ from pulp.server.webservices.views.consumer_groups import (ConsumerGroupAssociat
                                                            ConsumerGroupBindingsView,
                                                            ConsumerGroupContentActionView,
                                                            ConsumerGroupResourceView,
-                                                           ConsumerGroupUnassociateActionView)
+                                                           ConsumerGroupUnassociateActionView,
+                                                           ConsumerGroupView)
 from pulp.server.webservices.views.content import (
     CatalogResourceView, ContentTypeResourceView, ContentTypesView, ContentUnitResourceView,
     ContentUnitsCollectionView,ContentUnitUserMetadataResourceView,
     DeleteOrphansActionView, OrphanCollectionView, OrphanResourceView,
-    OrphanTypeSubCollectionView, UploadResourceView,
+    OrphanTypeSubCollectionView, UploadsCollectionView, UploadResourceView,
     UploadSegmentResourceView
 )
 from pulp.server.webservices.views.dispatch import TaskCollectionView, TaskResourceView
@@ -29,6 +30,7 @@ from pulp.server.webservices.views.users import UserResourceView, UsersView
 
 urlpatterns = patterns('',
     url(r'^v2/actions/login/$', LoginView.as_view(), name='login'), # flake8: noqa
+    url(r'^v2/consumer_groups/$', ConsumerGroupView.as_view(), name='consumer_group'),
     url(r'^v2/consumer_groups/(?P<consumer_group_id>[^/]+)/$',
         ConsumerGroupResourceView.as_view(), name='consumer_group_resource'),
     url(r'^v2/consumer_groups/(?P<consumer_group_id>[^/]+)/actions/associate/$',
@@ -61,6 +63,7 @@ urlpatterns = patterns('',
         ContentUnitResourceView.as_view(), name='content_unit_resource'),
     url(r'^v2/content/units/(?P<type_id>[^/]+)/(?P<unit_id>[^/]+)/pulp_user_metadata/$',
         ContentUnitUserMetadataResourceView.as_view(), name='content_unit_user_metadata_resource'),
+    url(r'^v2/content/uploads/$', UploadsCollectionView.as_view(), name='content_uploads'),
     url(r'^v2/content/uploads/(?P<upload_id>[^/]+)/$', UploadResourceView.as_view(),
         name='content_upload_resource'),
     url(r'^v2/content/uploads/(?P<upload_id>[^/]+)/(?P<offset>[^/]+)/$',

--- a/server/test/unit/server/webservices/test_urls.py
+++ b/server/test/unit/server/webservices/test_urls.py
@@ -146,6 +146,14 @@ class TestDjangoContentUrls(unittest.TestCase):
         url_name = 'content_orphan_type_subcollection'
         assert_url_match(url, url_name, content_type='mock_type')
 
+    def test_match_content_uploads(self):
+        """
+        Test url matching for content_uploads.
+        """
+        url = '/v2/content/uploads/'
+        url_name = 'content_uploads'
+        assert_url_match(url, url_name)
+
 
 class TestDjangoPluginsUrls(unittest.TestCase):
     """
@@ -219,6 +227,14 @@ class TestDjangoConsumerGroupsUrls(unittest.TestCase):
     """
     Tests for consumer_groups urls
     """
+
+    def test_match_consumer_group_view(self):
+        """
+        Test url matching for consumer_groups
+        """
+        url = '/v2/consumer_groups/'
+        url_name = 'consumer_group'
+        assert_url_match(url, url_name)
 
     def test_match_consumer_group_resource_view(self):
         """

--- a/server/test/unit/server/webservices/views/test_content.py
+++ b/server/test/unit/server/webservices/views/test_content.py
@@ -5,14 +5,14 @@ import unittest
 
 from django.http import HttpResponseNotFound
 
-from .base import assert_auth_DELETE, assert_auth_READ, assert_auth_UPDATE
+from .base import assert_auth_CREATE, assert_auth_DELETE, assert_auth_READ, assert_auth_UPDATE
 from pulp.server import constants
 from pulp.server.exceptions import InvalidValue, MissingResource, OperationPostponed
 from pulp.server.webservices.views.content import (
     CatalogResourceView, ContentTypeResourceView, ContentTypesView, ContentUnitResourceView,
     ContentUnitsCollectionView, ContentUnitUserMetadataResourceView, DeleteOrphansActionView,
     OrphanCollectionView, OrphanTypeSubCollectionView, OrphanResourceView, UploadResourceView,
-    UploadSegmentResourceView
+    UploadsCollectionView, UploadSegmentResourceView
 )
 
 
@@ -488,6 +488,9 @@ class TestContentUnitUserMetadataResourceView(unittest.TestCase):
     @mock.patch('pulp.server.webservices.views.content.generate_json_response')
     @mock.patch('pulp.server.webservices.views.content.factory')
     def test_put_content_unit_user_metadata_resource(self, mock_factory, mock_resp):
+        """
+        Test update content unit user metdata resource.
+        """
         request = mock.MagicMock()
         request.body = json.dumps('mock_data')
         mock_cm = mock_factory.content_manager()
@@ -519,6 +522,60 @@ class TestContentUnitUserMetadataResourceView(unittest.TestCase):
         msg = _('No content unit resource: mock_unit')
         mock_resp.assert_called_once_with(msg, HttpResponseNotFound)
         self.assertTrue(response is mock_resp.return_value)
+
+
+class TestUploadsCollectionView(unittest.TestCase):
+    """
+    Tests for views of all uploads.
+    """
+
+    @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
+                new=assert_auth_READ())
+    @mock.patch('pulp.server.webservices.views.content.generate_json_response')
+    @mock.patch('pulp.server.webservices.views.content.factory')
+    def test_get_uploads_collection_view(self, mock_factory, mock_resp):
+        """
+        View should return an response that contains a serialized dict with a list of upload_ids.
+        """
+        mock_upload_manager = mock.MagicMock()
+        mock_upload_manager.list_upload_ids.return_value = ['mock_upload_1', 'mock_upload_2']
+        mock_factory.content_upload_manager.return_value = mock_upload_manager
+        request = mock.MagicMock()
+
+        content_types_view = UploadsCollectionView()
+        response = content_types_view.get(request)
+
+        expected_content = {'upload_ids': ['mock_upload_1', 'mock_upload_2']}
+        mock_resp.assert_called_once_with(expected_content)
+        self.assertTrue(response is mock_resp.return_value)
+
+    @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
+                new=assert_auth_CREATE())
+    @mock.patch('pulp.server.webservices.views.content.generate_redirect_response')
+    @mock.patch('pulp.server.webservices.views.content.generate_json_response')
+    @mock.patch('pulp.server.webservices.views.content.reverse')
+    @mock.patch('pulp.server.webservices.views.content.factory')
+    def test_post_uploads_collection_view(self, mock_factory, mock_reverse, mock_resp,
+                                          mock_redirect):
+        """
+        View post should return a response that contains data for a new upload.
+        """
+        mock_upload_manager = mock.MagicMock()
+        mock_upload_manager.initialize_upload.return_value = 'mock_id'
+        mock_factory.content_upload_manager.return_value = mock_upload_manager
+
+        request = mock.MagicMock()
+        request.body = None
+        mock_reverse.return_value = '/mock/path/'
+
+        content_types_view = UploadsCollectionView()
+        response = content_types_view.post(request)
+
+        self.assertTrue(mock_upload_manager.initialize_upload.called)
+
+        mock_resp.assert_called_once_with({'upload_id': 'mock_id', '_href': '/mock/path/'})
+        mock_redirect.assert_called_once_with(mock_resp.return_value, '/mock/path/')
+        self.assertTrue(response is mock_redirect.return_value)
 
 
 class TestUploadSegmentResourceView(unittest.TestCase):

--- a/server/test/unit/test_contents_controller.py
+++ b/server/test/unit/test_contents_controller.py
@@ -145,45 +145,6 @@ class BaseUploadTest(base.PulpWebserviceTests):
         RepoImporter.get_collection().remove()
 
 
-class UploadsCollectionTests(BaseUploadTest):
-
-    def test_get_no_uploads(self):
-        # Test
-        status, body = self.get('/v2/content/uploads/')
-
-        # Verify
-        self.assertEqual(200, status)
-        self.assertTrue('upload_ids' in body)
-        self.assertEqual([], body['upload_ids'])
-
-    def test_get_uploads(self):
-        # Setup
-        id1 = self.upload_manager.initialize_upload()
-        id2 = self.upload_manager.initialize_upload()
-
-        # Test
-        status, body = self.get('/v2/content/uploads/')
-
-        # Verify
-        self.assertEqual(200, status)
-        self.assertTrue('upload_ids' in body)
-        self.assertTrue(id1 in body['upload_ids'])
-        self.assertTrue(id2 in body['upload_ids'])
-
-    def test_post(self):
-        # Test
-        status, body = self.post('/v2/content/uploads/')
-
-        # Verify
-        self.assertEqual(201, status)
-        self.assertTrue('upload_id' in body)
-        self.assertTrue('_href' in body)
-        self.assertEqual('/v2/content/uploads/%s/' % body['upload_id'], body['_href'])
-
-        upload_file = self.upload_manager._upload_file_path(body['upload_id'])
-        self.assertTrue(os.path.exists(upload_file))
-
-
 class ReservedResourceApplyAsync(object):
     """
     This object allows us to mock the return value of _reserve_resource.apply_async.get().


### PR DESCRIPTION
GET /pulp/api/v2/consumer_groups/ http://fpaste.org/184316/67088614/
POST /pulp/api/v2/consumer_groups/ http://fpaste.org/184326/67157314/
POST missing required param /pulp/api/v2/consumer_groups/  http://fpaste.org/184318/36710061/
POST invalid param /pulp/api/v2/consumer_groups/  http://fpaste.org/184320/36711661/
GET /pulp/api/v2/content/uploads/ http://fpaste.org/184323/71301142/
POST /pulp/api/v2/content/uploads/ http://fpaste.org/184324/67144414/