### PR TITLE
Allow basic auth when syncing from repos

### DIFF
--- a/client_lib/test/unit/test_commands_importer_config.py
+++ b/client_lib/test/unit/test_commands_importer_config.py
@@ -29,13 +29,14 @@ class MixinTest(PulpCliCommand, importer_config.ImporterConfigMixin):
     """
 
     def __init__(self, options_bundle=None, include_sync=True, include_ssl=True, include_proxy=True,
-                 include_throttling=True, include_unit_policy=True):
+                 include_throttling=True, include_unit_policy=True, include_basic_auth=True):
         PulpCliCommand.__init__(self, 'mixin', '', self.run)
         importer_config.ImporterConfigMixin.__init__(self,
                                                      options_bundle=options_bundle,
                                                      include_sync=include_sync,
                                                      include_ssl=include_ssl,
                                                      include_proxy=include_proxy,
+                                                     include_basic_auth=include_basic_auth,
                                                      include_throttling=include_throttling,
                                                      include_unit_policy=include_unit_policy)
 
@@ -65,16 +66,18 @@ class ImporterConfigMixinTests(base.PulpClientTests):
         tested separately.
         """
 
-        self.assertEqual(5, len(self.mixin.option_groups))
+        self.assertEqual(6, len(self.mixin.option_groups))
         group_names = [g.name for g in self.mixin.option_groups]
         expected_names = [importer_config.GROUP_NAME_SYNC, importer_config.GROUP_NAME_SSL,
                           importer_config.GROUP_NAME_PROXY, importer_config.GROUP_NAME_THROTTLING,
-                          importer_config.GROUP_NAME_UNIT_POLICY]
+                          importer_config.GROUP_NAME_UNIT_POLICY,
+                          importer_config.GROUP_NAME_BASIC_AUTH]
         self.assertEqual(set(group_names), set(expected_names))
 
     def test_groups_no_includes(self):
         self.mixin = MixinTest(include_sync=False, include_ssl=False, include_proxy=False,
-                               include_throttling=False, include_unit_policy=False)
+                               include_throttling=False, include_unit_policy=False,
+                               include_basic_auth=False)
         self.assertEqual(0, len(self.mixin.option_groups))
 
     # -- populate tests -------------------------------------------------------
@@ -106,6 +109,14 @@ class ImporterConfigMixinTests(base.PulpClientTests):
         self.assertEqual(options[1], self.mixin.options_bundle.opt_proxy_port)
         self.assertEqual(options[2], self.mixin.options_bundle.opt_proxy_user)
         self.assertEqual(options[3], self.mixin.options_bundle.opt_proxy_pass)
+
+    def test_populate_basic_auth_group(self):
+        group = [g for g in self.mixin.option_groups if g.name == importer_config.GROUP_NAME_BASIC_AUTH][0]
+        options = group.options
+
+        self.assertEqual(2, len(options))
+        self.assertEqual(options[0], self.mixin.options_bundle.opt_basic_auth_user)
+        self.assertEqual(options[1], self.mixin.options_bundle.opt_basic_auth_pass)
 
     def test_populate_throttling_group(self):
         group = [g for g in self.mixin.option_groups if g.name == importer_config.GROUP_NAME_THROTTLING][0]

--- a/common/pulp/common/plugins/importer_constants.py
+++ b/common/pulp/common/plugins/importer_constants.py
@@ -54,6 +54,14 @@ KEY_PROXY_USER = 'proxy_username'
 # Password for an authenticated proxy server
 KEY_PROXY_PASS = 'proxy_password'
 
+# -- basic auth
+
+# Username for basic auth downloads
+KEY_BASIC_AUTH_USER = 'basic_auth_username'
+
+# Password for basic auth downloads
+KEY_BASIC_AUTH_PASS = 'basic_auth_password'
+
 # -- throttling ---------------------------------------------------------------
 
 # Number of concurrent downloads to run

--- a/docs/dev-guide/integration/rest-api/repo/cud.rst
+++ b/docs/dev-guide/integration/rest-api/repo/cud.rst
@@ -22,7 +22,7 @@ Repository IDs must be unique across all repositories in the server.
 * :param:`?description,string,user-friendly text describing the repository's contents`
 * :param:`?notes,object,key-value pairs to programmatically tag the repository`
 * :param:`?importer_type_id,string,type id of importer being associated with the repository`
