### PR TITLE
Remove plugins that are part of pulp from the external deps

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -10,13 +10,5 @@
     "qpid-qmf": {
         "version": "0.26-2",
         "platform": ["el6"]
-    },
-    "pulp-docker": {
-        "version": "0.2.2-1",
-        "platform": ["el6", "el7", "fc20", "fc21"]
-    },
-    "python-crane": {
-        "version": "0.2.2-1",
-        "platform": ["el6", "el7", "fc20", "fc21"]
     }
 }


### PR DESCRIPTION
Plugins will be assembled via the ci tooling in pulp_packaging, no need for them to be listed in the external deps anymore