### PR TITLE
Fix a failing PEP-8 test.

### DIFF
--- a/server/test/unit/server/managers/content/test_upload.py
+++ b/server/test/unit/server/managers/content/test_upload.py
@@ -1,18 +1,5 @@
-# Copyright (c) 2011 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 import os
 import shutil
-
-import mock
 
 from .... import base
 from pulp.devel import mock_plugins


### PR DESCRIPTION
I noticed after merging one of my PEP-8 PRs that due to other changes in master, my merge introduced a failure. I usually run the tests before pushing merges, but this time I forgot, and it bit me!