### PR TITLE
Fixing discrepancy "canceled" vs. "cancelled

### DIFF
--- a/bindings/pulp/bindings/responses.py
+++ b/bindings/pulp/bindings/responses.py
@@ -128,7 +128,7 @@ class Task(object):
     def is_completed(self):
         """
         Indicates if the task has finished running and will not begin again,
-        regardless of the result (error, success, or cancelled).
+        regardless of the result (error, success, or canceled).
 
         :rtype: bool
         """

--- a/client_admin/pulp/client/admin/admin_auth.py
+++ b/client_admin/pulp/client/admin/admin_auth.py
@@ -1,16 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2012 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 from gettext import gettext as _
 from M2Crypto import X509
 import os
@@ -52,7 +39,7 @@ class LoginCommand(PulpCliCommand):
             password = self.context.prompt.prompt_password(_(prompt_msg))
             if password is self.context.prompt.ABORT:
                 self.context.prompt.render_spacer()
-                self.context.prompt.write(_('Login cancelled'))
+                self.context.prompt.write(_('Login canceled'))
                 return os.EX_NOUSER
 
         result = self.context.server.actions.login(username, password).response_body

--- a/client_admin/pulp/client/admin/auth.py
+++ b/client_admin/pulp/client/admin/auth.py
@@ -160,7 +160,7 @@ class UserSection(PulpCliSection):
                                                            _(unmatch_msg))
             if password is self.context.prompt.ABORT:
                 self.context.prompt.render_spacer()
-                self.context.prompt.write(_('Create user cancelled'))
+                self.context.prompt.write(_('Create user canceled'))
                 return os.EX_NOUSER
             if not password:
                 self.context.prompt.render_spacer()

--- a/client_admin/pulp/client/admin/tasks.py
+++ b/client_admin/pulp/client/admin/tasks.py
@@ -202,7 +202,7 @@ class BaseTasksSection(PulpCliSection):
                 finish_time = _('N/A')
                 result = _('N/A')
             elif task.was_cancelled():
-                state = _('Cancelled')
+                state = _('Canceled')
                 result = _('N/A')
 
         return state, start_time, finish_time, result

--- a/client_lib/pulp/client/commands/polling.py
+++ b/client_lib/pulp/client/commands/polling.py
@@ -332,8 +332,8 @@ class PollingCommand(PulpCliCommand):
         :param task: full task report for the task being displayed
         :type  task: pulp.bindings.responses.Task
         """
-        msg = _('Task Cancelled')
-        self.prompt.render_paragraph(msg, tag='cancelled')
+        msg = _('Task Canceled')
+        self.prompt.render_paragraph(msg, tag='canceled')
 
     def rejected(self, task):
         """

--- a/client_lib/pulp/client/commands/repo/status.py
+++ b/client_lib/pulp/client/commands/repo/status.py
@@ -51,7 +51,7 @@ class PublishStepStatusRenderer(StatusRenderer):
                 for report_details in reports:
                     self.render_step(report_details)
         except CancelException:
-            self.prompt.render_failure_message(_('Operation cancelled.'))
+            self.prompt.render_failure_message(_('Operation canceled.'))
 
     def render_step(self, step_details):
         """

--- a/client_lib/pulp/client/commands/repo/upload.py
+++ b/client_lib/pulp/client/commands/repo/upload.py
@@ -81,7 +81,7 @@ class PerformUploadCommand(polling.PollingCommand):
 
         d = _('Starting upload of selected units. If this process is stopped through '
               'ctrl+c, the uploads will be paused and may be resumed later using the '
-              'resume command or cancelled entirely using the cancel command.')
+              'resume command or canceled entirely using the cancel command.')
         context.prompt.render_paragraph(d)
 
         # Upload and import each upload. The try block is inside of the loop to
@@ -631,7 +631,7 @@ class CancelCommand(PulpCliCommand):
         non_running_uploads = [u for u in uploads if not u.is_running]
         if len(non_running_uploads) == 0:
             d = _('All requests are currently in the process of being uploaded. '
-                  'Only paused uploads may be cancelled.')
+                  'Only paused uploads may be canceled.')
             self.context.prompt.render_paragraph(d)
             return
 

--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -83,7 +83,7 @@ def main(config, exception_handler_class=ExceptionHandler):
 
         if password is prompt.ABORT:
             prompt.render_spacer()
-            prompt.write(_('Login cancelled'))
+            prompt.write(_('Login canceled'))
             sys.exit(os.EX_NOUSER)
 
     server = _create_bindings(config, logger, username, password, verbose=options.verbose)

--- a/client_lib/test/unit/client/commands/test_polling.py
+++ b/client_lib/test/unit/client/commands/test_polling.py
@@ -1,15 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 import mock
 
 
@@ -364,7 +352,7 @@ class PollingCommandTests(base.PulpClientTests):
         self.assertEqual(1, len(completed_tasks))
 
         expected_tags = ['abort', 'delayed-spinner', 'running-spinner', 'running-spinner',
-                         'running-spinner','cancelled']
+                         'running-spinner','canceled']
         self.assertEqual(expected_tags, self.prompt.get_write_tags())
 
     def test_keyboard_interrupt(self):

--- a/common/pulp/common/plugins/progress.py
+++ b/common/pulp/common/plugins/progress.py
@@ -1,15 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 """
 Contains classes and functions related to tracking the progress of the
 importer and distributor.

