### PR TITLE
This reduces the batch size to 5

### DIFF
--- a/server/pulp/server/managers/consumer/applicability.py
+++ b/server/pulp/server/managers/consumer/applicability.py
@@ -132,11 +132,11 @@ class ApplicabilityRegenerationManager(object):
         repo_ids = [r['id'] for r in repo_query_manager.find_by_criteria(repo_criteria)]
 
         for repo_id in repo_ids:
-            # Find all existing applicabilities for given repo_id. Setting batch size of 25 ensures
+            # Find all existing applicabilities for given repo_id. Setting batch size of 5 ensures
             # the MongoDB cursor does not time out. See https://pulp.plan.io/issues/998#note-6 for
             # more details.
             existing_applicabilities = RepoProfileApplicability.get_collection().find(
-                {'repo_id': repo_id}).batch_size(25)
+                {'repo_id': repo_id}).batch_size(5)
             for existing_applicability in existing_applicabilities:
                 # Convert cursor to RepoProfileApplicability object
                 existing_applicability = RepoProfileApplicability(**dict(existing_applicability))

--- a/server/test/unit/server/managers/consumer/test_applicability.py
+++ b/server/test/unit/server/managers/consumer/test_applicability.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+
+from mock import patch
+
+from pulp.server.managers.consumer.applicability import ApplicabilityRegenerationManager
+from pulp.server.managers import factory as managers
+
+
+class TestApplicabilityRegenerationManager(TestCase):
+
+    @patch('pulp.server.managers.repo.query.RepoQueryManager.find_by_criteria')
+    @patch('pulp.server.db.model.consumer.RepoProfileApplicability.get_collection')
+    def test_regenerate_applicability_for_repos_batch_size(self, mock_get_collection,
+                                                           mock_find_by_criteria):
+
+        managers.initialize()
+        applicability_manager = ApplicabilityRegenerationManager()
+        repo_criteria = {'filters': None, 'sort': None, 'limit': None,
+                         'skip': None, 'fields': None}
+        mock_find_by_criteria.return_value = [{'id': 'fake-repo'}]
+
+        applicability_manager.regenerate_applicability_for_repos(repo_criteria)
+
+        # validate that batch size of 5 is used
+
+        mock_get_collection.return_value.find.return_value.batch_size.assert_called_with(5)


### PR DESCRIPTION
25 was still causing timeouts for some users. 10 worked, so 5 seems
like a safe bet.

https://pulp.plan.io/issues/998
fixes #998