### PR TITLE
Update our troubleshooting for qpid-tools.

### DIFF
--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -219,8 +219,10 @@ On Red Hat operating systems, this is provided by the ``python-qpid`` package.
 qpidtoollibs is not installed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you are using Qpid as your message broker, you will also need the Python package
-``qpidtoollibs``. On Red Hat operating systems, this is provided by the python-qpid-qmf package.
+If you are using Qpid as your message broker, you will also need the Python
+package ``qpidtoollibs``. On Red Hat operating systems this is provided by
+either the qpid-tools package or the python-qpid-qmf package, depending on the
+versions of qpid you are using (newer qpid versions provide it with qpid-tools.)
 
 pulp-manage-db gives an error "Cannot delete queue"
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Qpid has unfortunately moved the qpidtoollibs Python package from the
python-qpid-qmf package to the qpid-tools package. This commit adds the
qpid-tools package to the troubleshooting guide in addition to the
python-qpid-qmf. We need to mention both for now since we do not know if
our users will be using the newer or older version of qpid.