### PR TITLE
Allow passwordless mongodb connections to be configured

### DIFF
--- a/server/pulp/server/db/connection.py
+++ b/server/pulp/server/db/connection.py
@@ -84,13 +84,13 @@ def initialize(name=None, seeds=None, max_pool_size=None, replica_set=None, max_
         # attempt to authenticate to the database
         username = config.config.get('database', 'username')
         password = config.config.get('database', 'password')
-        if username and password:
+        if username:
             _logger.debug(_('Attempting username and password authentication.'))
             connection_kwargs['username'] = username
             connection_kwargs['password'] = password
-        elif (username and not password) or (password and not username):
-            raise Exception(_("The server config specified username/password authentication but "
-                            "is missing either the username or the password"))
+        elif password and not username:
+            raise Exception(_("The server config specified a database password, but is "
+                              "missing a database username."))
 
         shadow_connection_kwargs = copy.deepcopy(connection_kwargs)
         if connection_kwargs.get('password'):

--- a/server/test/unit/server/db/test_connection.py
+++ b/server/test/unit/server/db/test_connection.py
@@ -423,7 +423,8 @@ class TestDatabaseAuthentication(unittest.TestCase):
                                                               connection.MONGO_MINIMUM_VERSION}
         config.config.set('database', 'username', 'admin')
         config.config.set('database', 'password', '')
-        self.assertRaises(Exception, connection.initialize)
+        # ensure no exception is raised (redmine #708)
+        connection.initialize()
 
     @patch('pulp.server.db.connection.mongoengine')
     def test_initialize_password_no_username(self, mock_mongoengine):


### PR DESCRIPTION
MongoDB allows passwordless logins. However, Pulp was checking that both the
username *and* password were set before attempting a login.

This patch alters the user/pass check to fail only if a password is set sans
username. If a username is set sans password, a MongoDB connection will be
attempted.

Note that all of the auth still happens in Mongo. This was just a "pre-check"
that Pulp was doing to give a clear error message.

fixes #708