### PR TITLE
Set storage path in ContentUnit.pre_save handler correctly.

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -436,6 +436,7 @@ class ContentUnit(Document):
                 document_full_storage_location = os.path.join(platform_storage_location,
                                                               target_file_name)
                 shutil.copy(document._source_location, document_full_storage_location)
+                platform_storage_location = document_full_storage_location
             document.storage_path = platform_storage_location
 
     def set_content(self, source_location):


### PR DESCRIPTION
The pre-save handler did not save the full path to the
file_path set with set_content in the case where
file_path is a file.

re #862