### PR TITLE
Updates bug docs to point users to Redmine

### DIFF
--- a/docs/sphinx/dev-guide/contributing/branching.rst
+++ b/docs/sphinx/dev-guide/contributing/branching.rst
@@ -63,11 +63,8 @@ which point "2.4-dev" will be used for 2.4.3 development.
 Bug Fix Branches
 ----------------
 
-When creating a pull request that fixes a specific bug in bugzilla, a naming
-convention is used for the pull request branch that is merged with the
-development branch. A bugzilla bug fix branch name should contain
-the bugzilla bug number and optionally, a short description may follow the BZ
-number.
+When creating a Pull Request (PR) that fixes a specific bug, title the PR as
+you would the :ref:`git commit message <commit_messages>`.
 
 
 Feature Branches
@@ -93,11 +90,14 @@ that merge, you additionally need to merge forward your commit to all "newer"
 branches. See :ref:`Merging to Multiple Releases <merging-to-multiple-releases>`
 for more information on merging forward from an older branch.
 
+
+.. _commit_messages:
+
 Commit Messages
 ---------------
 
 The primary commit in a bug fix should have a log message that starts with
-'<bz_id> - ', for example ``123456 - fixes a silly bug``.
+'<bug_id> - ', for example ``123456 - fixes a silly bug``.
 
 
 Cherry-picking and Rebasing

--- a/docs/sphinx/dev-guide/contributing/bugs.rst
+++ b/docs/sphinx/dev-guide/contributing/bugs.rst
@@ -4,17 +4,34 @@ Bugs
 Reporting
 ---------
 
-Bugs must be filed against "Pulp" in the bugzilla entry's *Product* field.
+Pulp bugs are tracked in `Pulp's Redmine instance <https://pulp.plan.io/>`_.
+You can `view existing bugs <https://pulp.plan.io/projects/pulp/issues>`_, or
+`file a new bug <https://pulp.plan.io/projects/pulp/issues/new>`_.
 
-Please try to select the closest corresponding component in the *Components* field.
+.. warning::
+  Security related bugs need to be marked as private when reported. Use the
+  private checkbox (top right) for this. Consider also setting the tag 'Security'.
 
-The *Version* field will have an entry for each Pulp release (2.0.6, 2.0.7, 2.1.0, etc.).
-If a bug is found when running from source instead of a released version, the "Master"
-value should be selected.
+If you are filing an issue or defect, select ``Issue`` as the *Tracker*. If you
+are filing a feature request, select *Story*.
 
-Once a week (typically on Wednesday), the Pulp team triages all new bugs, at which point
-the bug may be aligned to a different component and its *Severity* rating will be evaluated.
-If necessary, the bug may be marked as ``NEEDINFO`` if more clarification is requested.
+Fill in the *Subject* and *Description*. Leave the status at ``NEW``. Please
+select the closest corresponding component, if any, using the *Components*
+field. Select the *Severity* field and any tags based on your best judgement.
+
+Use the *Version* field to indicate which Pulp version you are using. It has an entry
+for each Pulp release (2.0.6, 2.0.7, 2.1.0, etc.). If a bug is found when running
+from source instead of a released version, the value "Master" should be selected.
+
+You can also upload attachments, but please only upload relevant data. For
+example, if you have an entire log which contains some errors, please trim it
+to just the relevant portions and upload those.
+
+Once a week, the Pulp team triages all new bugs, at which point its
+*Severity* rating and other aspects of the report will be evaluated. If
+necessary, the bug may be commented in requesting more information or
+clarification from the reporter. When a bug has enough information, it has
+its *Priority* rating set and is marked as triaged using the 'Triaged' boolean.
 
 
 Fixing
@@ -28,10 +45,10 @@ Developer
 #. Once the bug has been triaged and assigned to a developer, the state of the bug is set to
    ``ASSIGNED``.
 #. The developer creates a new remote branch for the bug on their GitHub fork. The name of the
-   branch should be the number of the bugzilla entry.
+   branch should be the number of the bug entry.
    Example: 123456
 #. When the fix is complete, the developer submits a pull request for the bug into the appropriate
-   branch (master, release branch, etc.). It's appreciated by the reviewer if a link to the bugzilla
+   branch (master, release branch, etc.). It's appreciated by the reviewer if a link to the bug
    is included in the merge request, as well as a brief description of what the change is. It is
    not required to find and assign someone to do the review.
 #. When the pull request is submitted, the developer changes the status of the bug to ``POST``.

--- a/docs/sphinx/dev-guide/contributing/merging.rst
+++ b/docs/sphinx/dev-guide/contributing/merging.rst
@@ -15,11 +15,11 @@ On the GitHub page for the repo where your development branch lives, there will 
 a "Pull Request" button. Click it. From there you will choose the source and
 destination branches.
 
-If there is a bugzilla issue, please title the pull request "<bz_id> -
+If there is a bug for this issue, please title the pull request "<bug_id> -
 Short Message". In the comment section below, please include a link to the
 issue. Use of GitHub's markdown for the link is prefered. Example:
-``[BZ-123456](http://link.tobug)`` Additionally, please also include a link to the
-pull request in the bugzilla comments.
+``[Issue 123456](https://link.tobug)`` Additionally, please also include a
+link to the pull request in the bugs notes.
 
 
 For details about using pull requests, see GitHub's


### PR DESCRIPTION
This PR will get merged forward to 2.5-release -> 2.5-testing -> 2.5-dev -> 2.6-dev -> master. I'm also manually going to merge this into 2.6-testing -> 2.6-dev -> master.

That will not introduce anything except this commit and its resolved conflicts into 2.6-dev because the parent of this commit is the merge-base for 2.5-release and 2.6-testing. That means it's the most recent commit that is in the history of both 2.5-release and 2.6-testing so any commits onto the branch (ie: this one) will only bring in the expected commit to both release streams.