### PR TITLE
Add prestart and friends to Vagrant provisioning.

### DIFF
--- a/playpen/vagrant-motd.txt
+++ b/playpen/vagrant-motd.txt
@@ -12,6 +12,9 @@ Here are some tips:
 
   Similarly, run "workon pulp" to jump into the pulp platform virtualenv.
 * Each project has a "run-tests.py" to run the unit tests.
+* There are a set of bash functions in your .bashrc that are useful: pstart,
+  pstop, prestart, pstatus. They will start, stop, restart, and tell you the
+  status of all of the Pulp services.
 * You can ssh into your vagrant environment with vagrant ssh, but presumably
   you already know this since you are reading this message :)
 


### PR DESCRIPTION
This commit adds some useful bash functions to the Vagrant provisioned
.bashrc file that will start, stop, restart, and display the status of
all the Pulp services. The functions are called pstart, pstop, prestart,
and pstatus, respectively.