### PR TITLE
Added SELinux rules to restrict pid and tmp file management

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -174,12 +174,12 @@ mkdir -p %{buildroot}/%{_sysconfdir}/default/
 mkdir -p %{buildroot}/%{_sysconfdir}/httpd/conf.d/
 mkdir -p %{buildroot}/%{_usr}/lib/%{name}/plugins
 mkdir -p %{buildroot}/%{_usr}/lib/%{name}/plugins/types
-mkdir -p %{buildroot}/%{_var}/lib/%{name}/celery
 mkdir -p %{buildroot}/%{_var}/lib/%{name}/uploads
 mkdir -p %{buildroot}/%{_var}/lib/%{name}/published
 mkdir -p %{buildroot}/%{_var}/lib/%{name}/static
 mkdir -p %{buildroot}/%{_var}/www
 mkdir -p %{buildroot}/%{_var}/cache/%{name}
+mkdir -p %{buildroot}/%{_var}/run/%{name}
 # These directories are used for Nodes
 mkdir -p %{buildroot}/%{_var}/lib/%{name}/nodes/published/http
 mkdir -p %{buildroot}/%{_var}/lib/%{name}/nodes/published/https
@@ -384,13 +384,13 @@ Pulp provides replication, access, and accounting for software repositories.
 # - apache:apache
 %defattr(-,apache,apache,-)
 %dir %{_var}/lib/%{name}
-%{_var}/lib/%{name}/celery
 %{_var}/lib/%{name}/published
 %{_var}/lib/%{name}/static
 %{_var}/lib/%{name}/uploads
 %dir %{_var}/log/%{name}
 %{_var}/www/pub
 %{_var}/cache/%{name}/
+%{_var}/run/%{name}/
 # Install the docs
 %defattr(-,root,root,-)
 %doc README LICENSE COPYRIGHT

--- a/server/etc/default/upstart_pulp_celerybeat
+++ b/server/etc/default/upstart_pulp_celerybeat
@@ -9,7 +9,7 @@ CELERYBEAT_LOG_LEVEL="INFO"
 # CELERYBEAT_PID_FILE="/var/run/pulp/celerybeat.pid"
 
 # The user that Celerybeat runs as must be able to write to this folder
-CELERYBEAT_OPTS="--workdir=/var/lib/pulp/celery/"
+CELERYBEAT_OPTS="--workdir=/var/run/pulp/"
 
 # Configure Python's encoding for writing all logs, stdout and stderr
 PYTHONIOENCODING="UTF-8"

--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -38,7 +38,7 @@ fi
 SCRIPT_NAME="$(basename "$SCRIPT_FILE")"
 
 DEFAULT_USER="celery"
-DEFAULT_PID_FILE="/var/run/celery/%n.pid"
+DEFAULT_PID_FILE="/var/run/pulp/%n.pid"
 DEFAULT_LOG_FILE="/var/log/celery/%n.log"
 DEFAULT_LOG_LEVEL="INFO"
 DEFAULT_NODES="celery"

--- a/server/pulp/server/async/manage_workers.py
+++ b/server/pulp/server/async/manage_workers.py
@@ -31,9 +31,9 @@ After=network.target
 [Service]
 EnvironmentFile=%(environment_file)s
 User=apache
