### PR TITLE
Task 952: Delete unused models from server.db.models.dispatch

### DIFF
--- a/docs/user-guide/admin-client/tasks.rst
+++ b/docs/user-guide/admin-client/tasks.rst
@@ -71,7 +71,7 @@ in the list.
 The ``reaper`` task is responsible for cleaning up the database on a regularly scheduled interval.
 The interval is configured with ``reaper_interval`` in ``[data_reaping]`` section of
 ``/etc/pulp/server.conf``. The value can be whole or fraction of days. The length of time to keep
-documents for each collection is also configured in the same section. ``archived_calls``,
+documents for each collection is also configured in the same section.
 ``task_status_history``, ``consumer_history``, ``repo_sync_history``, ``repo_publish_history``,
 ``repo_group_publish_history``, and ``task_result_history`` take values of whole or fraction of
 days to keep that type of history. This database cleanup is needed because these transactions can

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -52,6 +52,11 @@ Deprecation
 
 .. _2.6.x_upgrade_to_2.7.0:
 
+* The ``archived_calls`` setting in ``server.conf`` is removed. It has not been used in several releases.
+
+* The ``archived_calls`` collection is dropped from the database with a migration.
+
+
 Upgrade Instructions for 2.6.x --> 2.7.0
 -----------------------------------------
 

--- a/nodes/test/unit/base.py
+++ b/nodes/test/unit/base.py
@@ -16,7 +16,6 @@ from pulp.common.config import Config
 from pulp.server.async import celery_instance
 from pulp.server.config import config as pulp_conf
 from pulp.server.db import connection
-from pulp.server.db.model.dispatch import QueuedCall
 from pulp.server.logs import start_logging, stop_logging
 from pulp.server.managers import factory as managers
 from pulp.server.managers.auth.cert.cert_generator import SerialNumber
@@ -58,9 +57,6 @@ class ServerTests(TestCase):
             if name[:7] == 'system.':
                 continue
             db.drop_collection(name)
-
-    def setUp(self):
-        QueuedCall.get_collection().remove()
 
 
 class ClientTests(TestCase):

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -147,8 +147,6 @@
 # reaper_interval: float; time in days between checks for old data in
 #     the database
 #
-# archived_calls: float; time in days to store archived calls
-#
 # consumer_history: float; time in days to store consumer history events
 #
 # repo_sync_history: float; time in days to store repository sync history events
@@ -164,7 +162,6 @@
 
 [data_reaping]
 # reaper_interval: 0.25
