### PR TITLE
Removes orderreddict from Kombu Python deps. The rpm still includes it.

### DIFF
--- a/deps/python-kombu/1195361.patch
+++ b/deps/python-kombu/1195361.patch
@@ -1,0 +1,105 @@
+From f032b227747bc6ac3df27bc1866cf8e65a24f759 Mon Sep 17 00:00:00 2001
+From: Brian Bouterse <bmbouter@gmail.com>
+Date: Fri, 20 Feb 2015 11:59:54 -0500
+Subject: [PATCH] Fixes close bug where the connection was not being closed
+
+---
+ kombu/tests/transport/test_qpid.py | 19 ++++++++++++-------
+ kombu/transport/qpid.py            | 25 ++++++++++++++-----------
+ 2 files changed, 26 insertions(+), 18 deletions(-)
+
+diff --git a/kombu/tests/transport/test_qpid.py b/kombu/tests/transport/test_qpid.py
+index 5f53c2f..222f9b3 100644
+--- a/kombu/tests/transport/test_qpid.py
++++ b/kombu/tests/transport/test_qpid.py
+@@ -441,6 +441,16 @@ class TestConnectionGetQpidConnection(ConnectionTestBase):
+ 
+ @case_no_python3
+ @case_no_pypy
++class TestConnectionClose(ConnectionTestBase):
++
++    def test_connection_close(self):
++        self.conn._qpid_conn = Mock()
++        self.conn.close()
++        self.conn._qpid_conn.close.assert_called_once_with()
++
++
++@case_no_python3
++@case_no_pypy
+ class TestConnectionCloseChannel(ConnectionTestBase):
+ 
+     def setUp(self):
+@@ -1993,16 +2003,11 @@ class TestTransport(ExtraAssertionsMixin, Case):
+         self.mock_client = Mock()
+ 
+     def test_close_connection(self):
+-        """Test that close_connection calls close on each channel in the
+-        list of channels on the connection object."""
++        """Test that close_connection calls close on the connection."""
+         my_transport = Transport(self.mock_client)
+         mock_connection = Mock()
+-        mock_channel_1 = Mock()
+-        mock_channel_2 = Mock()
+-        mock_connection.channels = [mock_channel_1, mock_channel_2]
+         my_transport.close_connection(mock_connection)
+-        mock_channel_1.close.assert_called_with()
+-        mock_channel_2.close.assert_called_with()
++        mock_connection.close.assert_called_once_with()
+ 
+     def test_default_connection_params(self):
+         """Test that the default_connection_params are correct"""
+diff --git a/kombu/transport/qpid.py b/kombu/transport/qpid.py
+index a3b0a4c..fb240ad 100644
+--- a/kombu/transport/qpid.py
++++ b/kombu/transport/qpid.py
+@@ -928,7 +928,7 @@ class Channel(base.StdChannel):
+             self.connection._callbacks.pop(queue, None)
+ 
+     def close(self):
+-        """Close Channel and all associated messages.
++        """Cancel all associated messages and close the Channel.
+ 
+         This cancels all consumers by calling :meth:`basic_cancel` for each
+         known consumer_tag. It also closes the self._broker sessions. Closing
+@@ -1272,6 +1272,14 @@ class Connection(object):
+         """
+         return self._qpid_conn
+ 
++    def close(self):
++        """Close the connection
++
++        Closing the connection will close all associated session, senders, or
++        receivers used by the Connection.
++        """
++        self._qpid_conn.close()
++
+     def close_channel(self, channel):
+         """Close a Channel.
+ 
+@@ -1620,18 +1628,13 @@ class Transport(base.Transport):
+         return conn
+ 
+     def close_connection(self, connection):
+-        """Close the :class:`Connection` object, and all associated
+-        :class:`Channel` objects.
+-
+-        Iterates through all :class:`Channel` objects associated with the
+-        :class:`Connection`, pops them from the list of channels, and calls
+-        :meth:Channel.close` on each.
++        """
++        Close the :class:`Connection` object.
+ 
+-        :param connection: The Connection that should be closed
+-        :type connection: Connection
++        :param connection: The Connection that should be closed.
++        :type connection: :class:`kombu.transport.qpid.Connection`
+         """
+-        for channel in connection.channels:
+-                channel.close()
++        connection.close()
+ 
+     def drain_events(self, connection, timeout=0, **kwargs):
+         """Handle and call callbacks for all ready Transport messages.
+-- 
+1.9.3
+

--- a/deps/python-kombu/1212200.patch
+++ b/deps/python-kombu/1212200.patch
@@ -1,0 +1,19 @@
+From 46be66b913c30aedb1d5017441f1df5ff96a0370 Mon Sep 17 00:00:00 2001
+From: Brian Bouterse <bmbouter@gmail.com>
+Date: Mon, 20 Apr 2015 17:10:16 -0400
+Subject: [PATCH] Removes ordereddict as a 2.6 dep. The rpm still requires it.
+
+---
+ requirements/py26.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/requirements/py26.txt b/requirements/py26.txt
+index 1807d7c..ed3fe37 100644
+--- a/requirements/py26.txt
++++ b/requirements/py26.txt
+@@ -1,2 +1 @@
+ importlib
+-ordereddict
+-- 
+1.9.3
+

--- a/deps/python-kombu/README
+++ b/deps/python-kombu/README
@@ -4,3 +4,26 @@ Celery 3.1.11 requires kombu>=3.0.15,<4.0, which is not in Fedora <= 20, or EPEL
 
 Pulp would like to use the Qpid transport which is available in upstream kombu>=3.0.24
 
+
+Permanent Patches:
+
+1212200.patch - This patch will need to continue to be with us forever as it works around a
+                permanent downstream issue whereby ordereddict is installed as part of the Python
+                system library, and not in site-packages. This is not contributed to upstream Kombu.
+
+
+Temporary Patches:
+
+This are contributed to upstream Kombu and will be included in a future release of Kombu, but until
+it is we include it in downstream.
+
+1195361.patch - Fixes close bug where the connection was not being closed. This fixes
+                https://github.com/celery/kombu/issues/455
+
+
+Patches that need to be contributed upstream:
+
+1182322.patch - Fixes an auth mechanism issue. This patch adds an additional string that is
+                returned when PLAIN is not available and the python-saslwrapper is installed. I
+                don't think an upstream issue was filed on this, and I don't think it is in
+                upstream yet. It should be contributed upstream.

--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.24
-Release:        5.pulp%{?dist}
+Release:        7.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages
@@ -19,7 +19,9 @@ Group:          Development/Languages
 License:        BSD and Python
 URL:            http://pypi.python.org/pypi/%{srcname}
 Source0:        http://pypi.python.org/packages/source/k/%{srcname}/%{srcname}-%{version}.tar.gz
-Patch0:         1182322.patch
+Patch0:         1212200.patch
+Patch1:         1182322.patch
+Patch2:         1195361.patch
 BuildArch:      noarch
 
 BuildRequires:  python2-devel
@@ -111,7 +113,13 @@ This subpackage is for python3
 
 %prep
 %setup -q -n %{srcname}-%{version}
+
+%if 0%{?rhel} == 6
 %patch0 -p1
+%endif
+
+%patch1 -p1
+%patch2 -p1
 
 # manage requirements on rpm base
 sed -i 's/>=1.0.13,<1.1.0/>=1.3.0/' requirements/default.txt


### PR DESCRIPTION
This backports a patch that was built in a newer version of
Kombu so that multiple version of Pulp can all use the same
rebuilt dep.

closes #896
https://pulp.plan.io/issues/896