### PR TITLE
Add blinker dependency to setup.py

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -15,6 +15,6 @@ setup(
         ]
     },
     install_requires=[
-        'celery >=3.1.0, <3.2.0', 'httplib2', 'iniparse', 'isodate>=0.5.0', 'm2crypto',
+        'blinker', 'celery >=3.1.0, <3.2.0', 'httplib2', 'iniparse', 'isodate>=0.5.0', 'm2crypto',
         'mongoengine>=0.7.10', 'oauth2>=1.5.211', 'pymongo>=2.5.2', 'setuptools', 'web.py']
 )


### PR DESCRIPTION
Pulp_python unit tests were emitting error messages due to this dep being
missing. Blinker is needed for mongoengine signals to work.