### PR TITLE
added -v and -vv options to admin and consumer clients to get info and d...

### DIFF
--- a/client_admin/etc/pulp/admin/admin.conf
+++ b/client_admin/etc/pulp/admin/admin.conf
@@ -58,18 +58,6 @@
 # upload_working_dir: ~/.pulp/uploads
 
 
-# Client logging.
-#
-# filename:
-#   The location of the admin client log file.
-# call_log_filename:
-#   If present, the raw REST responses will be logged to the given file.
-
-[logging]
-# filename: ~/.pulp/admin.log
-# call_log_filename: ~/.pulp/server_calls.log
-
-
 # Admin client output.
 #
 # poll_frequency_in_seconds:

--- a/client_admin/pulp/client/admin/config.py
+++ b/client_admin/pulp/client/admin/config.py
@@ -22,10 +22,6 @@ DEFAULT = {
         'id_cert_filename': 'user-cert.pem',
         'upload_working_dir': '~/.pulp/uploads',
     },
-    'logging': {
-        'filename': '~/.pulp/admin.log',
-        'call_log_filename': '~/.pulp/server_calls.log',
-    },
     'output': {
         'poll_frequency_in_seconds': '1',
         'enable_color': 'true',
@@ -57,12 +53,6 @@ SCHEMA = (
             ('id_cert_dir', REQUIRED, ANY),
             ('id_cert_filename', REQUIRED, ANY),
             ('upload_working_dir', REQUIRED, ANY),
-        )
-     ),
-    ('logging', REQUIRED,
-        (
-            ('filename', REQUIRED, ANY),
-            ('call_log_filename', OPTIONAL, ANY)
         )
      ),
     ('output', REQUIRED,

--- a/client_consumer/etc/pulp/consumer/consumer.conf
+++ b/client_consumer/etc/pulp/consumer/consumer.conf
@@ -95,18 +95,6 @@
 # delay: 3
 
 
-# Client logging.
-#
-# filename:
-#   The location of the consumer client log file.
-# call_log_filename:
-#   If present, the raw REST responses will be logged to the given file.
-
-[logging]
-# filename: ~/.pulp/consumer.log
-# call_log_filename: ~/.pulp/consumer_server_calls.log
-
-
 # Consumer client output.
 #
 # poll_frequency_in_seconds:

--- a/client_consumer/pulp/client/consumer/config.py
+++ b/client_consumer/pulp/client/consumer/config.py
@@ -43,10 +43,6 @@ DEFAULT = {
         'permit': 'false',
         'delay': '3',
     },
-    'logging': {
-        'filename': '~/.pulp/consumer.log',
-        'call_log_filename': '~/.pulp/consumer_server_calls.log',
-    },
     'output': {
         'poll_frequency_in_seconds': '1',
         'enable_color': 'true',
@@ -104,12 +100,6 @@ SCHEMA = (
         (
             ('permit', REQUIRED, BOOL),
             ('delay', REQUIRED, NUMBER),
-        )
-    ),
-    ('logging', REQUIRED,
-        (
-            ('filename', REQUIRED, ANY),
-            ('call_log_filename', OPTIONAL, ANY)
         )
     ),
     ('output', REQUIRED,

--- a/client_lib/pulp/client/extensions/exceptions.py
+++ b/client_lib/pulp/client/extensions/exceptions.py
@@ -125,8 +125,7 @@ class ExceptionHandler:
             self.prompt.render_failure_message(msg)
 
             self.prompt.render_failure_message('   %s' % e.error_message)
-            msg = _('More information can be found in the client log file %(l)s.')
-            msg = msg % {'l': self._log_filename()}
+            msg = _('More information may be found using the -v flag.')
 
         self.prompt.render_failure_message(msg)
         return CODE_BAD_REQUEST
@@ -139,7 +138,7 @@ class ExceptionHandler:
         :type  e: dictionary containing error information.
         """
         malformed_msg = _('Request error does not contain a description, '
-                          'please check client logs for more information.')
+                          'please use -v option for more information.')
         self.prompt.render_failure_message('%s' % (e.get('description', malformed_msg)))
         for suberror in e.get('sub_errors', []):
             self._display_coded_error(suberror)
@@ -196,9 +195,8 @@ class ExceptionHandler:
                 msg += _('Operation: %(o)s') % {'o': r['operation']}
         else:
             msg = _('The requested operation could not execute due to an unexpected '
-                    'conflict on the server. More information can be found in the '
-                    'client log file %(l)s.')
-            msg = msg % {'l': self._log_filename()}
+                    'conflict on the server. More information may be found using the '
+                    '-v flag.')
 
         self.prompt.render_failure_message(msg)
         return CODE_CONFLICT
@@ -229,8 +227,7 @@ class ExceptionHandler:
         self._log_client_exception(e)
 
         msg = _('An error occurred attempting to contact the server. More information '
-                'can be found in the client log file %(l)s.')
-        msg = msg % {'l': self._log_filename()}
+                'may be found using the -v flag.')
 
         self.prompt.render_failure_message(msg)
         return CODE_CONNECTION_EXCEPTION
@@ -328,8 +325,7 @@ class ExceptionHandler:
             msg = msg % data
         else:
             msg = _('An error occurred attempting to contact the server. More information '
-                    'can be found in the client log file %(l)s.')
-            msg = msg % {'l': self._log_filename()}
+                    'may be found using the -v flag.')
 
         self.prompt.render_failure_message(msg)
         return CODE_SOCKET_ERROR
@@ -427,8 +423,7 @@ class ExceptionHandler:
         self._log_client_exception(e)
 
         msg = _('An unexpected error has occurred. More information '
-                'can be found in the client log file %(l)s.')
-        msg = msg % {'l': self._log_filename()}
+                'may be found using the -v flag.')
 
         self.prompt.render_failure_message(msg)
         return CODE_UNEXPECTED

--- a/client_lib/pulp/client/extensions/exceptions.py
+++ b/client_lib/pulp/client/extensions/exceptions.py
@@ -461,14 +461,6 @@ class ExceptionHandler:
         """
         _logger.exception('Client-side exception occurred')
 
-    def _log_filename(self):
-        """
-        Syntactic sugar for reading the log filename out of the config.
-
-        :return: full path to the log file
-        """
-        return self.config['logging']['filename']
-
     def _certificate_expiration_date(self, full_cert_path):
         """
         Attempts to read and return the expiration date of the certificate at the given

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -152,7 +152,7 @@ def _initialize_logging(verbose=None):
     """
     @return: configured cli logger
     """
-    cli_log_handler = logging.StreamHandler(stream=sys.stderr)
+    cli_log_handler = logging.StreamHandler(sys.stderr)
     cli_log_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
 
     cli_logger = logging.getLogger('pulp')
@@ -190,7 +190,7 @@ def _create_bindings(config, cli_logger, username, password, verbose=None):
 
     api_logger = None
     if verbose and verbose > 1:
-        api_log_handler = logging.StreamHandler(stream=sys.stderr)
+        api_log_handler = logging.StreamHandler(sys.stderr)
         api_log_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
 
         api_logger = logging.getLogger('call_log')

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -101,7 +101,7 @@ def main(config, exception_handler_class=ExceptionHandler):
         extensions_loader.load_extensions(extensions_dir, context, role)
     except extensions_loader.LoadFailed, e:
         prompt.write(_('The following extensions failed to load: %(f)s' % {'f': ', '.join(e.failed_packs)}))
-        prompt.write(_('More information on the failures can be found in %(l)s' % {'l': config['logging']['filename']}))
+        prompt.write(_('More information on the failures may be found by using -v option one or more times'))
         return os.EX_OSFILE
 
     # Launch the appropriate UI (add in shell support here later)

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -45,19 +45,19 @@ def main(config, exception_handler_class=ExceptionHandler):
                       help=_('password for the Pulp server; must be used with --username. '
                              'if used will bypass the stored certificate and override a password '
                              'specified in ~/.pulp/admin.conf'))
-    parser.add_option('--debug', dest='debug', action='store_true', default=False,
-                      help=_('enables debug logging'))
     parser.add_option('--config', dest='config', default=None,
                       help=_('absolute path to the configuration file'))
     parser.add_option('--map', dest='print_map', action='store_true', default=False,
                       help=_('prints a map of the CLI sections and commands'))
+    parser.add_option('-v', dest='verbose', action='count',
+                      help=_('enables verbose output; use twice for increased verbosity with debug information'))
 
     options, args = parser.parse_args()
 
     # Configuration and Logging
     if options.config is not None:
         config.update(Config(options.config))
-    logger = _initialize_logging(config, debug=options.debug)
+    logger = _initialize_logging(verbose=options.verbose)
 
     # General UI pieces
     prompt = _create_prompt(config)
@@ -85,7 +85,7 @@ def main(config, exception_handler_class=ExceptionHandler):
             prompt.write(_('Login cancelled'))
             sys.exit(os.EX_NOUSER)
 
-    server = _create_bindings(config, logger, username, password)
+    server = _create_bindings(config, logger, username, password, verbose=options.verbose)
 
     # Client context
     context = ClientContext(server, config, logger, prompt, exception_handler)
@@ -100,8 +100,8 @@ def main(config, exception_handler_class=ExceptionHandler):
     try:
         extensions_loader.load_extensions(extensions_dir, context, role)
     except extensions_loader.LoadFailed, e:
-        prompt.write(_('The following extensions failed to load: %(f)s' % {'f' : ', '.join(e.failed_packs)}))
-        prompt.write(_('More information on the failures can be found in %(l)s' % {'l' : config['logging']['filename']}))
+        prompt.write(_('The following extensions failed to load: %(f)s' % {'f': ', '.join(e.failed_packs)}))
+        prompt.write(_('More information on the failures can be found in %(l)s' % {'l': config['logging']['filename']}))
         return os.EX_OSFILE
 
     # Launch the appropriate UI (add in shell support here later)
@@ -148,34 +148,27 @@ def ensure_user_pulp_dir():
             sys.exit(1)
 
 
-def _initialize_logging(config, debug=False):
+def _initialize_logging(verbose=None):
     """
-    @return: configured logger
+    @return: configured cli logger
     """
+    cli_log_handler = logging.StreamHandler(stream=sys.stderr)
+    cli_log_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
 
-    filename = config['logging']['filename']
-    filename = os.path.expanduser(filename)
+    cli_logger = logging.getLogger('pulp')
+    cli_logger.addHandler(cli_log_handler)
 
-    # Make sure the parent directories for the log files exist
-    dirname = os.path.dirname(filename)
-    if not os.path.exists(dirname):
-        os.makedirs(dirname)
-
-    handler = logging.handlers.RotatingFileHandler(filename, mode='w', maxBytes=1048576, backupCount=2)
-    handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-
-    pulp_log = logging.getLogger('pulp')
-    pulp_log.addHandler(handler)
-
-    if debug:
-        pulp_log.setLevel(logging.DEBUG)
+    if not verbose:
+        cli_logger.setLevel(logging.FATAL)
+    elif verbose == 1:
+        cli_logger.setLevel(logging.INFO)
     else:
-        pulp_log.setLevel(logging.INFO)
+        cli_logger.setLevel(logging.DEBUG)
 
-    return pulp_log
+    return cli_logger
 
 
-def _create_bindings(config, logger, username, password):
+def _create_bindings(config, cli_logger, username, password, verbose=None):
     """
     @return: bindings with a fully configured Pulp connection
     @rtype:  pulp.bindings.bindings.Bindings
@@ -188,36 +181,28 @@ def _create_bindings(config, logger, username, password):
     cert_dir = config['filesystem']['id_cert_dir']
     cert_name = config['filesystem']['id_cert_filename']
 
-    cert_dir = os.path.expanduser(cert_dir) # this will likely be in a user directory
+    cert_dir = os.path.expanduser(cert_dir)  # this will likely be in a user directory
     cert_filename = os.path.join(cert_dir, cert_name)
 
     # If the certificate doesn't exist, don't pass it to the connection creation
     if not os.path.exists(cert_filename):
         cert_filename = None
 
-    call_log = None
-    if config.has_option('logging', 'call_log_filename'):
-        filename = config['logging']['call_log_filename']
-        filename = os.path.expanduser(filename) # also likely in a user dir
+    api_logger = None
+    if verbose and verbose > 1:
+        api_log_handler = logging.StreamHandler(stream=sys.stderr)
+        api_log_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
 
-        # Make sure the parent directories for the log files exist
-        dirname = os.path.dirname(filename)
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
-
-        handler = logging.handlers.RotatingFileHandler(filename, mode='w', maxBytes=1048576, backupCount=2)
-        handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-
-        call_log = logging.getLogger('call_log')
-        call_log.addHandler(handler)
-        call_log.setLevel(logging.INFO)
+        api_logger = logging.getLogger('call_log')
+        api_logger.addHandler(api_log_handler)
+        api_logger.setLevel(logging.INFO)
 
     # Create the connection and bindings
     verify_ssl = config.parse_bool(config['server']['verify_ssl'])
     ca_path = config['server']['ca_path']
     conn = PulpConnection(
         hostname, port, username=username, password=password, cert_filename=cert_filename,
-        logger=logger, api_responses_logger=call_log, verify_ssl=verify_ssl,
+        logger=cli_logger, api_responses_logger=api_logger, verify_ssl=verify_ssl,
         ca_path=ca_path)
     bindings = Bindings(conn)
 

--- a/client_lib/test/unit/client/test_launcher.py
+++ b/client_lib/test/unit/client/test_launcher.py
@@ -15,31 +15,6 @@ from pulp.client import constants, launcher
 from pulp.common import config
 
 
-class TestLoggingSetup(unittest.TestCase):
-    """
-    This class contains tests for default logging setup.
-    """
-    def test_initialize_logging_no_verbose(self):
-        cli_logger = launcher._initialize_logging(verbose=None)
-        self.assertEqual(cli_logger.level, logging.FATAL)
-        self._test_handler(cli_logger)
-
-    def test_initialize_logging_verbose(self):
-        cli_logger = launcher._initialize_logging(verbose=1)
-        self.assertEqual(cli_logger.level, logging.INFO)
-        self._test_handler(cli_logger)
-
-    def test_initialize_logging_extra_verbose(self):
-        cli_logger = launcher._initialize_logging(verbose=2)
-        self.assertEqual(cli_logger.level, logging.DEBUG)
-        self._test_handler(cli_logger)
-
-    def _test_handler(self, cli_logger):
-        handler = cli_logger.handlers[0]
-        self.assertEqual(handler.stream, sys.stderr)
-        self.assertEqual(handler.formatter._fmt, logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')._fmt)
-
-
 class TestCreateBindings(unittest.TestCase):
     """
     This class contains tests for the _create_bindings() function.
@@ -92,6 +67,13 @@ class TestCreateBindings(unittest.TestCase):
         bindings = launcher._create_bindings(self.config, None, 'username', 'password', verbose=2)
         api_logger = bindings.bindings.server.api_responses_logger
         handler = api_logger.handlers[0]
+        self.assertEqual(handler.stream, sys.stderr)
+        self.assertEqual(handler.formatter._fmt, logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')._fmt)
+
+    def test_initialize_logging_no_verbose(self):
+        cli_logger = launcher._initialize_logging(verbose=None)
+        self.assertEqual(cli_logger.level, logging.FATAL)
+        handler = cli_logger.handlers[0]
         self.assertEqual(handler.stream, sys.stderr)
         self.assertEqual(handler.formatter._fmt, logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')._fmt)
 

--- a/devel/data/test-override-admin.conf
+++ b/devel/data/test-override-admin.conf
@@ -16,15 +16,6 @@ id_cert_filename = user-cert.pem
 
 # -----------------------
 
-[logging]
-
-filename = /tmp/.pulp/admin.log
-
-# If present, the raw REST reponses will be logged to the given file
-call_log_filename = /tmp/.pulp/server_calls.log
-
-# -----------------------
-
 [output]
 
 # Number of seconds between requests for any operation that repeatedly polls

--- a/docs/user-guide/admin-client/authentication.rst
+++ b/docs/user-guide/admin-client/authentication.rst
@@ -208,8 +208,6 @@ remaining in the system.
 
    	The last superuser [admin] cannot be deleted
 
-	More information can be found in the client log file ~/.pulp/admin.log.
-
 Permissions
 -----------
 

--- a/docs/user-guide/admin-client/introduction.rst
+++ b/docs/user-guide/admin-client/introduction.rst
@@ -88,3 +88,84 @@ under the ``puppet`` command::
 
 As new types are supported, additional root-level sections will be provided in
 their content type bundles.
+
+.. _client-verbose-flag:
+
+Troubleshooting with verbose flag
+---------------------------------
+
+You can run Pulp commands in verbose mode to get additional information in case of a failure.
+Pulp CLI provide -v and -vv options for INFO and DEBUG level information respectively::
+
+ $ pulp-admin --help
+ Usage: pulp-admin [options]
+
+ Options:
+   -h, --help            show this help message and exit
+   -u USERNAME, --username=USERNAME
+                         username for the Pulp server; if used will bypass the
+                         stored certificate and override a username specified
+                         in ~/.pulp/admin.conf
+   -p PASSWORD, --password=PASSWORD
+                         password for the Pulp server; must be used with
+                         --username. if used will bypass the stored certificate
+                         and override a password specified in
+                         ~/.pulp/admin.conf
+   --config=CONFIG       absolute path to the configuration file
+   --map                 prints a map of the CLI sections and commands
+   -v                    enables verbose output; use twice for increased
+                         verbosity with debug information
+
+
+Here is an example of how verbose flag can be used one or more times::
+
+ $ pulp-admin rpm repo create --repo-id test
+ A resource with the ID "test" already exists.
+
+
+ $ pulp-admin -v rpm repo create --repo-id test
+ 2015-03-05 14:10:28,931 - ERROR - Exception occurred:
+        href:      /pulp/api/v2/repositories/
+        method:    POST
+        status:    409
+        error:     Duplicate resource: test
+        traceback: None
+        data:      {u'resource_id': u'test', u'error': {u'code': u'PLP0018', u'data': {u'resource_id': u'test'}, u'description': u'Duplicate resource: test', u'sub_errors': []}}
+
+ A resource with the ID "test" already exists.
+
+
+ $ pulp-admin -vv rpm repo create --repo-id test
+ 2015-03-05 14:12:22,014 - DEBUG - sending POST request to /pulp/api/v2/repositories/
+ 2015-03-05 14:12:22,361 - INFO - POST request to /pulp/api/v2/repositories/ with parameters {"display_name": null, "description": null, "distributors": [{"distributor_id": "yum_distributor", "auto_publish": true, "distributor_config": {"http": false, "relative_url": "test", "https": true}, "distributor_type_id": "yum_distributor"}, {"distributor_id": "export_distributor", "auto_publish": false, "distributor_config": {"http": false, "https": true}, "distributor_type_id": "export_distributor"}], "notes": {"_repo-type": "rpm-repo"}, "importer_type_id": "yum_importer", "importer_config": {}, "id": "test"}
+ 2015-03-05 14:12:22,362 - INFO - Response status : 409
+
+ 2015-03-05 14:12:22,362 - INFO - Response body :
+  {
+   "exception": null,
+   "traceback": null,
+   "_href": "/pulp/api/v2/repositories/",
+   "resource_id": "test",
+   "error_message": "Duplicate resource: test",
+   "http_request_method": "POST",
+   "http_status": 409,
+   "error": {
+     "code": "PLP0018",
+     "data": {
+       "resource_id": "test"
+     },
+     "description": "Duplicate resource: test",
+     "sub_errors": []
+   }
+ }
+
+ 2015-03-05 14:12:22,362 - ERROR - Exception occurred:
+         href:      /pulp/api/v2/repositories/
+         method:    POST
+         status:    409
+         error:     Duplicate resource: test
+         traceback: None
+         data:      {u'resource_id': u'test', u'error': {u'code': u'PLP0018', u'data': {u'resource_id': u'test'}, u'description': u'Duplicate resource: test', u'sub_errors': []}}
+
+ A resource with the ID "test" already exists.
+

--- a/docs/user-guide/consumer-client/introduction.rst
+++ b/docs/user-guide/consumer-client/introduction.rst
@@ -38,3 +38,9 @@ general, this will mean with ``root`` privileges. This is easiest with the
  $ sudo pulp-consumer ...
 
 
+Troubleshooting with verbose flag
+---------------------------------
+
+You can run pulp-consumer commands in verbose mode to get additional information
+in case of a failure. Look at the example usage of verbose flag in the
+:ref:`admin client troubleshooting section <client-verbose-flag>`.

--- a/docs/user-guide/release-notes/master.rst
+++ b/docs/user-guide/release-notes/master.rst
@@ -17,6 +17,13 @@ Deprecation
 Client Changes
 --------------
 
+* Admin and consumer Pulp clients now support -v and -vv flags to get additional
+  information in case of failures. Exceptions raised for CLI and API level
+  failures are not logged to the log files anymore. Instead, you can get the details
+  of the failures on STDERR stream by using verbose flag. You can look at an example
+  of the usage of verbose flag in the
+  :ref:`admin client troubleshooting section <client-verbose-flag>`.
+
 Agent Changes
 -------------
 

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -110,16 +110,8 @@ Some of Pulp's other processes still log to files. Those file locations are docu
   a stack trace or other information that can help a developer determine what
   went wrong.
 
-~/.pulp/admin.log
-  pulp-admin logs its activity here.
-
 ~/.pulp/consumer.log
   pulp-consumer logs its activity here.
-
-~/.pulp/server_calls.log
-  HTTP requests and responses get logged by the admin client in
-  this file. To enable/disable this, consult the ``[logging]`` section of
-  ``/etc/pulp/admin/admin.conf``.
 
 ~/.pulp/consumer_server_calls.log
   HTTP requests and responses get logged by the consumer client in


### PR DESCRIPTION
Debug level output which was going to the logs before

https://pulp.plan.io/issues/145

The behavior now can be summarized as -
------------------------Normal behavior ---------------------------------------
$ pulp-admin rpm repo create --repo-id test
A resource with the ID "test" already exists.

----------------------- with -v flag ---------------------------------------------
$ pulp-admin -v rpm repo create --repo-id test
2015-03-05 01:34:37,817 - ERROR - Exception occurred:
        href:      /pulp/api/v2/repositories/
        method:    POST
        status:    409
        error:     Duplicate resource: test
        traceback: None
        data:      {u'resource_id': u'test', u'error': {u'code': u'PLP0018', u'data': {u'resource_id': u'test'}, u'description': u'Duplicate resource: test', u'sub_errors': []}}
     
A resource with the ID "test" already exists.

-------------------------- with multiple -v flags ----------------------------------

$ pulp-admin -vv rpm repo create --repo-id test
2015-03-05 01:34:42,109 - DEBUG - sending POST request to /pulp/api/v2/repositories/
2015-03-05 01:34:42,325 - INFO - POST request to /pulp/api/v2/repositories/ with parameters {"display_name": null, "description": null, "distributors": [{"distributor_id": "yum_distributor", "auto_publish": true, "distributor_config": {"http": false, "relative_url": "test", "https": true}, "distributor_type_id": "yum_distributor"}, {"distributor_id": "export_distributor", "auto_publish": false, "distributor_config": {"http": false, "https": true}, "distributor_type_id": "export_distributor"}], "notes": {"_repo-type": "rpm-repo"}, "importer_type_id": "yum_importer", "importer_config": {}, "id": "test"}
2015-03-05 01:34:42,325 - INFO - Response status : 409 

2015-03-05 01:34:42,325 - INFO - Response body :
 {
  "exception": null, 
  "traceback": null, 
  "_href": "/pulp/api/v2/repositories/", 
  "resource_id": "test", 
  "error_message": "Duplicate resource: test", 
  "http_request_method": "POST", 
  "http_status": 409, 
  "error": {
    "code": "PLP0018", 
    "data": {
      "resource_id": "test"
    }, 
    "description": "Duplicate resource: test", 
    "sub_errors": []
  }
}

2015-03-05 01:34:42,325 - ERROR - Exception occurred:
        href:      /pulp/api/v2/repositories/
        method:    POST
        status:    409
        error:     Duplicate resource: test
        traceback: None
        data:      {u'resource_id': u'test', u'error': {u'code': u'PLP0018', u'data': {u'resource_id': u'test'}, u'description': u'Duplicate resource: test', u'sub_errors': []}}
        
A resource with the ID "test" already exists.

  