### PR TITLE
Fixes release notes link for 2.6.0

### DIFF
--- a/docs/user-guide/release-notes/2.6.x.rst
+++ b/docs/user-guide/release-notes/2.6.x.rst
@@ -84,7 +84,7 @@ After the database migrations finish, restart `httpd`, `pulp_workers`, `pulp_cel
 Bugs
 ----
 
-This release has fixes for `these issues <https://pulp.plan.io/issues?utf8=%E2%9C%93&set_filter=1&f%5B%5D=cf_4&op%5Bcf_4%5D=%3D&v%5Bcf_4%5D%5B%5D=2.6.0&f%5B%5D=tracker_id&op%5Btracker_id%5D=%3D&v%5Btracker_id%5D%5B%5D=1&f%5B%5D=&c%5B%5D=project&c%5B%5D=tracker&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=cf_5&c%5B%5D=subject&c%5B%5D=author&c%5B%5D=assigned_to&c%5B%5D=cf_3&group_by=>`_.
+This release has fixes for `these issues <https://pulp.plan.io/projects/pulp/issues?utf8=%E2%9C%93&set_filter=1&f%5B%5D=tracker_id&op%5Btracker_id%5D=%3D&v%5Btracker_id%5D%5B%5D=1&f%5B%5D=cf_4&op%5Bcf_4%5D=%3D&v%5Bcf_4%5D%5B%5D=2.6.0&f%5B%5D=&c%5B%5D=tracker&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=cf_5&c%5B%5D=subject&c%5B%5D=author&c%5B%5D=assigned_to&group_by=>`_.
 
 Known Issues
 ------------


### PR DESCRIPTION
Because of a redmine change, the query needs to be updated to show 2.6.0 in platform.