### PR TITLE
Release notes for 2.6.3

### DIFF
--- a/docs/user-guide/release-notes/2.6.x.rst
+++ b/docs/user-guide/release-notes/2.6.x.rst
@@ -2,6 +2,19 @@
 Pulp 2.6 Release Notes
 =========================
 
+Pulp 2.6.3
+==========
+
+Pulp 2.6.3 is released with packages for Fedora 22 and Fedora 21. Support for
+Fedora 20 has been dropped. Please see the `Fedora lifecycle
+<https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle#Maintenance_Schedule>`_
+for more detail.
+
+Bug Fixes
+---------
+
+This is a minor release which contains bug fixes for :fixedbugs:`these issues <2.6.3>`.
+
 Pulp 2.6.2
 ==========
 


### PR DESCRIPTION
The notes mention that Fedora 22 is supported, and Fedora 20 is dropped.