### PR TITLE
Allow the vagrant users to sudo as other users.

### DIFF
--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -18,6 +18,10 @@ if ! sudo grep -q "StrictModes no" /etc/ssh/sshd_config; then
 fi
 
 
+# Allow admins to passwordless sudo for all commands as any user
+sudo sed -i 's/%admin ALL=NOPASSWD: ALL/%admin ALL=(ALL) NOPASSWD: ALL/' /etc/sudoers
+
+
 echo "Install some prereqs"
 sudo dnf install -y wget yum-utils redhat-lsb-core
 


### PR DESCRIPTION
The Vagrant box's sudoers file did not allow the -u flag to be used
without a password. This commit edits the sudoers file so that it does
allow this.