### PR TITLE
make uri_path exclude get parameters

### DIFF
--- a/server/pulp/server/webservices/http.py
+++ b/server/pulp/server/webservices/http.py
@@ -219,7 +219,7 @@ def uri_path():
     @return: full current URI path
     """
     if _is_django():
-        return unicode(_get_wsgi_environ()['REQUEST_URI'])
+        return unicode(_get_wsgi_environ()['REQUEST_URI']).split("?")[0]
     else:
         return web.http.url(web.ctx.path)
 


### PR DESCRIPTION
This corrects a subtle exception handling difference between Webpy and Django .

For example, if you cause an errorr with a request url of `/v2/repositories/zoo/history/sync/?limit=notanint` you will get json objects that contain the the href of the call.

Django:

    "_href": "/pulp/api/v2/repositories/zoo/history/sync/?limit=notanint"
Webpy:

    "_href": "/pulp/api/v2/repositories/zoo/history/sync/"

