### PR TITLE
Fixes a file descriptor leak in python-kombu

### DIFF
--- a/deps/python-kombu/476.patch
+++ b/deps/python-kombu/476.patch
@@ -1,0 +1,63 @@
+From 25c56d955b81cf0c8a688c4bdf173cbde4fc220c Mon Sep 17 00:00:00 2001
+From: Jeff Ortel <jortel@redhat.com>
+Date: Fri, 8 May 2015 15:04:22 -0500
+Subject: [PATCH] Fix #476, file descriptor leak in transport.qpid.Transport.
+
+---
+ kombu/tests/transport/test_qpid.py | 23 +++++++++++++++++++++++
+ kombu/transport/qpid.py            | 11 +++++++++++
+ 2 files changed, 34 insertions(+)
+
+diff --git a/kombu/tests/transport/test_qpid.py b/kombu/tests/transport/test_qpid.py
+index 7ace243..3471c01 100644
+--- a/kombu/tests/transport/test_qpid.py
++++ b/kombu/tests/transport/test_qpid.py
+@@ -2023,3 +2023,26 @@ class TestTransport(ExtraAssertionsMixin, Case):
+         my_transport = Transport(self.mock_client)
+         result_params = my_transport.default_connection_params
+         self.assertDictEqual(correct_params, result_params)
++
++    @patch('os.close')
++    def test_del(self, close):
++        my_transport = Transport(self.mock_client)
++        my_transport.__del__()
++        self.assertEqual(
++            close.call_args_list,
++            [
++                ((my_transport.r,), {}),
++                ((my_transport._w,), {}),
++            ])
++
++    @patch('os.close')
++    def test_del_failed(self, close):
++        close.side_effect = OSError()
++        my_transport = Transport(self.mock_client)
++        my_transport.__del__()
++        self.assertEqual(
++            close.call_args_list,
++            [
++                ((my_transport.r,), {}),
++                ((my_transport._w,), {}),
++            ])
+diff --git a/kombu/transport/qpid.py b/kombu/transport/qpid.py
+index fb240ad..5b065d8 100644
+--- a/kombu/transport/qpid.py
++++ b/kombu/transport/qpid.py
+@@ -1707,3 +1707,14 @@ class Transport(base.Transport):
+         return {'userid': 'guest', 'password': '',
+                 'port': self.default_port, 'virtual_host': '',
+                 'hostname': 'localhost', 'sasl_mechanisms': 'PLAIN ANONYMOUS'}
++
++    def __del__(self):
++        """
++        Ensure file descriptors opened in __init__() are closed.
++        """
++        for fd in (self.r, self._w):
++            try:
++                os.close(fd)
++            except OSError:
++                # ignored
++                pass
+-- 
+1.9.3
+

--- a/deps/python-kombu/README
+++ b/deps/python-kombu/README
@@ -1,29 +1,36 @@
 Team owner: bbouters
 
-Celery 3.1.11 requires kombu>=3.0.15,<4.0, which is not in Fedora <= 20, or EPEL <= 7.
+Celery 3.1.11 requires kombu>=3.0.15,<4.0, which is not in Fedora <= 20, or
+EPEL <= 7.
 
-Pulp would like to use the Qpid transport which is available in upstream kombu>=3.0.24
+Pulp would like to use the Qpid transport which is available in upstream
+kombu>=3.0.24
 
 
 Permanent Patches:
 
-1212200.patch - This patch will need to continue to be with us forever as it works around a
-                permanent downstream issue whereby ordereddict is installed as part of the Python
-                system library, and not in site-packages. This is not contributed to upstream Kombu.
+1212200.patch - This patch will need to continue to be with us forever as it
+                works around a permanent downstream issue whereby ordereddict
+                is installed as part of the Python system library, and not in
+                site-packages. This is not contributed to upstream Kombu.
 
 
 Temporary Patches:
 
-This are contributed to upstream Kombu and will be included in a future release of Kombu, but until
-it is we include it in downstream.
+This are contributed to upstream Kombu and will be included in a future release
+of Kombu, but until it is we include it in downstream.
 
-1195361.patch - Fixes close bug where the connection was not being closed. This fixes
-                https://github.com/celery/kombu/issues/455
+1195361.patch - Fixes close bug where the connection was not being closed. This
+                fixes https://github.com/celery/kombu/issues/455
+
+476.patch - Fixes file descriptor leak issue:
+            https://github.com/celery/kombu/issues/476
 
 
 Patches that need to be contributed upstream:
 
-1182322.patch - Fixes an auth mechanism issue. This patch adds an additional string that is
-                returned when PLAIN is not available and the python-saslwrapper is installed. I
-                don't think an upstream issue was filed on this, and I don't think it is in
-                upstream yet. It should be contributed upstream.
+1182322.patch - Fixes an auth mechanism issue. This patch adds an additional
+                string that is returned when PLAIN is not available and the
+                python-saslwrapper is installed. I don't think an upstream
+                issue was filed on this, and I don't think it is in upstream
+                yet. It should be contributed upstream.

--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -22,6 +22,7 @@ Source0:        http://pypi.python.org/packages/source/k/%{srcname}/%{srcname}-%
 Patch0:         1212200.patch
 Patch1:         1182322.patch
 Patch2:         1195361.patch
+Patch3:         476.patch
 BuildArch:      noarch
 
 BuildRequires:  python2-devel
@@ -120,6 +121,7 @@ This subpackage is for python3
 
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 
 # manage requirements on rpm base
 sed -i 's/>=1.0.13,<1.1.0/>=1.3.0/' requirements/default.txt


### PR DESCRIPTION
I did a tito test build of the RPM and the patch applied cleanly. I did not bump the release because release 7 has not yet been built on koji.

This is a fix for upstream issue 476.
https://github.com/celery/kombu/issues/476

fixes #470
https://pulp.plan.io/issues/470