### PR TITLE
pulp-qpid-ssl-cfg - More robust hostname default, prompt for input, support relative paths for INST_DIR

### DIFF
--- a/docs/user-guide/qpid.rst
+++ b/docs/user-guide/qpid.rst
@@ -63,6 +63,11 @@ These inputs are as follows:
      the generated client certificates used by the Qpid broker, the Pulp server and the
      consumer. All keys and certificates are stored in the NSS database.
 
+ *The Qpid server hostname*
+     A server certificate will be generated for use by the Qpid broker. This needs to match
+     the exact hostname that clients will use to connect. Pressing <enter> will default to
+     the fully qualified domain name of the system, or the hostname if the fqdn is not set.
+
 The following is an example of running the script:
 
 ::
@@ -86,6 +91,13 @@ The following is an example of running the script:
   Please specify a CA.  Generated if not specified.
 
   Enter a path:
+
+  Please enter the hostname clients will use to connect to the qpid server.
+  If not specified, 'localhost' will be used.
+
+  Enter a hostname:
+
+  Using hostname: [localhost]
 
   Password file created.
 
@@ -134,12 +146,12 @@ The following is an example of running the script:
 
   ...
   [messaging]
-  url: ssl://<host>:5671
+  url: ssl://localhost:5671
   cacert: /etc/pki/pulp/qpid/ca.crt
   clientcert: /etc/pki/pulp/qpid/client.crt
 
   [tasks]
-  broker_url: qpid://<host>:5671/
+  broker_url: qpid://localhost:5671/
   celery_require_ssl: true
   cacert: /etc/pki/pulp/qpid/ca.crt
   keyfile: /etc/pki/pulp/qpid/client.crt
@@ -150,10 +162,22 @@ The following is an example of running the script:
 
   ...
   [messaging]
-  scheme: ssl
-  port: 5671
-  cacert: /etc/pki/pulp/qpid/ca.crt
-  clientcert: /etc/pki/pulp/qpid/client.crt
+  scheme=ssl
+  port=5671
+  cacert=/etc/pki/pulp/qpid/ca.crt
+  clientcert=/etc/pki/pulp/qpid/client.crt
+
+
+  NOTES:
+    [1] The location for qpidd.conf depends on the version of Qpid installed.
+        For 0.24+: /etc/qpid/qpidd.conf.
+        For all earlier versions: /etc/qpidd.conf.
+
+    [2] The /etc/pki/pulp/qpid/ca.crt and /etc/pki/pulp/qpid/client.crt certificates will
+        need to be manually copied to each consumer.
+
+    [3] The /etc/pki/pulp/qpid/ca.crt and /etc/pki/pulp/qpid/client.crt certificates will
+        need to be manually copied to each worker.
 
 
 The following directory and files are created by the script:

--- a/server/bin/pulp-qpid-ssl-cfg
+++ b/server/bin/pulp-qpid-ssl-cfg
@@ -82,7 +82,7 @@ echo ""
 echo "Please enter the hostname clients will use to connect to the qpid server."
 echo "If not specified, '$HOST' will be used."
 echo ""
-read -sp "Enter a hostname:" ans
+read -p "Enter a hostname:" ans
 if [ "${#ans}" -gt 0 ]
 then
   HOST=$ans

--- a/server/bin/pulp-qpid-ssl-cfg
+++ b/server/bin/pulp-qpid-ssl-cfg
@@ -14,7 +14,11 @@
 #
 
 DIR="/tmp/tmp$RANDOM"
-HOST=`hostname`
+HOST=`hostname -f`
+if [ -z "$HOST" ]
+then
+  HOST=`hostname`
+fi
 PWDFILE="password"
 SEEDFILE="seed"
 INST_DIR='/etc/pki/pulp/qpid'
@@ -38,7 +42,7 @@ echo ""
 read -p "Enter a directory [$INST_DIR]:" ans
 if [ "${#ans}" -gt 0 ]
 then
-  INST_DIR=$ans
+  INST_DIR=`readlink -f "$ans"`
 fi
 echo $INST_DIR
 
@@ -72,6 +76,19 @@ then
   done
   echo "Using CA key: $CA_KEY_PATH"
 fi
+
+# prompt user for this server's hostname, defaulting to the local fqdn
+echo ""
+echo "Please enter the hostname clients will use to connect to the qpid server."
+echo "If not specified, '$HOST' will be used."
+echo ""
+read -sp "Enter a hostname:" ans
+if [ "${#ans}" -gt 0 ]
+then
+  HOST=$ans
+fi
+echo ""
+echo "Using hostname: [$HOST]"
 
 # create temporary db directory
 rm -rf $DIR
@@ -229,12 +246,12 @@ echo "Recommended properties in /etc/pulp/server.conf:"
 echo "
 ...
 [messaging]
-url: ssl://<host>:5671
+url: ssl://$HOST:5671
 cacert: $INST_DIR/ca.crt
 clientcert: $INST_DIR/client.crt
 
 [tasks]
-broker_url: qpid://<host>:5671/
+broker_url: qpid://$HOST:5671/
 celery_require_ssl: true
 cacert: /etc/pki/pulp/qpid/ca.crt
 keyfile: /etc/pki/pulp/qpid/client.crt


### PR DESCRIPTION
Remote hosts are more likely to be connecting to qpidd using the fully
qualified hostname, especially in complex environments where not all
machines share the same domain/search suffix.

Sometimes the fqdn is not properly set up, and the hostname contains the
entire fqdn. This change addresses this, while also allowing the user to
specify in case a DNS alias or IP address is preferred.

It also fills the example configs out with the hostname used as the CN
in the cert, as that is the only string that will actually work due to
server certificate verification.

Support relative paths for INST_DIR

Previously relative path usage was not supported for INST_DIR due to the
script cding to the temp directory. Use readlink to make it an absolute
path.