### PR TITLE
- use cp instead of shutil.copytree due file attributes preservation

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -746,7 +746,7 @@ class AtomicDirectoryPublishStep(PublishStep):
         # for items where http & https are published to a separate directory
 
         _logger.debug('Copying tree from %s to %s' % (self.source_dir, timestamp_master_dir))
-        shutil.copytree(self.source_dir, timestamp_master_dir, symlinks=True)
+        os.system("cp -a %s %s" % (self.source_dir, timestamp_master_dir))
 
         for source_relative_location, publish_location in self.publish_locations:
             if source_relative_location.startswith('/'):
@@ -858,7 +858,7 @@ class CopyDirectoryStep(PublishStep):
         """
         if self.delete_before_copy:
             shutil.rmtree(self.target_dir, ignore_errors=True)
-        shutil.copytree(self.source_dir, self.target_dir, symlinks=self.preserve_symlinks)
+        os.system("cp -a %s %s" % (self.source_dir, timestamp_master_dir))
 
 
 class PluginStepIterativeProcessingMixin(object):


### PR DESCRIPTION
cp can preserver file attributes