### PR TITLE
Updates bug filing docs with changes to Tags

### DIFF
--- a/docs/dev-guide/contributing/bugs.rst
+++ b/docs/dev-guide/contributing/bugs.rst
@@ -101,10 +101,6 @@ Tag Name           Usage
 ================   ===============================================================
 Documentation      The bug/story itself is documentation related.
 EasyFix            A bug that is simple to fix, at least in theory.
-Groomed            Usually reserved for stories to indicate they have enough
-                   detail to be actionable.
-Sprint Candidate   Usually reserved for stories. It indicates a story is ready to
-                   go on the short list of stories to work on soon.
 ================   ===============================================================
 
 You may occasionally see discussion in #pulp or on the mailing list about "bug


### PR DESCRIPTION
The Redmine custom field 'Tags' at pulp.plan.io no longer has
the 'Groomed' or 'Sprint Candidate' options. Those have been
removed so this removes references from the bug filing docs
to match.