### PR TITLE
refs #99 - add ostree web prefix.

### DIFF
--- a/repoauth/pulp/repoauth/oid_validation.py
+++ b/repoauth/pulp/repoauth/oid_validation.py
@@ -198,6 +198,6 @@ class OidValidator:
         try:
             prefixes = config.get('main', 'repo_url_prefixes').split(',')
         except NoOptionError:
-            prefixes = ["/pulp/repos"]
+            prefixes = ["/pulp/repos", "/pulp/ostree/web"]
 
         return prefixes

--- a/repoauth/test/test_oid_validation.py
+++ b/repoauth/test/test_oid_validation.py
@@ -692,7 +692,7 @@ class TestOidValidation(unittest.TestCase):
         validator = oid_validation.OidValidator(mock_config)
         result = validator._get_repo_url_prefixes_from_config(mock_config)
 
-        self.assertEquals(result, ["/pulp/repos"])
+        self.assertEquals(result, ["/pulp/repos", "/pulp/ostree/web"])
 
 
 # -- test data ---------------------------------------------------------------------


### PR DESCRIPTION
Putting plugin specific values here is a total hack but reworking how repo-auth works is outside the scope of this pr.