### PR TITLE
Allow setting the broker_login_method.

### DIFF
--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -295,6 +295,10 @@
 # certfile: The absolute path to the PEM encoded certificate used for authentication to the message
 #     bus. The default value is '/etc/pki/pulp/qpid/client.crt'.
 #
+# broker_login_method: Select the login method used to connect to the broker. This should be left
+#     unset (use the broker default) except in special cases (e.g. do SSL client certificate
+#     authentication. For RabbitMQ with SSL client certificates, this needs to be 'EXTERNAL'.
+#
 
 [tasks]
 # broker_url: qpid://guest@localhost/

--- a/server/pulp/server/async/celery_instance.py
+++ b/server/pulp/server/async/celery_instance.py
@@ -90,5 +90,7 @@ def configure_SSL():
         }
         celery.conf.update(BROKER_USE_SSL=BROKER_USE_SSL)
 
+        if config.has_option('tasks', 'broker_login_method'):
+            celery.conf.update(BROKER_LOGIN_METHOD=config.get('tasks', 'broker_login_method'))
 
 configure_SSL()


### PR DESCRIPTION
When using RabbitMQ with SSL client certificates, it is necessary to use
the rabbitmq_auth_mechanism_ssl which uses the common_name (CN) of the
client certificate as user name and then use SASL EXTERNAL to have
RabbitMQ pick up the configuration.

Unfortunately, by default, pulp only supports the default (AMQPLAIN)
authentication and it can not be configured.

This change adds a new configuration parameter to the tasks section
which allows setting the requested authentication mechanism through the
celery BROKER_LOGIN_METHOD configuration setting.

This allows using RabbitMQ with strict SSL client certificates:

```erlang
[
  {rabbit, [
    {ssl_listeners, [5671]},
    {auth_mechanisms, ['EXTERNAL']},
    {ssl_options, [
      {cacertfile,           '.../cacertfile'},
      {certfile,             '.../cert.crt'},
      {keyfile,              '.../cert.key'},
      {verify,               verify_peer},
      {fail_if_no_peer_cert, true}
    ]},
    {ssl_cert_login_from,  common_name}]
  }
].
```

and adding the CN values from the client certificates as users to RabbitMQ.