### PR TITLE
Remove web.py reference from setup.py

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -17,5 +17,5 @@ setup(
     install_requires=[
         'blinker', 'celery >=3.1.0, <3.2.0', 'django>=1.4.0', 'httplib2', 'iniparse',
         'isodate>=0.5.0', 'm2crypto', 'mongoengine>=0.7.10', 'oauth2>=1.5.211', 'pymongo>=2.5.2',
-        'setuptools', 'web.py']
+        'setuptools']
 )


### PR DESCRIPTION
web.py is not available on "fresh" 2.7 installs from RPM, which causes
pulp-manage-db to not run.

fixes #959

https://pulp.plan.io/issues/959