### PR TITLE
Adds batch size to cursor used to iterate repo profile applicabilities

### DIFF
--- a/server/pulp/server/managers/consumer/applicability.py
+++ b/server/pulp/server/managers/consumer/applicability.py
@@ -132,9 +132,11 @@ class ApplicabilityRegenerationManager(object):
         repo_ids = [r['id'] for r in repo_query_manager.find_by_criteria(repo_criteria)]
 
         for repo_id in repo_ids:
-            # Find all existing applicabilities for given repo_id
+            # Find all existing applicabilities for given repo_id. Setting batch size of 25 ensures
+            # the MongoDB cursor does not time out. See https://pulp.plan.io/issues/998#note-6 for
+            # more details.
             existing_applicabilities = RepoProfileApplicability.get_collection().find(
-                {'repo_id': repo_id})
+                {'repo_id': repo_id}).batch_size(25)
             for existing_applicability in existing_applicabilities:
                 # Convert cursor to RepoProfileApplicability object
                 existing_applicability = RepoProfileApplicability(**dict(existing_applicability))


### PR DESCRIPTION
According to mongo documentation [0] the cursor will initially return about 101
documents or slightly more than 1 megabyte of data. The subsequent fetches return
4 times as much data. The default timeout of mongo cursor (version 2.4) is 600
seconds. This timeout cannot be adjusted until mongodb 2.6. If 400 applicability
calculations need to be performed in 600 seconds, each calculation cannot take
any longer than 1.5 seconds. In my testing I found the calculations to take 12 to
13 seconds. Limiting the batch size to 25 ensures that calculations can take up
to 24 seconds each before the cursor times out.

[0] http://docs.mongodb.org/v2.4/core/cursors/#cursor-batches

https://pulp.plan.io/issues/998
fixes #998