### PR TITLE
Allow disabling specific repo auth plugins

### DIFF
--- a/docs/dev-guide/contentauth.rst
+++ b/docs/dev-guide/contentauth.rst
@@ -43,3 +43,8 @@ need to pass all auth checks to see the log message; once one check fails then
 the rest are not executed. If the ``authenticate`` method raises an exception
 for any reason then mod_wsgi will write a message to ``ssl_error_log`` and deny
 the request.
+
+If you would like to disable a specific plugin, simply set
+``disabled_authenticators`` in ``/etc/pulp/repo_auth.conf`` to the name of the
+authenticator in the entry point. In the example above, we would set it to
+``example_auth``. Multiple entries can be given via comma-seperated values.

--- a/repoauth/pulp/repoauth/wsgi.py
+++ b/repoauth/pulp/repoauth/wsgi.py
@@ -1,8 +1,10 @@
+from ConfigParser import SafeConfigParser
 from pkg_resources import iter_entry_points
 
 from pulp.repoauth import auth_enabled_validation
 
 AUTH_ENTRY_POINT = 'pulp_content_authenticators'
+CONFIG_FILENAME = '/etc/pulp/repo_auth.conf'
 
 
 def allow_access(environ, host):
@@ -31,10 +33,26 @@ def allow_access(environ, host):
     for ep in iter_entry_points(group=AUTH_ENTRY_POINT):
         authenticators.update({ep.name: ep.load()})
 
+    # load our list of disabled authenticators
+    disabled_authenticators = _get_disabled_authenticators()
+
     # loop through authenticators. If any return False, kick the user out.
     for auth_method in authenticators:
+        if auth_method in disabled_authenticators:
+            continue
         if not authenticators[auth_method](environ):
             return False
 
     # if we get this far then the user is authorized
     return True
+
+
+def _get_disabled_authenticators():
+    disabled_authenticators = []
+    config = SafeConfigParser()
+    config.read(CONFIG_FILENAME)
+
+    if config.has_option('main', 'disabled_authenticators'):
+        disabled_authenticators = config.get('main', 'disabled_authenticators').split(',')
+
+    return disabled_authenticators

--- a/server/etc/pulp/repo_auth.conf
+++ b/server/etc/pulp/repo_auth.conf
@@ -11,6 +11,10 @@ max_num_certs_in_chain: 100
 # maintain backwards compatibility.
 # verify_ssl: true
 
+# If set, this disables specific repo auth plugins. More than one plugin can be
+# specified in the form of "plugin1,plugin2,plugin3".
+# disabled_authenticators = oid_validation
+
 [repos]
 cert_location: /etc/pki/pulp/content
 global_cert_location: /etc/pki/pulp/content


### PR DESCRIPTION
Previously in Pulp 2.7, repo authenticator plugins were controlled only via the
plugin's entry points. This meant that if a plugin was installed by default, we
were not able to disable it.

A new config value has been added to repo_auth.conf to disable specific
plugins. This lets us turn plugins on and off at will, without having to
uninstall any default plugins.

fixes #1055

https://pulp.plan.io/issues/1055