### PR TITLE
Provision a virtualenv for Crane if present.

### DIFF
--- a/playpen/ansible/roles/pulp_server/tasks/main.yml
+++ b/playpen/ansible/roles/pulp_server/tasks/main.yml
@@ -1,2 +1,7 @@
 ---
 - selinux: state=disabled
+
+- name: Install packages
+  dnf: name={{ item }} state=latest
+  with_items:
+      - "rpm-build"


### PR DESCRIPTION
Our Vagrant provisioning didn't do anything for Crane. This commit
creates basic support for creating a virtualenv and installing Crane's
dependencies.

In order to avoid copying the RPM dependency information, I determined
how to query Crane's spec file for the RPMs that Crane depends on.
Since this line was also useful for our other projects, I converted our
dependencies to all be installed this way. By
doing this, I also solved #990 and so this commit also fixes that issue.

https://pulp.plan.io/issues/990

fixes #990