### PR TITLE
Emit event notifications when TaskStatus is saved or updated.

### DIFF
--- a/docs/dev-guide/integration/events/amqp.rst
+++ b/docs/dev-guide/integration/events/amqp.rst
@@ -1,6 +1,9 @@
 AMQP Notifier
 ==============
 
+.. deprecated:: 2.7
+   This page describes a notification framework that has been deprecated and will go away in Pulp 3.0.
+
 The AMQP notifier is used to send Pulp events to an AMQP message broker. Messages
 are sent to a topic exchange. Each message "subject" starts with "pulp.server"
 and is then followed by the full message type, such as "repo.sync.finish" to

--- a/docs/dev-guide/integration/events/email.rst
+++ b/docs/dev-guide/integration/events/email.rst
@@ -1,5 +1,7 @@
 Email Notifier
 ==============
+.. deprecated:: 2.7
+   This pages describes a notification framework that has been deprecated and will go away in Pulp 3.0.
 
 The Email notifier is used to send an email to specified recipients every time
 a particular event type fires. The body of the email will be a JSON serialized

--- a/docs/dev-guide/integration/events/http.rst
+++ b/docs/dev-guide/integration/events/http.rst
@@ -1,6 +1,9 @@
 HTTP Notifier
 =================
 
+.. deprecated:: 2.7
+   This page describes a notification framework that has been deprecated and will go away in Pulp 3.0.
+
 The HTTP notifier is used to trigger a callback to a URL when the
 event fires. The callback is a POST operation, and the body of the call will
 be the contents of the event (and thus vary by type).

--- a/docs/dev-guide/integration/events/index.rst
+++ b/docs/dev-guide/integration/events/index.rst
@@ -3,15 +3,27 @@
 Events
 ======
 
-The Pulp server has the ability to fire events as a response to various actions
-taking place in the server. Event listeners are configured to respond to these
-events. The event listener's "notifier" is the action that will handle the
-event, such as sending a message describing the event over a message bus
-or invoking an HTTP callback. Each event listener is the pairing of a notifier
-type, its configuration, and one or more event types to listen for.
+The Pulp server has the ability to fire AMQP events when tasks change their
+status. This is enabled by setting ``event_notifications_enabled`` under
+``[messaging]`` to ``True`` in ``/etc/pulp/server.conf``. Additionally,
+``event_notification_url`` may be set if the notification AMQP server is not
+running locally on port 5672.
+
+Messages are published to the ``pulp.api.v2`` topic exchange. Currently only
+task status updates are published; they have a routing key of ``tasks.<task
+uuid>``. This allows a message consumer to only subscribe to updates for tasks
+they are interested in.
+
+The body of the message is a TaskStatus object in JSON form. It typically
+contains the task's ID, task status and detailed information about the task's
+progress.
+
 
 Notifiers
 ---------
+
+.. deprecated:: 2.7
+   This section describes a notification framework that has been deprecated and will go away in Pulp 3.0.
 
 .. toctree::
    :maxdepth: 1
@@ -22,6 +34,9 @@ Notifiers
 
 Event Types
 -----------
+
+.. deprecated:: 2.7
+   This section describes a notification framework that has been deprecated and will go away in Pulp 3.0.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/dev-guide/integration/events/repo-action-events.rst
+++ b/docs/dev-guide/integration/events/repo-action-events.rst
@@ -1,6 +1,9 @@
 Repository Synchronize and Publish Events
 =========================================
 
+.. deprecated:: 2.7
+   This page describes a notification framework that has been deprecated and will go away in Pulp 3.0.
+
 The following events are related to repo sync and publish operations.
 
 Repository Sync Started

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -11,3 +11,5 @@ New Features
 - The repo authentication functionality previously associated with pulp_rpm has
   been moved to platform. This makes it available for other plugins to use.
 
+- A new event notification framework is available. Please see
+  :ref:`the developer documentation <event>` for more detail.

