### PR TITLE
ref #214, support distributor search.

### DIFF
--- a/docs/dev-guide/integration/rest-api/repo/retrieval.rst
+++ b/docs/dev-guide/integration/rest-api/repo/retrieval.rst
@@ -423,3 +423,51 @@ Retrieves a single :term:`distributors <distributor>` associated with a reposito
    "id": "dist_1"
  }
 
+Advanced Search for Distributors
+--------------------------------
+
+Please see :ref:`search_api` for more details on how to perform these searches.
+
+Returns information on distributors in the Pulp server that match your search
+parameters. It is worth noting that this call will never return a 404; an empty
+array is returned in the case where there are no distributors.
+
+| :method:`post`
+| :path:`/v2/distributors/search/`
+| :permission:`read`
+| :param_list:`post`
+
+| :response_list:`_`
+
+* :response_code:`200,containing the array of distributors`
+
+| :return:`a list of distributor objects`
+
+:sample_response:`200` ::
+
+    [
+      {
+        "repo_id": "el7",
+        "last_publish": "2015-04-28T18:19:01Z",
+        "auto_publish": null,
+        "scheduled_publishes": [],
+        "distributor_type_id": "ostree_web_distributor",
+        "scratchpad": null,
+        "config": {
+          "relative_path": "/opt/content/ostree/el7"
+        },
+        "id": "ostree_web_distributor_name_cli"
+      },
+      {
+        "repo_id": "el6",
+        "last_publish": "2015-5-28T18:18:01Z",
+        "auto_publish": null,
+        "scheduled_publishes": [],
+        "distributor_type_id": "ostree_web_distributor",
+        "scratchpad": null,
+        "config": {
+          "relative_path": "/opt/content/ostree/el6"
+        },
+        "id": "ostree_web_distributor_name_cli"
+      }
+    ]

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -41,6 +41,9 @@ New Features
 - Pulp no longer returns proxy passwords or basic authentication passwords when
   viewing importer configurations.  Instead, ``*****`` is returned.
 
+* Added ``/v2/distributors/search/`` REST API endpoint to support distributor searches.
+
+
 Deprecation
 -----------
 

--- a/server/pulp/server/db/migrations/0017_distributor_last_published.py
+++ b/server/pulp/server/db/migrations/0017_distributor_last_published.py
@@ -1,0 +1,17 @@
+from pulp.common.dateutils import parse_iso8601_datetime
+from pulp.server.db.model.repository import RepoDistributor
+
+
+def migrate(*args, **kwargs):
+    """
+    Convert last_published iso8601 string to native date object.
+    """
+    key = 'last_publish'
+    collection = RepoDistributor.get_collection()
+    for distributor in collection.find():
+        last_publish = distributor[key]
+        if not isinstance(last_publish, basestring):
+            # already migrated
+            continue
+        distributor[key] = parse_iso8601_datetime(last_publish)
+        collection.save(distributor, safe=True)

--- a/server/pulp/server/managers/repo/distributor.py
+++ b/server/pulp/server/managers/repo/distributor.py
@@ -89,6 +89,19 @@ class RepoDistributorManager(object):
         return list(RepoDistributor.get_collection().find(spec, projection))
 
     @staticmethod
