### PR TITLE
Added persistence of /var/run/pulp

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -244,6 +244,9 @@ def get_paths_to_copy():
         paths.append({'source': 'server/usr/lib/systemd/system/pulp_workers.service',
                       'destination': '/etc/systemd/system/pulp_workers.service', 'owner': 'root',
                       'group': 'root', 'mode': '644', 'overwrite': True})
+        paths.append({'source': 'server/usr/lib/tmpfiles.d/pulp.conf',
+                      'destination': '/etc/tmpfiles.d/pulp.conf', 'owner': 'root',
+                      'group': 'root', 'mode': '644', 'overwrite': True})
 
     for path in paths:
         path['source'] = os.path.join(ROOT_DIR, path['source'])

--- a/pulp.spec
+++ b/pulp.spec
@@ -209,6 +209,8 @@ cp server/etc/default/systemd_pulp_resource_manager %{buildroot}/%{_sysconfdir}/
 cp server/etc/default/systemd_pulp_workers %{buildroot}/%{_sysconfdir}/default/pulp_workers
 mkdir -p %{buildroot}/%{_usr}/lib/systemd/system/
 cp server/usr/lib/systemd/system/* %{buildroot}/%{_usr}/lib/systemd/system/
+mkdir -p %{buildroot}/%{_usr}/lib/tmpfiles.d/
+cp server/usr/lib/tmpfiles.d/* %{buildroot}/%{_usr}/lib/tmpfiles.d/
 %endif
 
 # Pulp Web Services
@@ -374,6 +376,8 @@ Pulp provides replication, access, and accounting for software repositories.
 %{_usr}/lib/systemd/system/*
 %defattr(755,root,root,-)
 %{_libexecdir}/pulp-manage-workers
+%defattr(-,root,root,-)
+%{_usr}/lib/tmpfiles.d/
 %endif
 # 640 root:apache
 %defattr(640,root,apache,-)

--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -136,6 +136,9 @@ create_default_dir() {
             chgrp "$CELERYBEAT_GROUP" "$1"
             maybe_die "Couldn't change group of $1"
         fi
+        echo "- Restoring context of $1 to 'pulp_var_run_t'"
+        restorecon /var/run/pulp
+        maybe_die "Couldn't restore context of $1"
     fi
 }
 

--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -138,6 +138,9 @@ create_default_dir() {
             chgrp "$CELERYD_GROUP" "$1"
             maybe_die "Couldn't change group of $1"
         fi
+        echo "- Restoring context of $1 to 'pulp_var_run_t'"
+        restorecon /var/run/pulp
+        maybe_die "Couldn't restore context of $1"
     fi
 }
 

--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -55,6 +55,8 @@ allow celery_t pulp_tmp_t:file manage_file_perms;
 files_tmp_filetrans(celery_t, pulp_tmp_t, file)
 
 allow celery_t pulp_var_run_t:file manage_file_perms;
+# dir access needed when celery searches for existing pid files on startup
+allow celery_t pulp_var_run_t:dir manage_dir_perms;
 files_pid_filetrans(celery_t, pulp_var_run_t, file)
 
 

--- a/server/selinux/server/relabel.sh
+++ b/server/selinux/server/relabel.sh
@@ -20,4 +20,5 @@ fi
 if [[ $1 < '2.7.0' ]]
 then
     /sbin/restorecon -i -R /var/cache/pulp
+    /sbin/restorecon -i -R /var/run/pulp
 fi

--- a/server/usr/lib/tmpfiles.d/pulp.conf
+++ b/server/usr/lib/tmpfiles.d/pulp.conf
@@ -1,0 +1,1 @@
+d /var/run/pulp 0755 apache apache


### PR DESCRIPTION
This patch provides a fix for both systemd and upstart. A configuration file for
systemd-tmpfiles helps ensure that /var/run/pulp is recreated at boot time. The
upstart script already created the directory if it was missing. The same script
now restores the context on the newly created directory. The relabel.sh script
now contains a statement to restore context of /var/run/pulp also.

Fixes #719