-* :param:`?importer_config,object,configuration the repository will use to drive the behavior of the importer`
+* :param:`?importer_config,object,configuration the repository will use to drive the behavior of the importer. Note that proxy_password and basic_auth_password will be returned as '*****' for security purposes.`
 * :param:`?distributors,array,array of objects containing values of distributor_type_id, repo_plugin_config, auto_publish, and distributor_id`
 
 | :response_list:`_`
@@ -308,6 +308,10 @@ Update the configuration for an :term:`importer` that has already been associate
 repository.
 
 Any importer configuration value that is not specified remains unchanged.
+
+Note that the importer's ``proxy_password`` and ``basic_auth_password`` fields
+will be returned as ``*****`` if they are populated. This is done for security
+purposes.
 
 | :method:`put`
 | :path:`/v2/repositories/<repo_id>/importers/<importer_id>/`

--- a/docs/user-guide/content-sources.rst
+++ b/docs/user-guide/content-sources.rst
@@ -57,6 +57,10 @@ are supported:
      An optional proxy userid.
  - **proxy_password** <str>
      An optional proxy password.
+ - **basic_auth_username** <str>
+     An optional basic auth username.
+ - **basic_auth_password** <str>
+     An optional basic auth password.
 
 Example:
  

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -10,6 +10,14 @@ New Features
 
 - Pulp now allows users to add their own :ref:`content authentication mechanisms <content_auth_mechanisms>`.
 
+- Pulp now supports using basic authentication when syncing repositories. This
+  can be enabled via ``--basicauth-user`` and ``--basicauth-pass`` when
+  creating or updating repositories. Note that this also requires support in the
+  plugin; currently only pulp_rpm supports this option.
+
+- Pulp no longer returns proxy passwords or basic authentication passwords when
+  viewing importer configurations.  Instead, ``*****`` is returned.
+
 Deprecation
 -----------
 

--- a/server/pulp/plugins/util/importer_config.py
+++ b/server/pulp/plugins/util/importer_config.py
@@ -264,6 +264,60 @@ def validate_proxy_password(config):
         raise ValueError(msg)
 
 