--- a/server/pulp/server/async/emit.py
+++ b/server/pulp/server/async/emit.py
@@ -1,0 +1,41 @@
+import logging
+from kombu import Connection, Exchange, Producer
+
+from pulp.server.config import config
+
+DEFAULT_EXCHANGE_NAME = 'pulp.api.v2'
+_logger = logging.getLogger(__name__)
+
+
+def send(document, routing_key=None):
+    """
+    Attempt to send a message to the AMQP broker.
+
+    If we cannot obtain a new connection then the message will be dropped. Note
+    that we do not block when waiting for a connection.
+
+    :param document: the taskstatus Document we want to send
+    :type  document: mongoengine.Document
+    :param routing_key: The routing key for the message
+    :type  routing_key: str
+    """
+
+    # if the user has not enabled notifications, just bail
+    event_notifications_enabled = config.getboolean('messaging', 'event_notifications_enabled')
+    if not event_notifications_enabled:
+        return
+
+    try:
+        payload = document.to_json()
+    except TypeError:
+        _logger.warn("unable to convert document to JSON; event message not sent")
+        return
+
+    broker_url = config.get('messaging', 'event_notification_url')
+
+    notification_topic = Exchange(name=DEFAULT_EXCHANGE_NAME, type='topic')
+
+    with Connection(broker_url) as connection:
+        producer = Producer(connection)
+        producer.maybe_declare(notification_topic)
+        producer.publish(payload, exchange=notification_topic, routing_key=routing_key)

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -58,7 +58,9 @@ _default_values = {
         'auth_enabled': 'true',
         'cacert': '/etc/pki/qpid/ca/ca.crt',
         'clientcert': '/etc/pki/qpid/client/client.pem',
-        'topic_exchange': 'amq.topic'
+        'topic_exchange': 'amq.topic',
+        'event_notifications_enabled': 'false',
+        'event_notification_url': 'qpid://localhost:5672/',
     },
     'security': {
         'cacert': '/etc/pki/pulp/ca.crt',

--- a/server/test/unit/server/async/test_emit.py
+++ b/server/test/unit/server/async/test_emit.py
@@ -1,0 +1,79 @@
+"""
+This module contains tests for the pulp.server.async.emit module.
+"""
+import unittest
+
+import mock
+from pulp.server.async.emit import send
+
+
+class TestEmit(unittest.TestCase):
+
+    @mock.patch('pulp.server.async.emit.config')
+    def test_send_disabled(self, mock_config):
+        """
+        Ensure we bail out immediately if 'event_notifications_enabled' is False
+        """
+        doc = mock.Mock()
+        # NB: 'event_notifications_enabled' is the only config param found via
+        # getboolean() in emit.py
+        mock_config.getboolean.return_value = False
+
+        send(doc)
+
+        assert not doc.to_json.called
+
+    @mock.patch('pulp.server.async.emit._logger')
+    @mock.patch('pulp.server.async.emit.config')
+    def test_send_unserializable(self, mock_config, mock_logger):
+        """
+        Ensure we bail out if doc is not serializable
+        """
+        doc = mock.Mock()
+        doc.to_json.side_effect = TypeError("boom!")
+        mock_config.getboolean.return_value = True
+
+        send(doc)
+
+        mock_logger.warn.assert_called_once_with('unable to convert document to JSON; '
+                                                 'event message not sent')
+
+    @mock.patch('pulp.server.async.emit.config')
+    @mock.patch('pulp.server.async.emit.Connection')
+    @mock.patch('pulp.server.async.emit.Producer')
+    def test_send_other_exception(self, mock_producer, mock_conn, mock_config):
+        """
+        Raise an exception if we get an Exception when sending a message
+        """
+        doc = mock.Mock()
+        doc.to_json.return_value = '{"a": "B"}'
+        mock_config.getboolean.return_value = True
+        mock_config.get.return_value = "amqp://some.amqp.url/"
+        mock_producer.side_effect = Exception("boom!")
+
+        self.assertRaises(Exception, send, doc)
+
+    @mock.patch('pulp.server.async.emit.config')
+    @mock.patch('pulp.server.async.emit.Producer')
+    @mock.patch('pulp.server.async.emit.Connection')
+    @mock.patch('pulp.server.async.emit.Exchange')
+    def test_send(self, mock_exchange, mock_conn, mock_producer, mock_config):
+        """
+        Test a successful send
+        """
+        doc = mock.Mock()
+        doc.to_json.return_value = '{"a": "B"}'
+        mock_config.getboolean.return_value = True
+        mock_config.get.return_value = "amqp://some.amqp.url/"
+
+        mock_exchange_instance = mock.Mock()
+        mock_exchange.return_value = mock_exchange_instance
+
+        mock_producer_instance = mock.Mock()
+        mock_producer.return_value = mock_producer_instance
+
+        send(doc)
+
+        mock_producer_instance.maybe_declare.assert_called_once_with(mock_exchange_instance)
+        mock_producer_instance.publish.assert_called_once_with('{"a": "B"}', routing_key=None,
+                                                               exchange=mock_exchange_instance)


### PR DESCRIPTION
This patch adds new functionality to emit event notifications when TaskStatus
objects are changed. This relies on mongoengine's ``signals`` library; when a
TaskStatus is updated we publish a message.

re #87