### PR TITLE
  clear log handlers in stop_logging()

### DIFF
--- a/server/pulp/server/logs.py
+++ b/server/pulp/server/logs.py
@@ -75,10 +75,13 @@ def start_logging(*args, **kwargs):
 
 def stop_logging():
     """
-    Stop Pulp's logging.
+    Informs the logging system to perform an orderly shutdown by flushing and closing all handlers.
+    This should be called at application exit and no further use of the logging system should be
+    made after this call.
     """
-    # remove all the existing handlers and loggers from the logging module
     logging.shutdown()
+    root_logger = logging.getLogger()
+    root_logger.handlers = []
 
 
 class CompliantSysLogHandler(logging.handlers.SysLogHandler):

--- a/server/test/unit/server/test_logs.py
+++ b/server/test/unit/server/test_logs.py
@@ -825,11 +825,19 @@ class TestStopLogging(unittest.TestCase):
     """
     Test the stop_logging() function.
     """
+
+    @mock.patch('pulp.server.logs.logging.getLogger')
     @mock.patch('pulp.server.logs.logging.shutdown')
-    def test_stop_logging(self, shutdown):
+    def test_stop_logging(self, shutdown, get_logger):
         """
-        Make sure that stop_logging() calls logging.shutdown().
+        Make sure that stop_logging() calls logging.shutdown() and
+        the handlers are cleared.
         """
+        get_logger.return_value.handlers = [1, 2, 3]
+
+        # test
         logs.stop_logging()
 
+        # validation
         shutdown.assert_called_once_with()
+        self.assertEqual(get_logger.return_value.handlers, [])


### PR DESCRIPTION
Already reviewed on PR #1769 and just needed to be re-issued against 2.6-testing.

More complete and symmetrical with start_logging(). Also, fixes issue with unit tests.