### PR TITLE
fallback to config wrap width when unable to access tty size, closes 335

### DIFF
--- a/client_lib/pulp/client/extensions/core.py
+++ b/client_lib/pulp/client/extensions/core.py
@@ -59,9 +59,14 @@ ABORT = okaara.prompt.ABORT
 
 class PulpPrompt(Prompt):
     def __init__(self, input=sys.stdin, output=sys.stdout, enable_color=True,
-                 wrap_width=80, record_tags=False):
-        Prompt.__init__(self, input=input, output=output, enable_color=enable_color,
-                        wrap_width=wrap_width, record_tags=record_tags)
+                 wrap_width=80, record_tags=False, fallback_wrap=80):
+        try:
+            Prompt.__init__(self, input=input, output=output, enable_color=enable_color,
+                            wrap_width=wrap_width, record_tags=record_tags)
+        except IOError:
+            print "\nUnable to access tty size, continuing with wrap width.\n"
+            Prompt.__init__(self, input=input, output=output, enable_color=enable_color,
+                            wrap_width=fallback_wrap, record_tags=record_tags)
 
         # Shadowed for another alternative to referencing it
         self.ABORT = ABORT

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -232,10 +232,11 @@ def _create_prompt(config):
 
     enable_color = config.parse_bool(config['output']['enable_color'])
 
+    fallback_wrap = int(config['output']['wrap_width'])
     if config.parse_bool(config['output']['wrap_to_terminal']):
         wrap = WIDTH_TERMINAL
     else:
-        wrap = int(config['output']['wrap_width'])
+        wrap = fallback_wrap
 
-    prompt = PulpPrompt(enable_color=enable_color, wrap_width=wrap)
+    prompt = PulpPrompt(enable_color=enable_color, wrap_width=wrap, fallback_wrap=fallback_wrap)
     return prompt


### PR DESCRIPTION
Using an ssh client to execute pulp-admin commands caused a traceback if `wrap_to_terminal` in  `/etc/pulp/admin/admin.conf` was set to `true`. There is no way to get the terminal size in this case because the command is being run without a tty device, so we should fall back to the `wrap_width` specified in `admin.conf`