-WorkingDirectory=/var/lib/pulp/celery/
+WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -n reserved_resource_worker-%(num)s@%%%%h -A pulp.server.async.app\
-          -c 1 --events --umask 18
+          -c 1 --events --umask 18 --pidfile=/var/run/pulp/reserved_resource_worker-%(num)s.pid
 KillSignal=SIGQUIT
 """
 

--- a/server/selinux/server/pulp-celery.fc
+++ b/server/selinux/server/pulp-celery.fc
@@ -2,3 +2,4 @@
 /usr/bin/celery -- gen_context(system_u:object_r:celery_exec_t,s0)
 # Pulp celery workers need to manage temporary files in /var/cache/pulp
 /var/cache/pulp(/.*)? gen_context(system_u:object_r:pulp_var_cache_t,s0)
+/var/run/pulp(/.*)? gen_context(system_u:object_r:pulp_var_run_t,s0)

--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -8,12 +8,19 @@ init_daemon_domain(celery_t, celery_exec_t)
 type pulp_var_cache_t;
 files_type(pulp_var_cache_t)
 
+type pulp_var_run_t;
+files_pid_file(pulp_var_run_t)
+
+type pulp_tmp_t;
+files_tmp_file(pulp_tmp_t)
+
 require {
         type celery_t;
+        type pulp_var_run_t;
+        type pulp_tmp_t;
         type pulp_var_cache_t;
         type pulp_cert_t;
         type puppet_etc_t;
-        type var_run_t;
         class dir { getattr search write remove_name create add_name rmdir };
         class file { lock rename write setattr getattr read create unlink open };
         class process { setsched signal signull };
@@ -40,8 +47,17 @@ allow celery_t self:unix_dgram_socket { create connect };
 #
 
 allow celery_t self:process { setsched };
-allow celery_t tmp_t:dir { write remove_name create add_name rmdir setattr };
-allow celery_t tmp_t:file { rename create unlink setattr write read getattr open lock };
+
+allow celery_t pulp_tmp_t:dir manage_dir_perms;
+files_tmp_filetrans(celery_t, pulp_tmp_t, dir)
+
+allow celery_t pulp_tmp_t:file manage_file_perms;
+files_tmp_filetrans(celery_t, pulp_tmp_t, file)
+
+allow celery_t pulp_var_run_t:file manage_file_perms;
+files_pid_filetrans(celery_t, pulp_var_run_t, file)
+
+
 
 ifndef(`distro_rhel6', `
     fs_getattr_xattr_fs(celery_t)
@@ -74,7 +90,6 @@ manage_files_pattern(celery_t, pulp_var_cache_t, pulp_var_cache_t)
 
 ######################################
 
-allow celery_t var_run_t:file { write getattr read create unlink open };
 apache_delete_sys_content_rw(celery_t)
 apache_list_sys_content(celery_t)
 apache_manage_sys_content_rw(celery_t)
@@ -83,7 +98,6 @@ corecmd_exec_bin(celery_t)
 corecmd_exec_shell(celery_t)
 corecmd_read_bin_symlinks(celery_t)
 dev_read_urand(celery_t)
-files_list_tmp(celery_t)
 files_rw_pid_dirs(celery_t)
 kernel_read_system_state(celery_t)
 libs_exec_ldconfig(celery_t)

--- a/server/usr/lib/systemd/system/pulp_celerybeat.service
+++ b/server/usr/lib/systemd/system/pulp_celerybeat.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/default/pulp_celerybeat
 User=apache
-WorkingDirectory=/var/lib/pulp/celery/
+WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery beat --app=pulp.server.async.celery_instance.celery --scheduler=pulp.server.async.scheduler.Scheduler
 
 [Install]

--- a/server/usr/lib/systemd/system/pulp_resource_manager.service
+++ b/server/usr/lib/systemd/system/pulp_resource_manager.service
@@ -5,9 +5,9 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/default/pulp_resource_manager
 User=apache
-WorkingDirectory=/var/lib/pulp/celery/
+WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -A pulp.server.async.app -n resource_manager@%%h\
-          -Q resource_manager -c 1 --events --umask 18
+          -Q resource_manager -c 1 --events --umask 18 --pidfile=/var/run/pulp/resource_manager.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/server/usr/lib/systemd/system/pulp_workers.service
+++ b/server/usr/lib/systemd/system/pulp_workers.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 Type=oneshot
 RemainAfterExit=true
+WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/libexec/pulp-manage-workers start
 ExecStop=/usr/libexec/pulp-manage-workers stop
 


### PR DESCRIPTION
This patch also adds back some lines of pulp.spec file that were
accidently removed in
https://github.com/pulp/pulp/commit/f4d2de05d58f71e9baccd18e0ce8020c3e80d6fb