### PR TITLE
Adds three updates to the clustering documentation.

### DIFF
--- a/docs/dev-guide/integration/rest-api/status.rst
+++ b/docs/dev-guide/integration/rest-api/status.rst
@@ -11,9 +11,12 @@ An unauthenticated resource that shows the current status of the Pulp server. A
 want to examine ``pulp_messaging_connection``, ``pulp_database_connection``
 and ``known_workers`` to get more detailed status information.
 
-Note that this API is meant to provide an "at-a-glance" status to aid debugging
-of a Pulp deployment, and is not meant to replace monitoring of Pulp components
-in a production environment.
+.. warning:: Clustered Pulp installations have additional monitoring concerns.
+    See :ref:`clustered_monitoring` for more information.
+
+.. note:: This API is meant to provide an "at-a-glance" status to aid debugging
+    of a Pulp deployment, and is not meant to replace monitoring of Pulp
+    components in a production environment.
 
 A healthy Pulp installation will contain exactly one record for
 "resource_manager" and "scheduler" in the worker list, and one or more


### PR DESCRIPTION
* A section on clustered monitoring which identifies issues and
  workarounds for the /status/ API in clustered environments.

* A section on pulp-admin configuration for clustered
  environments.

* Generalizes the load balancer docs to include DNS based load
  balancing in addition to TCP based load balancing.

re #915
re #282

https://pulp.plan.io/issues/915
https://pulp.plan.io/issues/282