### PR TITLE
Added a label for importer config

### DIFF
--- a/docs/user-guide/server.rst
+++ b/docs/user-guide/server.rst
@@ -142,6 +142,8 @@ Plugins
 Many Pulp plugins support these settings in their config files. Rather than documenting these
 settings in each project repeatedly, the commonly accepted key-value pairs are documented below.
 
+.. _importer-config:
+
 Importers
 ~~~~~~~~~
 


### PR DESCRIPTION
This patch adds a label to the importer config section. This label is needed so that other projects can reference this section. 