### PR TITLE
API call to Update a scheduled publish returns 400 with invalid schedule_id

### DIFF
--- a/server/pulp/server/managers/schedule/utils.py
+++ b/server/pulp/server/managers/schedule/utils.py
@@ -98,7 +98,9 @@ def delete(schedule_id):
     try:
         spec = {'_id': ObjectId(schedule_id)}
     except InvalidId:
-        raise exceptions.InvalidValue(['schedule_id'])
+        # During schedule deletion, MissingResource should be raised even if
+        # schedule_id is invalid object_id.
+        raise exceptions.MissingResource(schedule_id=schedule_id)
 
     schedule = ScheduledCall.get_collection().find_and_modify(
         query=spec, remove=True, safe=True)
@@ -147,7 +149,9 @@ def update(schedule_id, delta):
     try:
         spec = {'_id': ObjectId(schedule_id)}
     except InvalidId:
-        raise exceptions.InvalidValue(['schedule_id'])
+        # During schedule update, MissingResource should be raised even if
+        # schedule_id is invalid object_id.
+        raise exceptions.MissingResource(schedule_id=schedule_id)
     schedule = ScheduledCall.get_collection().find_and_modify(
         query=spec, update={'$set': delta}, safe=True, new=True)
     if schedule is None:

--- a/server/test/unit/server/managers/schedule/test_utils.py
+++ b/server/test/unit/server/managers/schedule/test_utils.py
@@ -217,7 +217,11 @@ class TestDelete(unittest.TestCase):
         mock_get_collection.assert_called_once_with()
 
     def test_invalid_schedule_id(self):
-        self.assertRaises(exceptions.InvalidValue, utils.delete, 'notavalidid')
+        """
+        make sure that during deletion of schedule MissingResource is raised
+        even if the schedule_id is not a valid object_id
+        """
+        self.assertRaises(exceptions.MissingResource, utils.delete, 'notavalidid')
 
 
 class TestDeleteByResource(unittest.TestCase):
@@ -305,7 +309,8 @@ class TestUpdate(unittest.TestCase):
         self.assertEqual(mock_find.call_count, 1)
 
     def test_invalid_schedule_id(self):
-        self.assertRaises(exceptions.InvalidValue, utils.update, 'notavalidid', {'enabled': True})
+        self.assertRaises(exceptions.MissingResource, utils.update, 'notavalidid',
+                          {'enabled': True})
 
 
 class TestResetFailureCount(unittest.TestCase):
@@ -335,6 +340,10 @@ class TestResetFailureCount(unittest.TestCase):
         mock_get_collection.assert_called_once_with()
 
     def test_invalid_schedule_id(self):
+        """
+        make sure that during update of schedule MissingResource is raised
+        even if the schedule_id is not a valid object_id
+        """
         self.assertRaises(exceptions.InvalidValue, utils.reset_failure_count, 'notavalidid')
 
 


### PR DESCRIPTION
closes #768

This issue also was present in update/delete methods in schedule sync/publish and in
consumer schedule content install/update/uninstall.


Manual testing for:
scheduled sync http://fpaste.org/215722/43012388/
scheduled publish http://fpaste.org/215721/43012374/
scheduled consumer content install http://fpaste.org/215723/24126143/ (skipped update/uninstall - they are the same)