### PR TITLE
Updates to schedules are now respected by celerybeat

### DIFF
--- a/server/pulp/server/managers/schedule/utils.py
+++ b/server/pulp/server/managers/schedule/utils.py
@@ -144,6 +144,11 @@ def update(schedule_id, delta):
         interval, start_time, occurrences = dateutils.parse_iso8601_interval(delta['iso_schedule'])
         delta['schedule'] = pickle.dumps(CelerySchedule(interval))
 
+        # set first_run and next_run so that the schedule update will take effect
+        new_schedule_call = ScheduledCall(delta['iso_schedule'], 'dummytaskname')
+        delta['first_run'] = new_schedule_call.first_run
+        delta['next_run'] = new_schedule_call.next_run
+
     try:
         spec = {'_id': ObjectId(schedule_id)}
     except InvalidId:

--- a/server/test/unit/server/managers/schedule/test_utils.py
+++ b/server/test/unit/server/managers/schedule/test_utils.py
@@ -255,12 +255,10 @@ class TestUpdate(unittest.TestCase):
         self.assertTrue(isinstance(ret, ScheduledCall))
         self.assertEqual(mock_pickle.call_args_list, [])
 
-    @mock.patch('pickle.dumps')
     @mock.patch('pulp.server.db.model.dispatch.ScheduledCall.get_collection')
-    def test_update_iso_schedule(self, mock_get, mock_pickle):
+    def test_update_iso_schedule(self, mock_get):
         mock_find = mock_get.return_value.find_and_modify
         mock_find.return_value = SCHEDULES[0]
-        mock_pickle.return_value = "NEW_SCHEDULE"
 
         new_iso_sched = '2014-08-27T00:38:00Z/PT24H'
 
@@ -269,8 +267,11 @@ class TestUpdate(unittest.TestCase):
         self.assertEqual(mock_find.call_count, 1)
         self.assertEqual(len(mock_find.call_args[0]), 0)
         self.assertEqual(mock_find.call_args[1]['query'], {'_id': ObjectId(self.schedule_id)})
-        self.assertTrue(mock_find.call_args[1]['update']['$set']['iso_schedule'] == new_iso_sched)
-        self.assertTrue(mock_find.call_args[1]['update']['$set']['schedule'] == "NEW_SCHEDULE")
+        update_values = mock_find.call_args[1]['update']['$set']
+        self.assertTrue(update_values['iso_schedule'] == new_iso_sched)
+        self.assertTrue(update_values['first_run'] == '2014-08-27T00:38:00Z')
+        self.assertTrue('next_run' in update_values)
+        self.assertTrue('schedule' in update_values)
         last_updated = mock_find.call_args[1]['update']['$set']['last_updated']
         # make sure the last_updated value is within the last tenth of a second
         self.assertTrue(time.time() - last_updated < .1)


### PR DESCRIPTION
The schedule field was being updated, but next_run and
first_run were not being updated. These values are used
to determine if a schedued task should be run so updating
them is necessary.

fixes #922
https://pulp.plan.io/issues/922