### PR TITLE
Task failures of known types no longer log tracebacks.

### DIFF
--- a/client_lib/pulp/client/commands/repo/sync_publish.py
+++ b/client_lib/pulp/client/commands/repo/sync_publish.py
@@ -67,7 +67,8 @@ class SyncPublishCommand(polling.PollingCommand):
         :param spinner: Not used by this method, but the superclass will give it to us
         :type  spinner: okaara.progress.Spinner
         """
-        if task.progress_report is not None:
+        # if the task failed, the failure handler will render the error message
+        if task.progress_report is not None and not task.was_failure():
             self.renderer.display_report(task.progress_report)
 
     def task_header(self, task):

--- a/client_lib/test/unit/client/commands/repo/test_sync_publish.py
+++ b/client_lib/test/unit/client/commands/repo/test_sync_publish.py
@@ -183,6 +183,20 @@ class RunSyncRepositoryCommandTests(base.PulpClientTests):
 
         self.assertEqual(self.mock_renderer.display_report.call_count, 0)
 
+    def test_progress_failed_task(self):
+        """
+        Test the progress() method when the Task failed. In this case, the
+        error will be rendered by the generic failure handler.
+        """
+        progress_report = {'some': 'data'}
+        task = responses.Task({'progress_report': progress_report})
+        task.state = responses.STATE_ERROR
+        spinner = mock.MagicMock()
+
+        self.command.progress(task, spinner)
+
+        self.assertEqual(self.mock_renderer.display_report.call_count, 0)
+
     def test_structure(self):
         # Ensure all of the expected options are there
         found_option_keywords = set([o.keyword for o in self.command.options])

--- a/playpen/dev-setup.sh
+++ b/playpen/dev-setup.sh
@@ -125,7 +125,8 @@ sudo yum install -y @pulp-server-qpid @pulp-admin @pulp-consumer
 sudo yum remove -y pulp-\* python-pulp\*
 sudo yum install -y git mongodb mongodb-server python-django python-flake8 python-mock \
                     python-mongoengine python-nose python-paste python-pip python-qpid-qmf \
-                    python-setuptools python-sphinx qpid-cpp-server qpid-cpp-server-store
+                    python-setuptools python-sphinx qpid-cpp-server qpid-cpp-server-store \
+                    python-unittest2
 
 
 mkdir -p $DEVEL_PATH

--- a/pulp.spec
+++ b/pulp.spec
@@ -610,6 +610,9 @@ A collection of components that are common between the pulp server and client.
 %package -n python-pulp-devel
 Summary: Pulp devel python packages
 Group: Development/Languages
+%if 0%{?rhel} == 6
+Requires: python-unittest2
+%endif
 
 %description -n python-pulp-devel
 A collection of tools used for developing & testing Pulp plugins

--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 import logging
 import signal
 import time
+import traceback
 import uuid
 
 from celery import task, Task as CeleryTask, current_task
@@ -15,7 +16,8 @@ from pulp.common import constants, dateutils
 from pulp.common.constants import SCHEDULER_WORKER_NAME
 from pulp.server.async.celery_instance import celery, RESOURCE_MANAGER_QUEUE, \
     DEDICATED_QUEUE_EXCHANGE
-from pulp.server.exceptions import PulpException, MissingResource
+from pulp.server.exceptions import PulpException, MissingResource, \
+    PulpCodedException
 from pulp.server.db.model.dispatch import TaskStatus
 from pulp.server.db.model.resources import ReservedResource
 from pulp.server.db.model.workers import Worker
@@ -328,6 +330,9 @@ class Task(CeleryTask, ReservedTaskMixin):
     This is a custom Pulp subclass of the Celery Task object. It allows us to inject some custom
     behavior into each Pulp task, including management of resource locking.
     """
+    # this tells celery to not automatically log tracebacks for these exceptions
+    throws = (PulpCodedException,)
+
     def apply_async(self, *args, **kwargs):
         """
         A wrapper around the Celery apply_async method. It allows us to accept a few more
@@ -444,7 +449,13 @@ class Task(CeleryTask, ReservedTaskMixin):
         :param kwargs:  Original keyword arguments for the executed task.
         :param einfo:   celery's ExceptionInfo instance, containing serialized traceback.
         """
-        _logger.debug("Task failed : [%s]" % task_id)
+        if isinstance(exc, PulpCodedException):
+            _logger.info(_('Task failed : [%(task_id)s] : %(msg)s') %
+                         {'task_id': task_id, 'msg': str(exc)})
+            _logger.debug(traceback.format_exc())
+        else:
+            _logger.info(_('Task failed : [%s]') % task_id)
+            # celery will log the traceback
         if not self.request.called_directly:
             now = datetime.now(dateutils.utc_tz())
             finish_time = dateutils.format_iso8601_datetime(now)

--- a/server/pulp/server/managers/repo/sync.py
+++ b/server/pulp/server/managers/repo/sync.py
@@ -154,8 +154,6 @@ class RepoSyncManager(object):
                 repo_id, repo_importer['id'], repo_importer['importer_type_id'],
                 sync_start_timestamp, sync_end_timestamp, e, sys.exc_info()[2])
 
-            _logger.exception(
-                _('Exception caught from plugin during sync for repo [%(r)s]' % {'r': repo_id}))
             raise
 
         else:

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -21,7 +21,7 @@ from pulp.server.db.model.dispatch import TaskStatus
 from pulp.server.db.model.resources import ReservedResource
 from pulp.server.db.model.workers import Worker
 from pulp.server.db.reaper import queue_reap_expired_documents
-from pulp.server.exceptions import NoWorkers, PulpException
+from pulp.server.exceptions import NoWorkers, PulpException, PulpCodedException
 from pulp.server.maintenance.monthly import queue_monthly_maintenance
 
 
@@ -613,6 +613,15 @@ class TestTaskApplyAsync(ResourceReservationTests):
         result = task.apply_async(*args, **kwargs)
 
         self.assertEqual(result.tags, ['test_tags'])
+
+
+class TestTaskThrows(unittest.TestCase):
+    """
+    Exceptions listed in the "throws" collection will not have their stack
+    traces get auto-logged by celery.
+    """
+    def test_throws_pulp_coded_exception(self):
+        self.assertTrue(PulpCodedException in tasks.Task.throws)
 
 
 class TestCancel(PulpServerTests):


### PR DESCRIPTION
This goes along with additional changes to plugins so they can take advantage
of smarter error reporting. This includes the use of the unittest2 module for
testing that error reporting.

refs #652
refs #702

https://pulp.plan.io/issues/652
https://pulp.plan.io/issues/702