### PR TITLE
make critera required on repo associate and unassociate

### DIFF
--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -1130,7 +1130,7 @@ class RepoAssociate(View):
                 invalid_criteria.add_child_exception(e)
                 raise invalid_criteria
         else:
-            criteria = None
+            raise pulp_exceptions.MissingValue('criteria')
 
         task_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, dest_repo_id),
                      tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, source_repo_id),
@@ -1170,7 +1170,7 @@ class RepoUnassociate(View):
                 invalid_criteria.add_child_exception(e)
                 raise invalid_criteria
         else:
-            criteria = None
+            raise pulp_exceptions.MissingValue('criteria')
 
         task_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, repo_id),
                      tags.action_tag('unassociate')]


### PR DESCRIPTION
If criteria is allowed to default to `None`, it is initialized as an empty criteria query:

`{'criteria': {}}` which returns all possible results. This is unexpected, so we should simply enforce that criteria must exist.

closes #826