### PR TITLE
Upstart use stop/start instead of restart_workers.

### DIFF
--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -251,6 +251,10 @@ case "$1" in
         check_paths
         stop_beat
         check_dev_null
+        write_log_message "**********************************************************"
+        write_log_message "* Celerybeat startup requested. After startup is         *"
+        write_log_message "* complete, messages will be logged to /var/log/messages.*"
+        write_log_message "**********************************************************"
         start_beat
     ;;
     status)

--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -228,16 +228,6 @@ stop_workers () {
 }
 
 
-restart_workers () {
-    _chuid restart $CELERYD_NODES -QUIT $DAEMON_OPTS      \
-                   --pidfile="$CELERYD_PID_FILE"    \
-                   --logfile="$CELERYD_LOG_FILE"    \
-                   --loglevel="$CELERYD_LOG_LEVEL"  \
-                   $CELERY_APP_ARG                  \
-                   $CELERYD_OPTS
-}
-
-
 kill_workers() {
     _chuid kill $CELERYD_NODES --pidfile="$CELERYD_PID_FILE"
 }
@@ -323,7 +313,12 @@ case "$1" in
     restart)
         check_dev_null
         check_paths
-        restart_workers
+        stop_workers
+        write_log_message "********************************************************"
+        write_log_message "* Celery startup requested. After startup is complete, *"
+        write_log_message "* messages will be logged to /var/log/messages.        *"
+        write_log_message "********************************************************"
+        start_workers
     ;;
 
     graceful)


### PR DESCRIPTION
This commit updates our Upstart init scripts to call stop_workers and
then start_workers, instead of restart_workers(). There seems to be an
issue with Celery multi, restarting, and Pulp. This commit works around
that issue by fully stopping the workers instead of issuing a restart to
them.

https://pulp.plan.io/issues/686

closes #686