### PR TITLE
add flake8 to dev setup

### DIFF
--- a/docs/dev-guide/contributing/dev_setup.rst
+++ b/docs/dev-guide/contributing/dev_setup.rst
@@ -62,7 +62,7 @@ the latest dependencies according to the spec file.
    
    $ sudo yum install python-setuptools redhat-lsb mongodb mongodb-server \
           qpid-cpp-server qpid-cpp-server-store python-qpid-qmf python-nose \
-          python-mock python-paste python-pip
+          python-mock python-paste python-pip python-flake8
 
 The only caveat to this approach is that these dependencies will need to be maintained after this
 initial setup. Leaving the testing builds repository enabled will cause them to be automatically

--- a/playpen/dev-setup.sh
+++ b/playpen/dev-setup.sh
@@ -57,7 +57,7 @@ sudo yum install -y @pulp-server-qpid @pulp-admin @pulp-consumer
 sudo yum remove -y pulp-\* python-pulp\*
 sudo yum install -y python-setuptools redhat-lsb mongodb mongodb-server \
                     qpid-cpp-server qpid-cpp-server-store python-qpid-qmf \
-                    git python-pip python-nose python-mock python-paste
+                    git python-pip python-nose python-mock python-paste python-flake8
 sudo yum-config-manager --disable pulp-2.6-testing > /dev/null
 
 echo "installing newer kombu (temporary step until 2.6.0 is in testing repo)"


### PR DESCRIPTION
Since we now use flake8 in the tests, it is a dep for developers.

closes  https://pulp.plan.io/issues/300