### PR TITLE
Add support for parsing TaskStatus objects to the TaskResult object

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -232,6 +232,8 @@ class TaskResult(object):
                     self.spawned_tasks.append({'task_id': spawned_task.get('task_id')})
                 elif isinstance(spawned_task, AsyncResult):
                     self.spawned_tasks.append({'task_id': spawned_task.id})
+                elif isinstance(spawned_task, TaskStatus):
+                    self.spawned_tasks.append({'task_id': spawned_task.task_id})
                 else:  # This should be a string
                     self.spawned_tasks.append({'task_id': spawned_task})
 

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -277,13 +277,16 @@ class TestTaskResult(unittest.TestCase):
 
         async_result = AsyncResult('foo')
         test_exception = PulpException('foo')
-        result = tasks.TaskResult('foo', test_exception, [{'task_id': 'baz'}, async_result, "qux"])
+        task_status = TaskStatus(task_id='quux')
+        result = tasks.TaskResult('foo', test_exception, [{'task_id': 'baz'},
+                                                          async_result, "qux", task_status])
         serialized = result.serialize()
         self.assertEquals(serialized.get('result'), 'foo')
         compare_dict(test_exception.to_dict(), serialized.get('error'))
         self.assertEquals(serialized.get('spawned_tasks'), [{'task_id': 'baz'},
                                                             {'task_id': 'foo'},
-                                                            {'task_id': 'qux'}])
+                                                            {'task_id': 'qux'},
+                                                            {'task_id': 'quux'}])
 
 
 class TestReservedTaskMixinApplyAsyncWithReservation(ResourceReservationTests):


### PR DESCRIPTION
fixes #1011 

https://pulp.plan.io/issues/1011