### PR TITLE
Set server_name to FQDN for default server config

### DIFF
--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -60,6 +60,15 @@ Deprecation
 Upgrade Instructions for 2.6.x --> 2.7.0
 -----------------------------------------
 
+.. warning::
+
+   This release adjusts the default 'server_name' in `/etc/pulp/server.conf` to be the fully
+   qualified domain name (FQDN), but previous releases on some platforms may have used the short
+   hostname. Similarly, this release adjusts the pulp-gen-ca-certificate tool to use the FQDN as
+   the `CN` in a certificate it generates. As a result of this change, you may experience a
+   hostname mismatch when you run Pulp. If you experience that issue, you can either set the value
+   of 'server_name' in /etc/pulp/server.conf or regenerate your certificate using pulp-gen-ca-certificate.
+
 All services should be stopped. At that point you can issue an upgrade via:
 
 ::

--- a/server/bin/pulp-gen-ca-certificate
+++ b/server/bin/pulp-gen-ca-certificate
@@ -26,7 +26,7 @@ PULP_CONF=(`python -c "$READ_PULP_CONF"`)
 TMP=/tmp/$RANDOM
 CA_KEY=${PULP_CONF[0]}
 CA_CRT=${PULP_CONF[1]}
-CN=`hostname`
+CN=`hostname --fqdn`
 ORG="PULP"
 
 mkdir -p $TMP

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -52,7 +52,8 @@
 # Controls general Pulp web server behavior.
 #
 # server_name:      hostname the admin client and consumers should use when accessing
-#                   the server; if not specified, this is defaulted to the server's hostname
+#                   the server; if not specified, this defaults to the server's fully qualified
+#                   domain name (FQDN)
 # default_login:    default admin username of the Pulp server; this user will be
 #                   the first time the server is started
 # default_password: default password for admin when it is first created; this

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -70,7 +70,7 @@ _default_values = {
         'serial_number_path': '/var/lib/pulp/sn.dat',
     },
     'server': {
-        'server_name': socket.gethostname(),
+        'server_name': socket.getfqdn(),
         'default_login': 'admin',
         'default_password': 'admin',
         'debugging_mode': 'false',


### PR DESCRIPTION
The server_name and the CN in certificates generated by pulp-gen-ca-certificate is
the fully qualified domain name (FQDN).

https://pulp.plan.io/issues/926

fixes #926