### PR TITLE
split database query in publish_step into multiple smaller ones

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -1055,12 +1055,14 @@ class GetLocalUnitsStep(PluginStep):
         # any units that are already in pulp
         units_we_already_had = set()
 
-        # for any unit that is already in pulp, save it into the repo
-        for unit_dict in self.content_query_manager.get_multiple_units_by_keys_dicts(
-                self.unit_type, self.parent.available_units, self.unit_key_fields):
-            unit = self._dict_to_unit(unit_dict)
-            self.get_conduit().save_unit(unit)
-            units_we_already_had.add(unit)
+        # mongodb throws exceptions for too big queries, so we spilt it into multiple smaller ones
+        for page in misc.paginate(self.parent.available_units, 50):
+            # for any unit that is already in pulp, save it into the repo
+            for unit_dict in self.content_query_manager.get_multiple_units_by_keys_dicts(
+                    self.unit_type, page, self.unit_key_fields):
+                unit = self._dict_to_unit(unit_dict)
+                self.get_conduit().save_unit(unit)
+                units_we_already_had.add(unit)
 
         for unit_key in self.parent.available_units:
             # build a temp Unit instance just to use its comparison feature

--- a/server/test/unit/plugins/util/test_publish_step.py
+++ b/server/test/unit/plugins/util/test_publish_step.py
@@ -1180,12 +1180,16 @@ class TestGetLocalUnitsStep(unittest.TestCase):
         self.assertEqual(self.step.conduit.save_unit.call_count, 0)
         self.assertEqual(self.step.units_to_download, [])
 
-    def test_calls_get_multiple(self, mock_get_multiple):
-        mock_get_multiple.return_value = []
+    @patch('pulp.plugins.util.publish_step.misc.paginate')
+    def test_calls_get_multiple(self, mock_paginate, mock_get_multiple):
+        """
+        ensure that paginate is used
+        """
+        mock_paginate.return_value = []
 
         self.step.process_main()
 
-        mock_get_multiple.assert_called_once_with('fake_unit_type', [], ['foo'])
+        mock_paginate.assert_called_once_with([], 50)
 
     def test_saves_unit(self, mock_get_multiple):
         mock_get_multiple.return_value = [{'foo': 'a'}]


### PR DESCRIPTION
During publish, pulp needs to obtain a list of existing units to associate with
the repo. This is typically done in one large query.

However, this query can occasionally be too large for mongodb to handle.
Instead, use paginate() to break the query down into 50-unit chunks.

A giant thanks to Pulp community member Andreas Schieb for this patch!