### PR TITLE
set heartbeat interval to 30s

### DIFF
--- a/server/etc/default/upstart_pulp_resource_manager
+++ b/server/etc/default/upstart_pulp_resource_manager
@@ -25,7 +25,7 @@ CELERYD_NODES="resource_manager"
 
 # Set the concurrency of each worker node to 1, tell the worker to participate in event
 # broadcasting, and subscribe to the resource_manager queue. DO NOT CHANGE THIS SETTING!
-CELERYD_OPTS="-c 1 --events -Q resource_manager --umask=18"
+CELERYD_OPTS="-c 1 --events -Q resource_manager --umask=18 --heartbeat-interval=30"
 
 CELERYD_USER="apache"
 

--- a/server/etc/default/upstart_pulp_workers
+++ b/server/etc/default/upstart_pulp_workers
@@ -29,7 +29,7 @@ CELERY_CREATE_DIRS=1
 CELERYD_NODES=""
 
 # Set the concurrency of each worker node to 1. DO NOT CHANGE THE CONCURRENCY!
-CELERYD_OPTS="-c 1 --events --umask=18"
+CELERYD_OPTS="-c 1 --events --umask=18 --heartbeat-interval=30"
 
 CELERYD_USER="apache"
 

--- a/server/pulp/server/async/manage_workers.py
+++ b/server/pulp/server/async/manage_workers.py
@@ -33,7 +33,8 @@ EnvironmentFile=%(environment_file)s
 User=apache
 WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -n reserved_resource_worker-%(num)s@%%%%h -A pulp.server.async.app\
-          -c 1 --events --umask 18 --pidfile=/var/run/pulp/reserved_resource_worker-%(num)s.pid
+          -c 1 --events --umask 18 --pidfile=/var/run/pulp/reserved_resource_worker-%(num)s.pid\
+          --heartbeat-interval=30
 KillSignal=SIGQUIT
 """
 

--- a/server/usr/lib/systemd/system/pulp_resource_manager.service
+++ b/server/usr/lib/systemd/system/pulp_resource_manager.service
@@ -7,7 +7,8 @@ EnvironmentFile=/etc/default/pulp_resource_manager
 User=apache
 WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -A pulp.server.async.app -n resource_manager@%%h\
-          -Q resource_manager -c 1 --events --umask 18 --pidfile=/var/run/pulp/resource_manager.pid
+          -Q resource_manager -c 1 --events --umask 18 --pidfile=/var/run/pulp/resource_manager.pid\
+          --heartbeat-interval=30
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The heartbeat interval for celery was previously set to the default of 2
seconds. This caused the workers collection to be updated in mongo every two
seconds as well, even on an idle system.

Instead, set the heartbeat interval to 30 seconds. This should be sufficient
for worker status updates.

fixes #808