### PR TITLE
ref #666, fix dups in binding list.

### DIFF
--- a/client_lib/pulp/client/commands/consumer/query.py
+++ b/client_lib/pulp/client/commands/consumer/query.py
@@ -68,18 +68,18 @@ class ConsumerListCommand(PulpCliCommand):
         if not bindings:
             return
 
-        confirmed = []
-        unconfirmed = []
+        confirmed = set()
+        unconfirmed = set()
 
         for binding in bindings:
             repo_id = binding['repo_id']
 
             if binding['deleted'] or len(binding['consumer_actions']):
-                unconfirmed.append(repo_id)
+                unconfirmed.add(repo_id)
             else:
-                confirmed.append(repo_id)
+                confirmed.add(repo_id)
 
-        consumer['bindings'] = {'confirmed': confirmed, 'unconfirmed': unconfirmed}
+        consumer['bindings'] = {'confirmed': list(confirmed), 'unconfirmed': list(unconfirmed)}
 
 
 class ConsumerSearchCommand(CriteriaCommand):

--- a/client_lib/test/unit/test_commands_consumer_query.py
+++ b/client_lib/test/unit/test_commands_consumer_query.py
@@ -79,6 +79,37 @@ class ListCommandTests(base.PulpClientTests):
         self.assertTrue(url.find('bindings=True') > 0)
         self.assertTrue(url.find('details=False') > 0)
 
+    def test_format_bindings(self):
+        bindings = [
+            {'repo_id': 'r1', 'deleted': False, 'consumer_actions': []},
+            {'repo_id': 'r1', 'deleted': False, 'consumer_actions': []},
+            {'repo_id': 'r2', 'deleted': False, 'consumer_actions': []},
+            {'repo_id': 'r3', 'deleted': True, 'consumer_actions': []},
+            {'repo_id': 'r4', 'deleted': False, 'consumer_actions': []},
+            {'repo_id': 'r5', 'deleted': False, 'consumer_actions': ['1234']},
+        ]
+        consumer = {
+            'bindings': bindings
+        }
+
+        # test
+        self.command.format_bindings(consumer)
+
+        # validation
+        self.assertEqual(sorted(consumer['bindings']['confirmed']), ['r1', 'r2', 'r4'])
+        self.assertEqual(sorted(consumer['bindings']['unconfirmed']), ['r3', 'r5'])
+
+    def test_format_bindings_none(self):
+        consumer = {
+            'bindings': []
+        }
+
+        # test
+        self.command.format_bindings(consumer)
+
+        # validation
+        self.assertEqual(sorted(consumer['bindings']), [])
+
 
 class SearchCommandTests(base.PulpClientTests):
 

--- a/nodes/extensions/admin/pulp_node/extensions/admin/commands.py
+++ b/nodes/extensions/admin/pulp_node/extensions/admin/commands.py
@@ -177,9 +177,13 @@ class NodeListCommand(ConsumerListCommand):
     def format_bindings(self, consumer):
         formatted = {}
         key = 'bindings'
-        for b in consumer.get(key, []):
-            repo_id = b['repo_id']
-            strategy = b['binding_config'].get('strategy', constants.DEFAULT_STRATEGY)
+        for binding in consumer.get(key, []):
+            repo_id = binding['repo_id']
+            type_id = binding['type_id']
+            if type_id not in constants.ALL_DISTRIBUTORS:
+                # nodes only
+                continue
+            strategy = binding['binding_config'].get('strategy', constants.DEFAULT_STRATEGY)
             repo_ids = formatted.get(strategy)
             if repo_ids is None:
                 repo_ids = []

--- a/nodes/test/unit/test_admin_extensions.py
+++ b/nodes/test/unit/test_admin_extensions.py
@@ -66,20 +66,37 @@ CONSUMERS_AND_NODES = [
 ]
 
 NODES_WITH_BINDINGS = [
-    {'notes': {constants.NODE_NOTE_KEY: True},
-     'bindings': [
-         {'repo_id': 'r1',
-          'binding_config': {constants.STRATEGY_KEYWORD: constants.DEFAULT_STRATEGY}}
-     ]},
-    {'notes': {constants.NODE_NOTE_KEY: True},
-     'bindings': [
-         {'repo_id': 'r2',
-          'binding_config': {constants.STRATEGY_KEYWORD: constants.DEFAULT_STRATEGY}},
-         {'repo_id': 'r3',
-          'binding_config': {}},  # not node binding
-         {'repo_id': 'r4',
-          'binding_config': {}},  # not node binding
-     ]},
+    {
+        'notes': {constants.NODE_NOTE_KEY: True},
+        'bindings': [
+            {
+                'repo_id': 'r1',
+                'type_id': constants.HTTP_DISTRIBUTOR,
+                'binding_config': {constants.STRATEGY_KEYWORD: constants.DEFAULT_STRATEGY}
+            }
+        ]
+    },
+    {
+        'notes': {constants.NODE_NOTE_KEY: True},
+        'bindings': [
+            {
+                'repo_id': 'r2',
+                'type_id': constants.HTTP_DISTRIBUTOR,
+                'binding_config': {constants.STRATEGY_KEYWORD: constants.DEFAULT_STRATEGY},
+            },
+            {
+                'repo_id': 'r3',
+                'type_id': 'other',
+                'binding_config': {},  # not node binding
+            },
+            {
+                'repo_id': 'r4',
+                'type_id': 'other',
+                'binding_config': {},  # not node binding
+
+            },
+        ]
+    },
 ]
 
 ALL_REPOSITORIES = [{'id': REPOSITORY_ID}, ]


### PR DESCRIPTION
https://pulp.plan.io/issues/666

This is just a display issue.

For the *consumer list* command - de-duplicate the list of repositories.

For the *node list* command - only include nodes distributors.