### PR TITLE
Update docs for task notification messages

### DIFF
--- a/docs/dev-guide/integration/events/index.rst
+++ b/docs/dev-guide/integration/events/index.rst
@@ -9,15 +9,45 @@ status. This is enabled by setting ``event_notifications_enabled`` under
 ``event_notification_url`` may be set if the notification AMQP server is not
 running locally on port 5672.
 
-Messages are published to the ``pulp.api.v2`` topic exchange. Currently only
-task status updates are published; they have a routing key of ``tasks.<task
-uuid>``. This allows a message consumer to only subscribe to updates for tasks
-they are interested in.
+.. warning::
+   It is highly recommended to use ``python-kombu-3.0.24-6.pulp`` or newer
+   which includes a fix for a connection leak.
 
-The body of the message is a TaskStatus object in JSON form. It typically
+
+Messages are published to the ``pulp.api.v2`` topic exchange. Currently only
+task status updates are published; they have a routing key of
+``tasks.<task-uuid>``. This allows a message consumer to only subscribe to
+updates for tasks they are interested in.
+
+The body of the message is a :ref:`task_report` object in JSON form. It typically
 contains the task's ID, task status and detailed information about the task's
 progress.
 
+This example script will read all events from the exchange and print them:
+
+::
+
+  import base64
+  from qpid.messaging import Connection
+
+  receiver = Connection.establish('localhost:5672').session().receiver('pulp.api.v2')
+
+  try:
+      while True:
+          message = receiver.fetch()
+          print base64.b64decode(message.content['body'])
+  except KeyboardInterrupt:
+      print ''
+
+It is important to note that a sync and publish of a small RPM repo can
+generate upwards of 400 messages. We do not queue task status update messages
+for later delivery due to the number of messages that may pile up.
+
+If you know the UUID of a task you are interested in, you can subscribe to
+messages related to that particular task by adding a subject to the listener.
+In the example above, this would be done by replacing ``pulp.api.v2`` with
+``pulp.api.v2/tasks.<task-uuid>``. The task's UUID is returned by any API calls
+that generate asynchronous work.
 
 Notifiers
 ---------

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -258,6 +258,11 @@
 #     default is 'amq.topic', which is a default exchange that is guaranteed to exist on a Qpid
 #     broker. This setting is a string, and therefore includes the single quotes.
 #
+# event_notifications_enabled:
+#     Enables or disables Pulp event notfications on the message bus. Defaults to 'false'.
+#
+# event_notification_url:
+#     The AMQP URL for event notifications. Defaults to 'qpid://localhost:5672/'.
 
 [messaging]
 # url: tcp://localhost:5672
@@ -266,6 +271,8 @@
 # cacert: /etc/pki/qpid/ca/ca.crt
 # clientcert: /etc/pki/qpid/client/client.pem
 # topic_exchange: 'amq.topic'
+# event_notifications_enabled: false
+# event_notification_url: qpid://localhost:5672/
 
 
 # = Asynchronous Tasks =


### PR DESCRIPTION
The previous docs were not suitable for someone who wanted to integrate with
Pulp but was not already familiar with TaskStatus objects.

This patch adds some examples and further explanation on task notifications and
how to use them.