### PR TITLE
Adjusts the upload delete API implementation

### DIFF
--- a/server/pulp/server/managers/content/upload.py
+++ b/server/pulp/server/managers/content/upload.py
@@ -1,21 +1,11 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2011 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-from celery import task
+from errno import ENOENT
 from gettext import gettext as _
-from uuid import uuid4
 import logging
 import os
 import sys
+from uuid import uuid4
+
+from celery import task
 
 from pulp.plugins.conduits.upload import UploadConduit
 from pulp.plugins.config import PluginCallConfiguration
@@ -100,8 +90,11 @@ class ContentUploadManager(object):
         """
 
         file_path = ContentUploadManager._upload_file_path(upload_id)
-        if os.path.exists(file_path):
+        try:
             os.remove(file_path)
+        except OSError as e:
+            if e.errno != ENOENT:
+                raise
 
     def read_upload(self, upload_id):
         """


### PR DESCRIPTION
The upload delete method used inode data to determine if a file
exists before deleting it. On filesystems with cached or slow-to-
respond inode data like NFS this was causing issues. The new
implementation always tries to remove a file and silences
only the error in the case where the file does not exist.

Also some small flake8 fixes.

closes #480

https://pulp.plan.io/issues/480