### PR TITLE
1185868 - allow as_generator to be passed in to get_source_units 

### DIFF
--- a/server/pulp/plugins/conduits/unit_import.py
+++ b/server/pulp/plugins/conduits/unit_import.py
@@ -110,7 +110,7 @@ class ImportUnitConduit(ImporterScratchPadMixin, RepoScratchPadMixin,
             _LOG.exception(_('Content unit association failed [%s]' % str(unit)))
             raise ImporterConduitException(e), None, sys.exc_info()[2]
 
-    def get_source_units(self, criteria=None):
+    def get_source_units(self, criteria=None, as_generator=False):
         """
         Returns the collection of content units associated with the source
         repository for a unit import.
@@ -125,7 +125,8 @@ class ImportUnitConduit(ImporterScratchPadMixin, RepoScratchPadMixin,
         :return: list of unit instances
         :rtype:  list of pulp.plugins.model.AssociatedUnit
         """
-        return mixins.do_get_repo_units(self.source_repo_id, criteria, ImporterConduitException)
+        return mixins.do_get_repo_units(self.source_repo_id, criteria, ImporterConduitException,
+                                        as_generator=as_generator)
 
     def get_destination_units(self, criteria=None):
         """

--- a/server/test/unit/test_unit_import_conduit.py
+++ b/server/test/unit/test_unit_import_conduit.py
@@ -50,7 +50,8 @@ class ImportUnitConduitTests(base.PulpServerTests):
         self.conduit.get_source_units(criteria=criteria)
 
         # Verify the correct propagation to the mixin method
-        mock_get.assert_called_once_with(self.source_repo_id, criteria, ImporterConduitException)
+        mock_get.assert_called_once_with(self.source_repo_id, criteria, ImporterConduitException,
+                                         as_generator=False)
 
     @mock.patch('pulp.plugins.conduits.mixins.do_get_repo_units')
     def test_get_destination_units(self, mock_get):


### PR DESCRIPTION
do_get_repo_units() supports `as_generator` but previously we were unable to
pass this in via get_source_units.