### PR TITLE
Consumer/consumer_group content management should have 'execute' permission and not 'create'

### DIFF
--- a/docs/dev-guide/integration/rest-api/consumer/content.rst
+++ b/docs/dev-guide/integration/rest-api/consumer/content.rst
@@ -21,7 +21,7 @@ performs the operation.
 
 | :method:`post`
 | :path:`/v2/consumers/<consumer_id>/actions/content/install/`
-| :permission:`create`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`units,array,array of content units to install`
@@ -73,7 +73,7 @@ performs the operation.
 
 | :method:`post`
 | :path:`/v2/consumers/<consumer_id>/actions/content/update/`
-| :permission:`create`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`units,array,array of content units to update`
@@ -122,7 +122,7 @@ performs the operation.
 
 | :method:`post`
 | :path:`/v2/consumers/<consumer_id>/actions/content/uninstall/`
-| :permission:`create`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`units,array,array of content units to uninstall`

--- a/docs/dev-guide/integration/rest-api/consumer/group/content.rst
+++ b/docs/dev-guide/integration/rest-api/consumer/group/content.rst
@@ -21,7 +21,7 @@ content are handler specific.  The options drive how the handler performs the op
 
 | :method:`post`
 | :path:`/v2/consumer_groups/<group_id>/actions/content/install/`
-| :permission:`create`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`units,array,array of content units to install`
@@ -72,7 +72,7 @@ content are handler specific.  The options drive how the handler performs the op
 
 | :method:`post`
 | :path:`/v2/consumer_groups/<group_id>/actions/content/update/`
-| :permission:`create`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`units,array,array of content units to update`
@@ -125,7 +125,7 @@ content are handler specific.  The options drive how the handler performs the op
 
 | :method:`post`
 | :path:`/v2/consumer_groups/<group_id>/actions/content/uninstall/`
-| :permission:`create`
+| :permission:`execute`
 | :param_list:`post`
 
 * :param:`units,array,array of content units to uninstall`

--- a/server/pulp/server/webservices/views/consumer_groups.py
+++ b/server/pulp/server/webservices/views/consumer_groups.py
@@ -199,7 +199,7 @@ class ConsumerGroupContentActionView(View):
     Views for content manipulation on consumer group.
     """
 
-    @auth_required(authorization.CREATE)
+    @auth_required(authorization.EXECUTE)
     @json_body_allow_empty
     def post(self, request, consumer_group_id, action):
         """

--- a/server/pulp/server/webservices/views/consumers.py
+++ b/server/pulp/server/webservices/views/consumers.py
@@ -363,7 +363,7 @@ class ConsumerContentActionView(View):
     Views for content manipulation on the consumer.
     """
 
-    @auth_required(authorization.CREATE)
+    @auth_required(authorization.EXECUTE)
     @json_body_required
     def post(self, request, consumer_id, action):
         """

--- a/server/test/unit/server/webservices/views/test_consumer_groups.py
+++ b/server/test/unit/server/webservices/views/test_consumer_groups.py
@@ -439,7 +439,7 @@ class TestConsumerGroupContentActionView(unittest.TestCase):
     """
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     def test_consumer_group_bad_request_content(self):
         """
         Test consumer group invalid content action.
@@ -452,7 +452,7 @@ class TestConsumerGroupContentActionView(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumer_groups.factory')
     def test_consumer_group_content_install(self, mock_factory):
         """
@@ -468,7 +468,7 @@ class TestConsumerGroupContentActionView(unittest.TestCase):
             'my-group', [], {})
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumer_groups.factory')
     def test_consumer_group_content_update(self, mock_factory):
         """
@@ -484,7 +484,7 @@ class TestConsumerGroupContentActionView(unittest.TestCase):
             'my-group', [], {})
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumer_groups.factory')
     def test_consumer_group_content_uninstall(self, mock_factory):
         """

--- a/server/test/unit/server/webservices/views/test_consumers.py
+++ b/server/test/unit/server/webservices/views/test_consumers.py
@@ -4,7 +4,8 @@ import unittest
 import mock
 from django.http import HttpResponseBadRequest
 
-from base import assert_auth_CREATE, assert_auth_DELETE, assert_auth_READ, assert_auth_UPDATE
+from base import (assert_auth_CREATE, assert_auth_DELETE, assert_auth_EXECUTE, assert_auth_READ,
+                  assert_auth_UPDATE)
 from pulp.server.exceptions import (InvalidValue, MissingResource, MissingValue,
                                     OperationPostponed, UnsupportedValue)
 from pulp.server.webservices.views import consumers
@@ -704,7 +705,7 @@ class TestConsumerContentActionView(unittest.TestCase):
     """
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     def test_consumer_bad_request_content(self):
         """
         Test consumer invalid content action.
@@ -717,7 +718,7 @@ class TestConsumerContentActionView(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_manager')
     def test_consumer_content_install_missing_cons(self, mock_consumer):
         """
@@ -737,7 +738,7 @@ class TestConsumerContentActionView(unittest.TestCase):
         self.assertEqual(response.error_data['resources'], {'consumer_id': 'my-consumer'})
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_manager')
     def test_consumer_content_install_missing_units(self, mock_consumer):
         """
@@ -757,7 +758,7 @@ class TestConsumerContentActionView(unittest.TestCase):
         self.assertEqual(response.error_data['property_names'], ['units'])
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_manager')
     def test_consumer_content_install_missing_options(self, mock_consumer):
         """
@@ -777,7 +778,7 @@ class TestConsumerContentActionView(unittest.TestCase):
         self.assertEqual(response.error_data['property_names'], ['options'])
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_manager')
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_agent_manager')
     def test_consumer_content_install(self, mock_factory, mock_consumer):
@@ -795,7 +796,7 @@ class TestConsumerContentActionView(unittest.TestCase):
             'my-consumer', [], {})
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_manager')
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_agent_manager')
     def test_consumer_content_update(self, mock_factory, mock_consumer):
@@ -813,7 +814,7 @@ class TestConsumerContentActionView(unittest.TestCase):
             'my-consumer', [], {})
 
     @mock.patch('pulp.server.webservices.controllers.decorators._verify_auth',
-                new=assert_auth_CREATE())
+                new=assert_auth_EXECUTE())
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_manager')
     @mock.patch('pulp.server.webservices.views.consumers.factory.consumer_agent_manager')
     def test_consumer_content_uninstall(self, mock_factory, mock_consumer):


### PR DESCRIPTION
closes #825
Same for consumer.