+    def find_by_criteria(criteria):
+        """
+        Find distributors by criteria.
+
+        :param criteria: The search criteria.
+        :type criteria: pulp.server.db.model.criteria.Criteria
+        :return: list of: RepoDistributor
+        :rtype: list
+        """
+        collection = RepoDistributor.get_collection()
+        return collection.query(criteria)
+
+    @staticmethod
     def add_distributor(repo_id, distributor_type_id, repo_plugin_config,
                         auto_publish, distributor_id=None):
         """

--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -50,7 +50,7 @@ from pulp.server.webservices.views.repo_groups import (
     RepoGroupUnassociateView
 )
 from pulp.server.webservices.views.repositories import(
-    ContentApplicabilityRegenerationView, RepoDistributorResourceView,
+    ContentApplicabilityRegenerationView, RepoDistributorResourceView, RepoDistributorsSearchView,
     RepoDistributorsView, RepoAssociate, RepoImporterResourceView, RepoImportersView,
     RepoImportUpload, RepoPublish, RepoPublishHistory, RepoPublishScheduleResourceView,
     RepoPublishSchedulesView, RepoResourceView, RepoSearch, RepoSync, RepoSyncHistory,
@@ -150,6 +150,8 @@ urlpatterns = patterns('',
         name='content_upload_resource'),
     url(r'^v2/content/uploads/(?P<upload_id>[^/]+)/(?P<offset>[^/]+)/$',
         UploadSegmentResourceView.as_view(), name='content_upload_segment_resource'),
+    url(r'^v2/distributors/search/$', RepoDistributorsSearchView.as_view(),
+        name='distributor_search'),
     url(r'^v2/events/$', EventView.as_view(), name='events'),
     url(r'^v2/events/(?P<event_listener_id>[^/]+)/$', EventResourceView.as_view(), name='event_resource'),
     url(r'^v2/permissions/$', PermissionView.as_view(), name='permissions'),

--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -12,6 +12,7 @@ from pulp.server.managers.consumer.applicability import regenerate_applicability
 from pulp.server.managers.content.upload import import_uploaded_unit
 from pulp.server.managers.repo import query as repo_query
 from pulp.server.managers.repo import importer as repo_importer_manager
+from pulp.server.managers.repo.distributor import RepoDistributorManager
 from pulp.server.managers.repo.unit_association import associate_from_repo, unassociate_by_criteria
 from pulp.server.tasks import repository as repo_tasks
 from pulp.server.webservices.controllers.decorators import auth_required
@@ -722,6 +723,15 @@ class RepoDistributorsView(View):
         )
         response = generate_json_response_with_pulp_encoder(distributor)
         return generate_redirect_response(response, distributor['_href'])
+
+
+class RepoDistributorsSearchView(search.SearchView):
+    """
+    Distributor search view.
+    """
+
+    manager = RepoDistributorManager()
+    response_builder = staticmethod(generate_json_response_with_pulp_encoder)
 
 
 class RepoDistributorResourceView(View):

--- a/server/test/unit/plugins/conduits/test_repo_publish.py
+++ b/server/test/unit/plugins/conduits/test_repo_publish.py
@@ -57,15 +57,15 @@ class RepoPublishConduitTests(base.PulpServerTests):
         self.assertTrue(unpublished is None)
 
         # Setup - Previous publish
-        last_publish = datetime.datetime.now()
+        last_publish = datetime.datetime(2015, 4, 29, 20, 23, 56, 0)
         repo_dist = RepoDistributor.get_collection().find_one({'repo_id': 'repo-1'})
-        repo_dist['last_publish'] = dateutils.format_iso8601_datetime(last_publish)
+        repo_dist['last_publish'] = last_publish
         RepoDistributor.get_collection().save(repo_dist, safe=True)
 
         # Test - Last publish
         found = self.conduit.last_publish()
         self.assertTrue(isinstance(found, datetime.datetime))  # check returned format
-        self.assertEqual(repo_dist['last_publish'], dateutils.format_iso8601_datetime(found))
+        self.assertEqual(repo_dist['last_publish'], found)
 
     @mock.patch('pulp.server.managers.repo.publish.RepoPublishManager.last_publish')
     def test_last_publish_with_error(self, mock_call):

--- a/server/test/unit/server/db/migrations/test_0017_distributor_list_published.py
+++ b/server/test/unit/server/db/migrations/test_0017_distributor_list_published.py
@@ -1,0 +1,51 @@
+from copy import deepcopy
+from datetime import datetime
+from unittest import TestCase
+
+from mock import patch, Mock, call
+
+from pulp.server.db.migrate.models import MigrationModule
+
+LAST_PUBLISH = 'last_publish'
+MIGRATION = 'pulp.server.db.migrations.0017_distributor_last_published'
+
+
+class TestMigration(TestCase):
+    """
+    Test the migration.
+    """
+
+    @patch('.'.join((MIGRATION, 'parse_iso8601_datetime')))
+    @patch('.'.join((MIGRATION, 'RepoDistributor')))
+    def test_migrate(self, distributor, parse_iso8601_datetime):
+        collection = Mock()
+        found = [
+            {LAST_PUBLISH: '2015-04-28T18:19:01Z'},
+            {LAST_PUBLISH: datetime.now()},
+            {LAST_PUBLISH: '2015-04-28T18:20:01Z'},
+            {LAST_PUBLISH: datetime.now()},
+        ]
+        parsed = [1, 2]
+        collection.find.return_value = deepcopy(found)
+        distributor.get_collection.return_value = collection
+        parse_iso8601_datetime.side_effect = parsed
+
+        # test
+        module = MigrationModule(MIGRATION)._module
+        module.migrate()
+
+        # validation
+        distributor.get_collection.assert_called_once_with()
+        collection.find.assert_called_once_with()
+        self.assertEqual(
+            parse_iso8601_datetime.call_args_list,
+            [
+                call(found[0][LAST_PUBLISH]),
+                call(found[2][LAST_PUBLISH]),
+            ])
+        self.assertEqual(
+            collection.save.call_args_list,
+            [
+                call({LAST_PUBLISH: parsed[0]}, safe=True),
+                call({LAST_PUBLISH: parsed[1]}, safe=True)
+            ])

--- a/server/test/unit/server/managers/repo/test_distributor.py
+++ b/server/test/unit/server/managers/repo/test_distributor.py
@@ -712,3 +712,17 @@ class RepoDistributorManagerTests(base.PulpServerTests):
         self.distributor_manager.find_by_repo_list(['repo-1'])
         self.assertTrue(mock_get_collection.return_value.find.called)
         mock_get_collection.return_value.find.assert_called_once_with(EXPECT, PROJECTION)
+
+    @mock.patch.object(RepoDistributor, 'get_collection')
+    def test_find_by_criteria(self, get_collection):
+        criteria = mock.Mock()
+        collection = mock.Mock()
+        get_collection.return_value = collection
+
+        # test
+        result = self.distributor_manager.find_by_criteria(criteria)
+
+        # validation
+        get_collection.assert_called_once_with()
+        collection.query.assert_called_once_with(criteria)
+        self.assertEqual(result, collection.query.return_value)

--- a/server/test/unit/server/webservices/views/test_repositories.py
+++ b/server/test/unit/server/webservices/views/test_repositories.py
@@ -5,18 +5,20 @@ import unittest
 import json
 import mock
 
-from .base import (assert_auth_CREATE, assert_auth_DELETE, assert_auth_EXECUTE, assert_auth_READ,
-                   assert_auth_UPDATE)
+from base import (
+    assert_auth_CREATE, assert_auth_DELETE, assert_auth_EXECUTE, assert_auth_READ,
+    assert_auth_UPDATE
+)
 from pulp.common import constants, dateutils, error_codes
 from pulp.server import exceptions as pulp_exceptions
-from pulp.server.managers.repo import query as repo_query
-from pulp.server.webservices.views import repositories, util
+from pulp.server.managers.repo import query as repo_query, distributor
+from pulp.server.webservices.views import repositories, util, search
 from pulp.server.webservices.views.repositories import(
     ContentApplicabilityRegenerationView, RepoAssociate, RepoDistributorResourceView,
-    RepoDistributorsView, RepoImportUpload, RepoImporterResourceView, RepoImportersView,
-    RepoPublish, RepoPublishHistory, RepoPublishScheduleResourceView, RepoPublishSchedulesView,
-    RepoResourceView, RepoSearch, RepoSync, RepoSyncHistory, RepoSyncScheduleResourceView,
-    RepoSyncSchedulesView, RepoUnassociate, RepoUnitSearch, ReposView
+    RepoDistributorsView, RepoDistributorsSearchView, RepoImportUpload, RepoImporterResourceView,
+    RepoImportersView, RepoPublish, RepoPublishHistory, RepoPublishScheduleResourceView,
+    RepoPublishSchedulesView, RepoResourceView, RepoSearch, RepoSync, RepoSyncHistory,
+    RepoSyncScheduleResourceView, RepoSyncSchedulesView, RepoUnassociate, RepoUnitSearch, ReposView
 )
 
 
@@ -1270,6 +1272,17 @@ class TestRepoDistributorsView(unittest.TestCase):
         mock_resp.assert_called_once_with(mock_dist)
         mock_redir.assert_called_once_with(mock_resp.return_value, mock_rev.return_value)
         self.assertTrue(response is mock_redir.return_value)
+
+
+class TestRepoDistributorsSearchView(unittest.TestCase):
+
+    def test_view(self):
+        view = RepoDistributorsSearchView()
+        self.assertTrue(isinstance(view, search.SearchView))
+        self.assertTrue(isinstance(RepoDistributorsSearchView.manager,
+                                   distributor.RepoDistributorManager))
+        self.assertEqual(RepoDistributorsSearchView.response_builder,
+                         util.generate_json_response_with_pulp_encoder)
 
 
 class TestRepoDistributorResourceView(unittest.TestCase):


### PR DESCRIPTION
Contained in the PR:
- Change storage of *last_publish* on distributors from iso8601 string to native date object in mongo.  This is needed to support date range searches.  The API will continue to return this field as an ios8601 string so backwards compatibility is maintained.
- The distributor  *last_publish* only updated on successful publish.
- Added /v2/distributors/seach/ endpoint to support search.