### PR TITLE
Set the PR remote to "upstream" instead of "origin".

### DIFF
--- a/playpen/dev-setup.sh
+++ b/playpen/dev-setup.sh
@@ -134,7 +134,7 @@ for r in $REPOS; do
       # Configure the upstream remote
       git remote add -f upstream git@github.com:pulp/$r.git
       # Add the ability to checkout pull requests (git checkout pr/99 will check out #99!)
-      git config --add remote.upstream.fetch '+refs/pull/*/head:refs/remotes/origin/pr/*'
+      git config --add remote.upstream.fetch '+refs/pull/*/head:refs/remotes/upstream/pr/*'
       # Set master's remote to upstream
       git config branch.master.remote upstream
       # Get the latest code from upstream


### PR DESCRIPTION
The pull request remote was accidentally set to origin instead of upstream in the dev-setup.sh
script. This PR fixes the PRs to use the same remote as the other upstream branches.