### PR TITLE
BZ1182760 - Add proper SELinux rules for PuppetInstallDistributor

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -109,7 +109,7 @@ optional_policy(`
     tunable_policy(`pulp_manage_puppet', `
         # Puppet modules can contain symlinks, though it seems they often do not. This line allows
         # Pulp to install the symlinks if they are present.
-        allow celery_t puppet_etc_t:lnk_file create;
+        allow celery_t puppet_etc_t:lnk_file { create read getattr unlink };
         manage_dirs_pattern(celery_t, puppet_etc_t, puppet_etc_t)
         manage_files_pattern(celery_t, puppet_etc_t, puppet_etc_t)
     ')


### PR DESCRIPTION
Some puppet modules have symlinks.  celery_t context needs to have permissions to manage creation and removal of symlinks when publishing using the PuppetInstallDistributor.