--- a/docs/dev-guide/integration/rest-api/tasks.rst
+++ b/docs/dev-guide/integration/rest-api/tasks.rst
@@ -79,8 +79,8 @@ executing. Polling returns a :ref:`task_report`
 Cancelling a Task
 -----------------
 
-Some asynchronous tasks may be cancelled by the user before they complete. A
-task must be in the *waiting* or *running* states in order to be cancelled.
+Some asynchronous tasks may be canceled by the user before they complete. A
+task must be in the *waiting* or *running* states in order to be canceled.
 
 .. Note::
 

--- a/docs/user-guide/admin-client/tasks.rst
+++ b/docs/user-guide/admin-client/tasks.rst
@@ -101,7 +101,7 @@ The **pulp-admin** command line client provides the ``tasks`` section and the
 
  Operations:   sync
  Resources:    ff7-e6 (repository)
- State:        Cancelled
+ State:        Canceled
  Start Time:   2012-12-09T04:28:10Z
  Finish Time:  2012-12-09T04:29:09Z
  Result:       N/A

--- a/docs/user-guide/server.rst
+++ b/docs/user-guide/server.rst
@@ -18,14 +18,14 @@ For a recap of Pulp components and the work they are responsible for, read :ref:
 
 * If a ``pulp_worker`` dies, the dispatched Pulp tasks destined for that worker (both the task
   currently being worked on and queued/related tasks) will not be processed. They will stall for
-  at most six minutes before being cancelled. Status of the tasks is marked as cancelled after
+  at most six minutes before being canceled. Status of the tasks is marked as canceled after
   5 minutes or in case the worker has been re-started, whichever action occurs first.
   Cancellation after 5 minutes is dependent on ``pulp_celerybeat`` service running. A monitoring
   component inside of ``pulp_celerybeat`` monitors all workers' heartbeats. If a worker does not
   heartbeat within five minutes, it is considered missing. This check occurs once a minute, causing
-  a maximum delay of six minutes before a worker is considered missing and tasks cancelled by Pulp.
+  a maximum delay of six minutes before a worker is considered missing and tasks canceled by Pulp.
 
-  A missing worker has all tasks destined for it cancelled, and no new work is assigned to the
+  A missing worker has all tasks destined for it canceled, and no new work is assigned to the
   missing worker. This causes new Pulp operations dispatched to continue normally with the other
   available workers. If a worker with the same name is started again after being missing, it is
   added into the pool of workers as any worker starting up normally would.

--- a/nodes/child/pulp_node/handlers/model.py
+++ b/nodes/child/pulp_node/handlers/model.py
@@ -1,16 +1,3 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright © 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
-
 """
 Provides classes representing the database objects contained in either
 the parent or child pulp server.  Parent objects are read-only and are used for querying,
@@ -319,7 +306,7 @@ class Repository(Entity):
         bindings = resources.pulp_bindings()
         http = bindings.tasks.cancel_task(task.task_id)
         if http.response_code == httplib.ACCEPTED:
-            log.info('Task [%s] cancelled', task.task_id)
+            log.info('Task [%s] canceled', task.task_id)
         else:
             log.error('Task [%s] cancellation failed http=%s', task.task_id, http.response_code)
 

--- a/nodes/common/pulp_node/reports.py
+++ b/nodes/common/pulp_node/reports.py
@@ -1,17 +1,3 @@
-# Copyright (c) 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
-# --- summary reporting  -----------------------------------------------------
-
-
 class RepositoryReport(object):
     """
     Repository merge report.

--- a/nodes/extensions/admin/pulp_node/extensions/admin/rendering.py
+++ b/nodes/extensions/admin/pulp_node/extensions/admin/rendering.py
@@ -1,14 +1,3 @@
-# Copyright (c) 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 from gettext import gettext as _
 from operator import itemgetter
 


### PR DESCRIPTION
I also changed all the docs and messages not to confuse the users. I did not touch any variables' or methods' name.
closes #966
https://pulp.plan.io/issues/966

these PRs should be merged together:
https://github.com/pulp/pulp_rpm/pull/694
https://github.com/pulp/pulp_docker/pull/71