+def validate_basic_auth_username(config):
+    """
+    The basic_auth_username is optional. If it is set, this method will ensure
+    that it is a string, and it will also ensure that the basic_auth_password is set.
+
+    :param config: The configuration object that we are validating.
+    :type config: pulp.plugins.config.PluginCallConfiguration
+    """
+    basic_auth_username = config.get(importer_constants.KEY_BASIC_AUTH_USER)
+    # basic_auth username is not required unless the password is set
+    if basic_auth_username is None and config.get(importer_constants.KEY_BASIC_AUTH_PASS) is None:
+        return
+    elif basic_auth_username is None:
+        # If basic_auth_password is set, basic_auth_username must also be set
+        msg = _('The configuration parameter <%(password_name)s> requires the <%(username_name)s> '
+                'parameter to also be set.')
+        msg = msg % {'password_name': importer_constants.KEY_BASIC_AUTH_PASS,
+                     'username_name': importer_constants.KEY_BASIC_AUTH_USER}
+        raise ValueError(msg)
+
+    if not isinstance(basic_auth_username, basestring):
+        msg = _('The configuration parameter <%(name)s> should be a string, but it was %(type)s.')
+        msg = msg % {'name': importer_constants.KEY_BASIC_AUTH_USER,
+                     'type': type(basic_auth_username)}
+        raise ValueError(msg)
+
+
+def validate_basic_auth_password(config):
+    """
+    The basic_auth password setting is optional. However, if it is set, it must
+    be a string. Also, if it is set, user must also be set.
+
+    :param config: The configuration object that we are validating.
+    :type config: pulp.plugins.config.PluginCallConfiguration
+    """
+    basic_auth_password = config.get(importer_constants.KEY_BASIC_AUTH_PASS)
+    if basic_auth_password is None and config.get(importer_constants.KEY_BASIC_AUTH_USER) is None:
+        return  # optional
+    elif basic_auth_password is None:
+        # If basic_auth_password is set, basic_auth_username must also be set
+        msg = _('The configuration parameter <%(username_name)s> requires the <%(password_name)s> '
+                'parameter to also be set.')
+        msg = msg % {'password_name': importer_constants.KEY_BASIC_AUTH_PASS,
+                     'username_name': importer_constants.KEY_BASIC_AUTH_USER}
+        raise ValueError(msg)
+
+    if not isinstance(basic_auth_password, basestring):
+        msg = _('The configuration parameter <%(basic_auth_password_name)s> should be a string, '
+                'but it was %(type)s.')
+        msg = msg % {'basic_auth_password_name': importer_constants.KEY_BASIC_AUTH_PASS,
+                     'type': type(basic_auth_password)}
+        raise ValueError(msg)
+
+
 def validate_validate_downloads(config):
     """
     This (humorously named) method will validate the optional config option called
@@ -367,6 +421,8 @@ VALIDATIONS = (
     validate_proxy_port,
     validate_proxy_username,
     validate_proxy_password,
+    validate_basic_auth_username,
+    validate_basic_auth_password,
     validate_validate_downloads,
     validate_remove_missing,
     validate_retain_old_count,

--- a/server/pulp/plugins/util/nectar_config.py
+++ b/server/pulp/plugins/util/nectar_config.py
@@ -44,6 +44,9 @@ def importer_config_to_nectar_config(importer_config):
         (constants.KEY_PROXY_USER, 'proxy_username'),
         (constants.KEY_PROXY_PASS, 'proxy_password'),
 
+        (constants.KEY_BASIC_AUTH_USER, 'basic_auth_username'),
+        (constants.KEY_BASIC_AUTH_PASS, 'basic_auth_password'),
+
         (constants.KEY_MAX_DOWNLOADS, 'max_concurrent'),
         (constants.KEY_MAX_SPEED, 'max_speed'),
     )

--- a/server/pulp/server/content/sources/constants.py
+++ b/server/pulp/server/content/sources/constants.py
@@ -21,6 +21,8 @@ PROXY_URL = 'proxy_url'
 PROXY_PORT = 'proxy_port'
 PROXY_USERID = 'proxy_username'
 PROXY_PASSWORD = 'proxy_password'
+BASIC_AUTH_USERID = 'basic_auth_username'
+BASIC_AUTH_PASSWORD = 'basic_auth_password'
 HEADERS = 'headers'
 
 # format: <property>, <nectar-property>, <conversion-function>
@@ -35,6 +37,8 @@ NECTAR_PROPERTIES = (
     (PROXY_PORT, 'proxy_port', int),
     (PROXY_USERID, 'proxy_username', str),
     (PROXY_PASSWORD, 'proxy_password', str),
+    (BASIC_AUTH_USERID, 'basic_auth_username', str),
+    (BASIC_AUTH_PASSWORD, 'basic_auth_password', str),
     (HEADERS, 'headers', str),
 )
 

--- a/server/pulp/server/content/sources/descriptor.py
+++ b/server/pulp/server/content/sources/descriptor.py
@@ -48,6 +48,10 @@ are supported:
      An optional proxy userid.
  - proxy_password <str>
      An optional proxy password.
+ - basic_auth_username <str>
+     An optional basic auth username.
+ - basic_auth_password <str>
+     An optional basic auth password
 
 Example:
 

--- a/server/test/unit/plugins/util/test_importer_config.py
+++ b/server/test/unit/plugins/util/test_importer_config.py
@@ -276,6 +276,71 @@ class ProxyPasswordTests(unittest.TestCase):
             self.assertTrue('int' in e[0])
 
 
+class BasicAuthUsernameTests(unittest.TestCase):
+
+    def test_valid(self):
+        config = PluginCallConfiguration({}, {importer_constants.KEY_BASIC_AUTH_PASS: 'basicpw',
+                                              importer_constants.KEY_BASIC_AUTH_USER: 'basicuser'})
+        importer_config.validate_basic_auth_username(config)
+        # no exception should be raised
+
+    def test_optional(self):
+        config = PluginCallConfiguration({}, {})
+        importer_config.validate_basic_auth_username(config)
+        # no exception should be raised
+
+    def test_password_no_username(self):
+        config = PluginCallConfiguration({}, {importer_constants.KEY_BASIC_AUTH_PASS: 'basicpw'})
+        try:
+            importer_config.validate_basic_auth_username(config)
+            self.fail()
+        except ValueError, e:
+            self.assertTrue(importer_constants.KEY_BASIC_AUTH_USER in e[0])
+            self.assertTrue(importer_constants.KEY_BASIC_AUTH_PASS in e[0])
+
+    def test_username_is_non_string(self):
+        config = PluginCallConfiguration({}, {importer_constants.KEY_BASIC_AUTH_USER: 185})
+        try:
+            importer_config.validate_basic_auth_username(config)
+            self.fail()
+        except ValueError, e:
+            self.assertTrue('int' in e[0])
+
+
+class BasicAuthPasswordTests(unittest.TestCase):
+
+    def test_valid(self):
+        config = PluginCallConfiguration(
+            {},
+            {importer_constants.KEY_BASIC_AUTH_PASS: 'basicpw',
+             importer_constants.KEY_BASIC_AUTH_USER: 'basicuser'})
+        importer_config.validate_basic_auth_password(config)
+        # no exception should be raised
+
+    def test_optional(self):
+        config = PluginCallConfiguration({}, {})
+        importer_config.validate_basic_auth_password(config)
+        # no exception should be raised
+
+    def test_username_no_password(self):
+        config = PluginCallConfiguration({}, {importer_constants.KEY_BASIC_AUTH_USER: 'user-1'})
+        try:
+            importer_config.validate_basic_auth_password(config)
+            self.fail()
+        except ValueError, e:
+            self.assertTrue(importer_constants.KEY_BASIC_AUTH_USER in e[0])
+            self.assertTrue(importer_constants.KEY_BASIC_AUTH_PASS in e[0])
+
+    def test_password_is_non_string(self):
+        config = PluginCallConfiguration({}, {importer_constants.KEY_BASIC_AUTH_PASS: 7,
+                                              importer_constants.KEY_BASIC_AUTH_USER: 'user-1'})
+        try:
+            importer_config.validate_basic_auth_password(config)
+            self.fail()
+        except ValueError, e:
+            self.assertTrue('int' in e[0])
+
+
 class SSLValidationFlagTests(unittest.TestCase):
 
     @mock.patch('pulp.plugins.util.importer_config._run_validate_is_non_required_bool')

--- a/server/test/unit/plugins/util/test_nectar_config.py
+++ b/server/test/unit/plugins/util/test_nectar_config.py
@@ -21,6 +21,9 @@ class ConfigTranslationTests(unittest.TestCase):
             constants.KEY_PROXY_USER: 'user',
             constants.KEY_PROXY_PASS: 'pass',
 
+            constants.KEY_BASIC_AUTH_USER: 'basicuser',
+            constants.KEY_BASIC_AUTH_PASS: 'basicpass',
+
             constants.KEY_MAX_DOWNLOADS: 10,
             constants.KEY_MAX_SPEED: 1024,
         }
@@ -38,6 +41,8 @@ class ConfigTranslationTests(unittest.TestCase):
         self.assertEqual(download_config.proxy_port, 8080)
         self.assertEqual(download_config.proxy_username, 'user')
         self.assertEqual(download_config.proxy_password, 'pass')
+        self.assertEqual(download_config.basic_auth_username, 'basicuser')
+        self.assertEqual(download_config.basic_auth_password, 'basicpass')
         self.assertEqual(download_config.max_concurrent, 10)
         self.assertEqual(download_config.max_speed, 1024)
 

--- a/server/test/unit/server/content/sources/test_descriptor.py
+++ b/server/test/unit/server/content/sources/test_descriptor.py
@@ -79,7 +79,9 @@ class TestDescriptor(TestCase):
             constants.PROXY_URL: 'proxy-url',
             constants.PROXY_PORT: '5000',
             constants.PROXY_USERID: 'proxy-userid',
-            constants.PROXY_PASSWORD: 'proxy-password'
+            constants.PROXY_PASSWORD: 'proxy-password',
+            constants.BASIC_AUTH_USERID: 'basic_auth-userid',
+            constants.BASIC_AUTH_PASSWORD: 'basic_auth-password'
         }
         conf = nectar_config(descriptor)
         self.assertEqual(conf.max_concurrent, 10)
@@ -92,3 +94,5 @@ class TestDescriptor(TestCase):
         self.assertEqual(conf.proxy_port, 5000)
         self.assertEqual(conf.proxy_username, descriptor[constants.PROXY_USERID])
         self.assertEqual(conf.proxy_password, descriptor[constants.PROXY_PASSWORD])
+        self.assertEqual(conf.basic_auth_username, descriptor[constants.BASIC_AUTH_USERID])
+        self.assertEqual(conf.basic_auth_password, descriptor[constants.BASIC_AUTH_PASSWORD])


### PR DESCRIPTION
Nectar already has support for basic auth when downloading files. However, Pulp
did not have an option to set this on the importer.

This commit adds a `basic_auth_username` and `basic_auth_password` to importer
configs to allow for basic auth. Options to `pulp-admin` have also been added.
Plugins will not automatically be able to use basic auth, and will have to set
`include_basic_auth=True` when using the *ImporterConfigMixin* mixin.

This commit contains an additional security-related change to obfuscate
`basic_auth_password` and `proxy_password` in importer configs when returned
via the REST api.

re #163