-# archived_calls: 0.5
 # consumer_history: 60
 # repo_sync_history: 60
 # repo_publish_history: 60

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -16,7 +16,6 @@ _default_values = {
     },
     'data_reaping': {
         'reaper_interval': '0.25',
-        'archived_calls': '0.5',
         'consumer_history': '60',
         'repo_sync_history': '60',
         'repo_publish_history': '60',

--- a/server/pulp/server/db/migrations/0018_remove_archived_calls.py
+++ b/server/pulp/server/db/migrations/0018_remove_archived_calls.py
@@ -1,0 +1,30 @@
+"""
+This migration deletes the archived_calls collection if it is present.
+"""
+from gettext import gettext as _
+import logging
+
+from pulp.server.db import connection
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(*args, **kwargs):
+    """
+    Perform the migration as described in this module's docblock.
+
+    :param args:   unused
+    :type  args:   list
+    :param kwargs: unused
+    :type  kwargs: dict
+    """
+    db = connection.get_database()
+    # If 'archived_calls' is not present, do nothing.
+    if 'archived_calls' not in db.collection_names():
+        return
+
+    # If it's present, drop it
+    collection = db['archived_calls']
+    collection.drop()
+    msg = _("Deleted the archived_calls collection.")
+    _logger.info(msg)

--- a/server/pulp/server/db/model/dispatch.py
+++ b/server/pulp/server/db/model/dispatch.py
@@ -13,58 +13,10 @@ from celery.utils.timeutils import timedelta_seconds
 from pulp.common import dateutils
 from pulp.server.async.celery_instance import celery as app
 from pulp.server.db.model.base import Model
-from pulp.server.db.model.reaper_base import ReaperMixin
 from pulp.server.managers import factory
 
 
 _logger = logging.getLogger(__name__)
-
-
-class CallResource(Model):
-    """
-    Information for an individual resource used by a call request.
-    """
-
-    collection_name = 'call_resources'
-    search_indices = ('call_request_id', 'resource_type', 'resource_id')
-
-    def __init__(self, call_request_id, resource_type, resource_id, operation):
-        super(CallResource, self).__init__()
-        self.call_request_id = call_request_id
-        self.resource_type = resource_type
-        self.resource_id = resource_id
-        self.operation = operation
-
-
-class QueuedCall(Model):
-    """
-    Serialized queued call request
-    """
-
-    collection_name = 'queued_calls'
-    unique_indices = ()
-
-    def __init__(self, call_request):
-        super(QueuedCall, self).__init__()
-        self.serialized_call_request = call_request.serialize()
-        self.timestamp = datetime.now()
-
-
-class QueuedCallGroup(Model):
-    """
-    """
-
-    collection_name = 'queued_call_groups'
-    unique_indices = ('group_id',)
-
-    def __init__(self, call_request_group_id, call_request_ids):
-        super(QueuedCallGroup, self).__init__()
-
-        self.call_request_group_id = call_request_group_id
-        self.call_request_ids = call_request_ids
-
-        self.total_calls = len(call_request_ids)
-        self.completed_calls = 0
 
 
 class ScheduledCall(Model):
@@ -470,22 +422,3 @@ class ScheduleEntry(beat.ScheduleEntry):
             _logger.debug('not running task %s: %d seconds remaining' % (
                           self.name, remaining_s))
             return False, remaining_s
-
-
-class ArchivedCall(Model, ReaperMixin):
-    """
-    Call history
-
-    The documents in this collection may be reaped, so it inherits from ReaperMixin.
-    """
-
-    collection_name = 'archived_calls'
-    unique_indices = ()
-    search_indices = ('serialized_call_report.call_request_id',
-                      'serialized_call_report.call_request_group_id')
-
-    def __init__(self, call_request, call_report):
-        super(ArchivedCall, self).__init__()
-        self.timestamp = dateutils.now_utc_timestamp()
-        self.call_request_string = str(call_request)
-        self.serialized_call_report = call_report.serialize()

--- a/server/pulp/server/db/reaper.py
+++ b/server/pulp/server/db/reaper.py
@@ -7,7 +7,7 @@ from pulp.common.tags import action_tag
 from pulp.server import config as pulp_config
 from pulp.server.async.tasks import Task
 from pulp.server.db import model
-from pulp.server.db.model import celery_result, consumer, dispatch, repo_group, repository
+from pulp.server.db.model import celery_result, consumer, repo_group, repository
 
 
 # Add collections to reap here. The keys in this datastructure are the Model classes that represent
@@ -15,7 +15,6 @@ from pulp.server.db.model import celery_result, consumer, dispatch, repo_group, 
 # section that corresponds to the collection. The config is consulted by the reap_expired_documents
 # Task to determine how old documents should be (in days) before they are removed.
 _COLLECTION_TIMEDELTAS = {
-    dispatch.ArchivedCall: 'archived_calls',
     model.TaskStatus: 'task_status_history',
     consumer.ConsumerHistoryEvent: 'consumer_history',
     repository.RepoSyncResult: 'repo_sync_history',

--- a/server/test/unit/server/db/migrations/test_0018_remove_archived_calls.py
+++ b/server/test/unit/server/db/migrations/test_0018_remove_archived_calls.py
@@ -1,0 +1,38 @@
+"""
+This module contains tests for pulp.server.db.migrations.0018_remove_archived_calls.
+"""
+import unittest
+
+from mock import patch
+
+from pulp.server.db.migrate.models import _import_all_the_way
+
+migration = _import_all_the_way('pulp.server.db.migrations.0018_remove_archived_calls')
+
+
+class TestMigrate(unittest.TestCase):
+    """
+    Test the migrate() function.
+    """
+
+    @patch.object(migration.connection, 'get_database')
+    def test_migrate_no_collection_archived_calls(self, mock_get_database):
+        """
+        Assert that drop is not called when archived_calls is not present in the db
+        """
+
+        mock_get_database.return_value.collection_names.return_value = []
+        collection = mock_get_database.return_value['archived_calls']
+        migration.migrate()
+        self.assertFalse(collection.drop.called)
+
+    @patch.object(migration.connection, 'get_database')
+    def test_migrate_collection_present_archived_calls(self, mock_get_database):
+        """
+        Assert that drop is called when archived_calls is present in the db
+        """
+
+        mock_get_database.return_value.collection_names.return_value = ['archived_calls']
+        collection = mock_get_database.return_value['archived_calls']
+        migration.migrate()
+        self.assertTrue(collection.drop.called)

--- a/server/test/unit/server/db/test_reaper.py
+++ b/server/test/unit/server/db/test_reaper.py
@@ -10,7 +10,7 @@ from ... import base
 from pulp.server.compat import ObjectId
 from pulp.server.db import model
 from pulp.server.db import reaper
-from pulp.server.db.model import celery_result, consumer, dispatch, repo_group, repository
+from pulp.server.db.model import celery_result, consumer, repo_group, repository
 from pulp.server.db.model.consumer import ConsumerHistoryEvent
 from pulp.server.db.model.reaper_base import _create_expired_object_id, ReaperMixin
 
@@ -23,8 +23,7 @@ class TestReaperCollectionConfig(unittest.TestCase):
         """
         Test that the expected key-value pairs exist in the reaper collection to timedelta mapping.
         """
-        collections_to_reap = [dispatch.ArchivedCall,
-                               model.TaskStatus,
+        collections_to_reap = [model.TaskStatus,
                                consumer.ConsumerHistoryEvent,
                                repository.RepoSyncResult,
                                repository.RepoPublishResult,
@@ -33,7 +32,6 @@ class TestReaperCollectionConfig(unittest.TestCase):
         for key in collections_to_reap:
             self.assertTrue(key in reaper._COLLECTION_TIMEDELTAS)
         # Also check the values.
-        self.assertEqual(reaper._COLLECTION_TIMEDELTAS[dispatch.ArchivedCall], 'archived_calls')
         self.assertEqual(reaper._COLLECTION_TIMEDELTAS[model.TaskStatus], 'task_status_history')
         self.assertEqual(reaper._COLLECTION_TIMEDELTAS[consumer.ConsumerHistoryEvent],
                          'consumer_history')


### PR DESCRIPTION
https://pulp.plan.io/issues/952

Closes #952

Reviewed under master #1903. Created against 2.7-dev. 