### PR TITLE
Configure Vagrant for NFS shares and document it.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,8 +6,11 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box = "humaton/fedora-21-cloud"
  config.vm.host_name = "pulp-devel"
- config.vm.synced_folder ".", "/home/vagrant/devel/pulp", type: "rsync"
- config.vm.synced_folder "..", "/home/vagrant/devel", type: "rsync"
+ config.vm.synced_folder "..", "/home/vagrant/devel", type: "nfs", nfs_version: 4, nfs_udp: false
+ # By default, Vagrant wants to mount the code in /vagrant with NFSv3, which will fail. Let's
+ # explicitly mount the code using NFSv4. We probably won't need to use this, since the above line
+ # configures all the code we need for us, but vagrant up will fail without this line.
+ config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
 
  config.vm.provider :libvirt do |domain|
    domain.memory = 2048

--- a/docs/dev-guide/contributing/dev_setup.rst
+++ b/docs/dev-guide/contributing/dev_setup.rst
@@ -5,12 +5,109 @@ Developer Setup
 ===============
 
 For the Impatient
-^^^^^^^^^^^^^^^^^
+-----------------
 
-These instructions will create a developer install of Pulp on a dedicated
-development instance.
+There are two ways to automatically configure a development environment. There is a Vagrantfile
+in the platform git repository that can automatically deploy a virtual machine on your host with a
+Pulp development environment configured. Alternatively, there is a script that can turn a blank
+running virtual machine into a Pulp development environment.
 
-* Start a RHEL 7 or Fedora 20/21 x86_64 instance that will be dedicated for development with
+Vagrant
+^^^^^^^
+
+`Vagrant <https://docs.vagrantup.com/>`_ is a tool to aid developers in quickly deploying
+development environments. Pulp has provided a ``Vagrantfile`` in the platform git repository. This
+is the easiest way to get started on developing with Pulp if you aren't sure which method you
+prefer. Vagrant is available in Fedora 21 and newer. Follow these steps:
+
+#. Install vagrant::
+   
+      $ sudo yum install vagrant-libvirt
+
+#. Install NFS. NFS will be used to share your code directory with the deployed virtual machine::
+   
+      $ sudo yum install nfs-utils
+
+#. You will need to grant the nfsnobody user rx access to the folder that you check out your code
+   under. Many developers check out code into $HOME/devel or similar. In Fedora, $HOME typically
+   does not allow such access to other users. If your code is in $HOME, you will need to::
+   
+      $ setfacl -m user:nfsnobody:r-x $HOME  # Season to taste, as per above
+
+   .. warning::
+   
+      Wherever you have hosted your code, it would be good to verify that nfsnobody is able to read
+      it. If you experience an error message similar to
+      "mount.nfs: access denied by server while mounting 192.168.121.1:/path/to/my/code/dir"
+      during the vagrant up later, it is likely that nfsnobody is being blocked from reading your
+      code directory by either filesystem permissions or SELinux.
+
+#. Start and enable the nfs-server service::
+
+      $ sudo systemctl enable nfs-server && sudo systemctl start nfs-server
+
+#. You will need to allow NFS services through your firewall::
+   
+      $ sudo firewall-cmd --permanent --add-service=nfs
+      $ sudo firewall-cmd --permanent --add-service=rpc-bind
+      $ sudo firewall-cmd --permanent --add-service=mountd
+      $ sudo firewall-cmd --reload
+
+#. You are now prepared to check out the Pulp code into your preferred location. Change directories
+   to that location, and check out at least the platform and the RPM plugins. The RPM plugins are
+   needed as the provisioning script configures and synchronizes an example repository::
+
+      $ cd $HOME/devel  # Season to taste
+      $ git clone git@github.com:pulp/pulp.git && git clone git@github.com:pulp/pulp_rpm.git
+
+#. Optionally, check out some of our other plugins as well::
+
+      $ git clone git@github.com:pulp/pulp_docker
+      $ git clone git@github.com:pulp/pulp_python
+      $ git clone git@github.com:pulp/pulp_puppet
+      $ git clone git@github.com:pulp/pulp_ostree
+
+   .. note::
+
+      It is important to ensure that your repositories are all checked out to compatible versions.
+      If you followed the instructions above, you have checked out master on all repositories which
+      should be compatible.
+
+#. Next, cd into the pulp directory, and begin provisioning your Vagrant environment. Due to what
+   seems to be a `Vagrant bug <https://github.com/mitchellh/vagrant/issues/5321>`_, the first run
+   will fail due to Vagrant attempting to control NFS through init scripts rather than through
+   systemd. There is an easy workaround, as you can tell Vagrant to reload the box after it
+   configures your NFS exports, and everything should work. Another possible failure point is during
+   provisioning when mongod is building its initial files. This sometimes takes longer than systemd
+   allows and can fail. If that happens, simply run ``vagrant provision``. We will run two vagrant
+   reloads in a row. The first is a workaround for the mentioned bug, and the second allows the
+   machine to reboot after provisioning.::
+
+      $ cd pulp
+      $ vagrant up  # You will experience an error starting nfs and rpcbind here
+      $ vagrant reload  # mongod may fail when this runs. vagrant provision will fix it.
+      $ vagrant reload  # Reboot the machine at the end to apply kernel updates, etc.
+
+Once you have followed the steps above, you should have a running deployed Pulp development machine.
+You can ssh into the environment with ``vagrant ssh``. All of the code is mounted in
+/home/vagrant/devel. Your development environment has been configured for
+`virtualenvwrapper <http://virtualenvwrapper.readthedocs.org/en/latest/>`_. If you would like to
+activate a virtualenv, you can simply type ``workon <repo_dir>`` to work on any particular Pulp
+repo. For example, ``workon pulp`` will activate the Pulp platform virtualenv and cd into the code
+directory for you. You can type ``workon pulp_rpm`` for pulp_rpm, ``workon pulp_python`` for
+pulp_python, and so forth. Any plugins in folders that start with ``pulp_`` that you had checked out
+in your host machine's code folder alongside the Pulp platform repository should have been installed
+and configured for virtualenv.
+
+
+Provisioning Script
+^^^^^^^^^^^^^^^^^^^
+
+These instructions will create a developer install of Pulp on a dedicated pre-installed development
+instance. It is recommended not to use this machine for any other purpose, as the script will
+disable SELinux and install items as root outside of the system package manager.
+
+* Start a RHEL 7 or Fedora 20/21 x86_64 instance that will be dedicated for Pulp development with
   at least 2GB of memory and 10GB of disk space. More disk space is needed if
   you plan on syncing larger repos for test purposes.
 
