### PR TITLE
Speed up the vagrant provisioning.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,8 +17,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
    domain.cpus   = 2
  end
 
- config.vm.provision "shell", inline: "yum install -y deltarpm"
- config.vm.provision "shell", inline: "yum update -y"
- config.vm.provision "shell", inline: "yum install -y vagrant vagrant-libvirt vagrant-lxc"
+ config.vm.provision "shell", inline: "yum install -y dnf"
+ config.vm.provision "shell", inline: "dnf upgrade -y"
  config.vm.provision "shell", inline: "sudo -u vagrant bash -e /home/vagrant/devel/pulp/playpen/vagrant-setup.sh"
 end

--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -19,7 +19,7 @@ fi
 
 
 echo "Install some prereqs"
-sudo yum install -y wget yum-utils redhat-lsb-core
+sudo dnf install -y wget yum-utils redhat-lsb-core
 
 echo "setting up repos"
 # repo setup
@@ -34,7 +34,7 @@ else
     fi
     if ! rpm -q epel-release; then
         if [ "$(lsb_release -si)" = "CentOS" ]; then
-            sudo yum install -y epel-release
+            sudo dnf install -y epel-release
         else
             sudo rpm -Uvh http://download.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
         fi
@@ -45,7 +45,7 @@ sudo yum-config-manager --enable pulp-2.6-testing > /dev/null
 popd
 
 echo "installing some dev tools"
-sudo yum install -y vim-enhanced python-virtualenvwrapper bash-completion \
+sudo dnf install -y vim-enhanced python-virtualenvwrapper bash-completion \
                     python-django-bash-completion
 
 if ! grep WORKON_HOME ~/.bashrc; then
@@ -58,13 +58,12 @@ fi
 
 # install rpms, then remove pulp*
 echo "installing RPMs"
-sudo yum install -y @pulp-server-qpid @pulp-admin @pulp-consumer
-sudo yum remove -y pulp-\* python-pulp\*
-sudo yum install -y git mongodb mongodb-server python-django python-flake8 python-mock \
+sudo dnf install -y @pulp-server-qpid @pulp-admin @pulp-consumer
+sudo dnf remove --setopt=clean_requirements_on_remove=false -y pulp-\* python-pulp\*
+sudo dnf install -y git mongodb mongodb-server python-django python-flake8 python-mock \
                     python-mongoengine python-nose python-paste python-pip python-qpid-qmf \
                     python-setuptools python-sphinx qpid-cpp-server qpid-cpp-server-store \
                     python-unittest2
-
 
 pushd devel
 for r in {pulp,pulp_docker,pulp_openstack,pulp_ostree,pulp_puppet,pulp_python,pulp_rpm}; do
@@ -89,8 +88,11 @@ fi
 echo "Adjusting facls for apache"
 setfacl -m user:apache:rwx /home/vagrant
 
-echo "Starting services, this may take a few minutes due to mongodb journal allocation"
-for s in qpidd goferd mongod; do
+# disable mongo journaling since this is a dev setup
+sudo sed -i 's/journal = true/nojournal = true/' /etc/mongodb.conf
+
+echo "Disabling MongoDB journal and starting services"
+for s in qpidd mongod goferd; do
   sudo systemctl enable $s
   sudo systemctl start $s
 done


### PR DESCRIPTION
This commit speeds up vagrant provision in two ways:
* Turn off the mongo journal.
* Use dnf instead of yum.