### PR TITLE
Distributor config added to publish history

### DIFF
--- a/server/pulp/server/db/model/repository.py
+++ b/server/pulp/server/db/model/repository.py
@@ -427,8 +427,9 @@ class RepoPublishResult(Model, ReaperMixin):
         return r
 
     @classmethod
-    def expected_result(cls, repo_id, distributor_id, distributor_type_id, started,
-                        completed, summary, details, result_code):
+    def expected_result(cls, repo_id, distributor_id, distributor_type_id,
+                        distributor_config, started, completed, summary,
+                        details, result_code):
         """
         Creates a new history entry for a successful publish.
 
@@ -457,7 +458,8 @@ class RepoPublishResult(Model, ReaperMixin):
         @type  result_code: str
         """
 
-        r = cls(repo_id, distributor_id, distributor_type_id, started, completed, result_code)
+        r = cls(repo_id, distributor_id, distributor_type_id,
+                distributor_config, started, completed, result_code)
         r.summary = summary
         r.details = details
 
@@ -497,7 +499,8 @@ class RepoPublishResult(Model, ReaperMixin):
 
         return r
 
-    def __init__(self, repo_id, distributor_id, distributor_type_id, started, completed, result):
+    def __init__(self, repo_id, distributor_id, distributor_type_id,
+                 distributor_config, started, completed, result):
         """
         Describes the results of a single completed (potentially errored) publish.
         Rather than directory instantiating instances, use one of the above
@@ -508,6 +511,7 @@ class RepoPublishResult(Model, ReaperMixin):
         self.repo_id = repo_id
         self.distributor_id = distributor_id
         self.distributor_type_id = distributor_type_id
+        self.distributor_config = distributor_config
         self.started = started
         self.completed = completed
         self.result = result

--- a/server/pulp/server/managers/repo/publish.py
+++ b/server/pulp/server/managers/repo/publish.py
@@ -165,7 +165,9 @@ class RepoPublishManager(object):
             result_code = RepoPublishResult.RESULT_SUCCESS
 
         result = RepoPublishResult.expected_result(
-            repo_id, repo_distributor['id'], repo_distributor['distributor_type_id'],
+            repo_id, repo_distributor['id'],
+            call_config.flatten(),
+            repo_distributor['distributor_type_id'], call_config.flatten(),
             publish_start_timestamp, publish_end_timestamp, summary, details, result_code)
         publish_result_coll.save(result, safe=True)
         return result

--- a/server/test/unit/server/managers/repo/test_publish.py
+++ b/server/test/unit/server/managers/repo/test_publish.py
@@ -606,6 +606,18 @@ class RepoSyncManagerTests(base.PulpServerTests):
         self.assertRaises(publish_manager.MissingResource, self.publish_manager.publish_history,
                           'missing', 'irrelevant')
 
+    def test_publish_history_distributor_config(self):
+        """
+        Test there's distributor config included in publish history
+        """
+        # Setup
+        self.repo_manager.create_repo('test_date')
+        self.distributor_manager.add_distributor('test_date', 'mock-distributor', {}, True,
+                                                 distributor_id='test_dist')
+        add_result('test_date', 'test_dist', 1)
+        entry = self.publish_manager.publish_history('test_date', 'test_dist')[0]
+        self.assertTrue(hasattr(entry, "distributor_config"))
+
     def _test_auto_distributors(self):
         """
         Tests that the query for distributors on a repo that are configured for automatic

--- a/server/test/unit/server/managers/repo/test_publish.py
+++ b/server/test/unit/server/managers/repo/test_publish.py
@@ -482,7 +482,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
         date_string = '2013-06-01T12:00:0%sZ'
         for i in range(0, 10, 2):
             r = RepoPublishResult.expected_result(
-                'test_sort', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
+                'test_sort', 'test_dist', 'bar', {}, date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
             RepoPublishResult.get_collection().insert(r, safe=True)
 
@@ -508,7 +508,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
         date_string = '2013-06-01T12:00:0%sZ'
         for i in range(0, 10, 2):
             r = RepoPublishResult.expected_result(
-                'test_sort', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
+                'test_sort', 'test_dist', 'bar', {}, date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
             RepoPublishResult.get_collection().insert(r, safe=True)
 
@@ -543,7 +543,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
         date_string = '2013-06-01T12:00:0%sZ'
         for i in range(0, 6, 2):
             r = RepoPublishResult.expected_result(
-                'test_date', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
+                'test_date', 'test_dist', 'bar', {}, date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
             RepoPublishResult.get_collection().insert(r, safe=True)
 
@@ -569,7 +569,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
         date_string = '2013-06-01T12:00:0%sZ'
         for i in range(0, 6, 2):
             r = RepoPublishResult.expected_result(
-                'test_date', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
+                'test_date', 'test_dist', 'bar', {}, date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
             RepoPublishResult.get_collection().insert(r, safe=True)
 
@@ -617,6 +617,18 @@ class RepoSyncManagerTests(base.PulpServerTests):
         add_result('test_date', 'test_dist', 1)
         entry = self.publish_manager.publish_history('test_date', 'test_dist')[0]
         self.assertTrue(hasattr(entry, "distributor_config"))
+
+    def test_publish_history_distributor_config(self):
+        """
+        Test there's distributor config included in publish history
+        """
+        # Setup
+        self.repo_manager.create_repo('test_date')
+        self.distributor_manager.add_distributor('test_date', 'mock-distributor', {}, True,
+                                                 distributor_id='test_dist')
+        add_result('test_date', 'test_dist', 1)
+        entry = self.publish_manager.publish_history('test_date', 'test_dist')[0]
+        self.assertTrue("distributor_config" in entry, entry)
 
     def _test_auto_distributors(self):
         """
@@ -728,7 +740,7 @@ def add_result(repo_id, dist_id, offset):
     started = dateutils.now_utc_datetime_with_tzinfo()
     completed = started + datetime.timedelta(days=offset)
     r = RepoPublishResult.expected_result(
-        repo_id, dist_id, 'bar', dateutils.format_iso8601_datetime(started),
+        repo_id, dist_id, 'bar', {}, dateutils.format_iso8601_datetime(started),
         dateutils.format_iso8601_datetime(completed), 'test-summary', 'test-details',
         RepoPublishResult.RESULT_SUCCESS)
     RepoPublishResult.get_collection().insert(r, safe=True)


### PR DESCRIPTION
It could be handy to have distributor config included in each entry of publish history