### PR TITLE
540 - Check previous version of pulp-server SELinux policy at ugrade

### DIFF
--- a/server/selinux/server/relabel.sh
+++ b/server/selinux/server/relabel.sh
@@ -1,13 +1,20 @@
 #!/bin/sh
 
-/sbin/restorecon -i -R /etc/httpd/conf.d/pulp.conf
-/sbin/restorecon -i -R /etc/pulp
-/sbin/restorecon -i -R /etc/pki/pulp
-/sbin/restorecon -i -R /srv/pulp
-/sbin/restorecon -i -R /usr/bin/pulp-admin
-/sbin/restorecon -i -R /usr/bin/pulp-consumer
-/sbin/restorecon -i -R /var/lib/pulp
-/sbin/restorecon -i -R /var/log/pulp
-
-# Relabel the celery binary
-/sbin/restorecon -i -R /usr/bin/celery
+# If upgrading from before 2.4.0
+if [[ $1 < '2.4.0' ]]
+then
+    /sbin/restorecon -i -R /etc/httpd/conf.d/pulp.conf
+    /sbin/restorecon -i -R /etc/pulp
+    /sbin/restorecon -i -R /etc/pki/pulp
+    /sbin/restorecon -i -R /srv/pulp
+    /sbin/restorecon -i -R /usr/bin/pulp-admin
+    /sbin/restorecon -i -R /usr/bin/pulp-consumer
+    /sbin/restorecon -i -R /var/lib/pulp
+    /sbin/restorecon -i -R /var/log/pulp
+fi
+# If upgrading from before 2.5.0
+if [[ $1 < '2.5.0' ]]
+then
+    # Relabel the celery binary
+    /sbin/restorecon -i -R /usr/bin/celery
+fi


### PR DESCRIPTION
This patch enhances the pulp-selinux RPM install process. The version of the
pulp-server SELinux policy is recorded in /var/lib/rpm-state/pulp before the new
policy is installed. Then that version is passed as an argument to relabel.sh.
The relabel script then only relabels the files that have not been properly labeled
in the previously installed version. If no version is passed in, all files
are relabeled.

Fixes #540