### PR TITLE
Don't use full path to systemctl in pulp-dev.py.

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -354,8 +354,8 @@ def install(opts):
         os.system('chmod 3775 /var/www/pub')
         os.system('chown -R apache:apache /var/lib/pulp/published')
 
-        # Reload systemctl daemon
-        os.system('/sbin/systemctl daemon-reload')
+        # Reload systemd unit files
+        os.system('systemctl daemon-reload')
 
     if warnings:
         print "\n***\nPossible problems:  Please read below\n***"
@@ -388,6 +388,10 @@ def uninstall(opts):
 
     # Remove the Python packages
     environment.manage_setup_pys('uninstall')
+
+    if LSB_VERSION >= 6.0:
+        # Reload systemd unit files
+        os.system('systemctl daemon-reload')
 
     return os.EX_OK
 


### PR DESCRIPTION
Not all distributions put the systemctl executable in the same location.
pulp-dev.py had been calling it as /sbin/systemctl, but Fedora 21 keeps
that executable in /usr/bin/systemctl. This commit calls the executable
as just systemctl and allows the PATH variable to be used to locate it.

https://pulp.plan.io/issues/991

fixes #991