### PR TITLE
Fix error during pulp-selinux uninstall

### DIFF
--- a/server/selinux/server/uninstall.sh
+++ b/server/selinux/server/uninstall.sh
@@ -12,6 +12,4 @@ do
         /usr/sbin/semodule -s ${selinuxvariant} -r ${NAME} &> /dev/null || :
         rm -f ${INSTALL_DIR}/${selinuxvariant}/${NAME}.pp
     done
-
-    rm -f ${INSTALL_DIR}/selinux/devel/include/${MODULE_TYPE}/${NAME}.if
 done


### PR DESCRIPTION
The `uninstall.sh` script was removing two `.if` files which were also
controlled by RPM. These should only be cleaned up by RPM itself.

re #554