### PR TITLE
636 - API delete nonexisting upload_id now returns 404

### DIFF
--- a/server/pulp/server/managers/content/upload.py
+++ b/server/pulp/server/managers/content/upload.py
@@ -93,15 +93,19 @@ class ContentUploadManager(object):
         """
         Deletes all files associated with the given upload request. If the
         upload request does not exist or has already been deleted, this call
-        has no effect.
+        will raise MissingResource.
 
         @param upload_id: upload request ID
         @type  upload_id: str
+
+        @raise MissingResource: if the upload request ID does not exist
         """
 
         file_path = ContentUploadManager._upload_file_path(upload_id)
         if os.path.exists(file_path):
             os.remove(file_path)
+        else:
+            raise MissingResource(upload_id=upload_id)
 
     def read_upload(self, upload_id):
         """

--- a/server/test/unit/server/managers/content/test_upload.py
+++ b/server/test/unit/server/managers/content/test_upload.py
@@ -109,6 +109,17 @@ class ContentUploadManagerTests(base.PulpServerTests):
         # Verify
         self.assertTrue(not os.path.exists(uploaded_filename))
 
+    def test_delete_non_existent_upload(self):
+
+        # Setup
+        upload_id = '1234'
+
+        uploaded_filename = self.upload_manager._upload_file_path(upload_id)
+        self.assertFalse(os.path.exists(uploaded_filename))
+
+        # Test
+        self.assertRaises(MissingResource, self.upload_manager.delete_upload, upload_id)
+
     def test_list_upload_ids(self):
 
         # Test - Empty


### PR DESCRIPTION
(as mentioned in docs)
closes [636] (https://pulp.plan.io/issues/636)