@@ -19,15 +116,16 @@ development instance.
   sufficient.
 
 * As that user, ``curl -O https://raw.githubusercontent.com/pulp/pulp/master/playpen/dev-setup.sh && bash -e dev-setup.sh``.
-  Note that this installs RPMs and makes system modifications that you wouldn't
-  want to apply on a VM that was not dedicated to Pulp development.
+
+   .. warning:: Note that this installs RPMs and makes system modifications that you wouldn't
+                want to apply on a VM that was not dedicated to Pulp development.
 
 * While it runs, read the rest of this document! It details what the quickstart
   script does and gives background information on the development
   process.
 
 Source Code
-^^^^^^^^^^^
+-----------
 
 Pulp's code is stored on `GitHub <http://www.github.com/pulp>`_. The repositories should be forked
 into your personal GitHub account where all work will be done. Changes are
@@ -40,7 +138,7 @@ Read-Only). In most cases, Read-Only will be sufficient; contributions will be d
 pull requests into the Pulp repositories as described in :doc:`merging`.
 
 Dependencies
-^^^^^^^^^^^^
+------------
 
 The easiest way to download the other dependencies is to install Pulp through yum, which will pull in
 the latest dependencies according to the spec file.
@@ -70,7 +168,7 @@ updated on subsequent ``yum update`` calls. Messages are sent to the Pulp mailin
 dependencies are updated as well to serve as a reminder to update before the next code update.
 
 Installation
-^^^^^^^^^^^^
+------------
 
 Pulp can be installed to run directly from the checked out code base through ``setup.py`` scripts.
 Running these scripts requires the ``python-setuptools`` package to be installed. Additionally,
@@ -92,7 +190,7 @@ root of each git repository. The full command is::
   $ sudo python ./pulp-dev.py -I
 
 Uninstallation
-^^^^^^^^^^^^^^
+--------------
 
 The ``pulp-dev.py`` script has an uninstall option that will remove the symlinks from the system
 into the local source directory, as well as the Python packages. It is run using the ``-U`` flag:
@@ -102,7 +200,7 @@ into the local source directory, as well as the Python packages. It is run using
  $ sudo python ./pulp-dev.py -U
 
 Permissions
-^^^^^^^^^^^
+-----------
 
 The ``pulp-dev.py`` script links Pulp's WSGI application into the checked out code base. In many
 cases, Apache will not have the required permissions to serve the applications (for instance,
@@ -124,7 +222,7 @@ commands would grant Apache the required access:
 
 
 SELinux
-^^^^^^^
+-------
 
 Unfortunately, when developing Pulp SELinux needs to be disabled or run in Permissive mode. Most
 development environments will be created with ``pulp-dev.py``, which deploys Pulp onto the system
@@ -136,14 +234,14 @@ To turn off SELinux, you can use ``sudo setenforce 0`` which will set SELinux to
     SELINUX=permissive
 
 mod_python
-^^^^^^^^^^
+----------
 
 Pulp is a mod_wsgi application. The mod_wsgi and mod_python modules can not both be loaded into
 Apache at the same time as they conflict in odd ways. Either uninstall mod_python before starting
 Pulp or make sure the mod_python module is not loaded in the Apache config.
 
 Start Pulp and Related Services
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------
 
 The instructions below are written to be a simple process to start pulp. You should read the user docs for more information on each of these services. Systemd shown below,see user docs for upstart commands.
 
@@ -184,7 +282,7 @@ Login::
 The default password is ``admin``
 
 Uninstallation
-^^^^^^^^^^^^^^
+--------------
 
 The ``pulp-dev.py`` script has an uninstall option that will remove the symlinks from the system
 into the local source directory. It is run using the ``-U`` flag:

--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -120,8 +120,6 @@ if [ "$(pulp-admin rpm repo list | grep zoo)" = "" ]; then
 fi
 
 echo -e '\n\nDone. You should be able to run 'pulp-admin' successfully! Here are some tips:\n'
-echo -e "\t* If this is your first time running this script, you should source your .bashrc file:\n"
-echo -e "\t\t$ . ~/.bashrc"
 echo -e "\n\t* Your code is all checked out inside of ~/devel/."
 echo -e "\n\t* The default username:password is admin:admin. When your session expires, you can log"
 echo -e "\t  in again with pulp-admin login -u admin"


### PR DESCRIPTION
This commit adds documentation of our new Vagrant setup, as well as
configuring it to use NFS to share the code rather than rsync which was
very slow.