### PR TITLE
Removes duplicate calling of systemctl daemon reload

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -426,12 +426,6 @@ then
   pulp-gen-ca-certificate
 fi
 
-%if %{pulp_systemd} == 1
-  if [ $1 -eq 2 ]; # an upgrade
-  then
-    /sbin/systemctl daemon-reload > /dev/null 2>&1
-  fi
-%endif
 
 %preun server
 # If we are uninstalling


### PR DESCRIPTION
This was already being performed as a macro.
fixes #980
https://pulp.plan.io/issues/980