### PR TITLE
Add  criteria search operator.

### DIFF
--- a/docs/dev-guide/conventions/criteria.rst
+++ b/docs/dev-guide/conventions/criteria.rst
@@ -24,6 +24,15 @@ find specification syntax, the resource fields and values to match. For more
 information on the syntax, see:
 http://www.mongodb.org/display/DOCS/Querying
 
+Pulp supports an operator extension for matching date fields. The ``$date``
+operator may be used to specify ISO-8601 date strings for fields that are
+stored as a *Date* or *ISODate* (instead of string) in the database.
+
+For example::
+
+ {"created": {"$gt": {"$date": "2015-01-01T00:00:00Z"}}}
+
+
 The **sort** field is an array of arrays. Each specifying a field and a
 direction.
 

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -43,6 +43,9 @@ New Features
 
 * Added ``/v2/distributors/search/`` REST API endpoint to support distributor searches.
 
+* The ``$date`` operator added to support queries on fields stored in the database
+  as *ISODate*. See :ref:`search_criteria` for details.
+
 
 Deprecation
 -----------


### PR DESCRIPTION
https://pulp.plan.io/issues/214

To completely support the use case in #214, pulp *criteria* needs to support filters on fields stored in the DB as mongo *ISODate*.  Since filters are passed to pymongo, the value of filters on fields stored as ISODate need to be parsed and converted into python *datetime* before being passed to mongo.

This approach attempts to follow the *operator* pattern already established by mongo for expressing queries.  It introduces an operator extension named ``$date`` which coverts the iso-8601 string value into a python *datetime* object before it is handed to pymongo.