### PR TITLE
Update style guide for in-code documentation and add an example

### DIFF
--- a/docs/dev-guide/policies/style.rst
+++ b/docs/dev-guide/policies/style.rst
@@ -11,11 +11,36 @@ length limit is 100 characters, which we chose to prevent line wrapping on GitHu
 In-code Documentation
 ---------------------
 
-Document your functions using the markup described
-`here <http://sphinx-doc.org/markup/desc.html#info-field-lists>`_.
-If it's worth having a function, it's worth taking 1 minute to describe what it
-does, define each parameter, and define its return value. This saves a
-tremendous amount of time for the next person who looks at your code.
+All new code must have a doc block that describes what the function or class does,
+describes each of the parameters and its type (fully qualified please), lists
+exceptions that can be raised, and describes the return value and its type.
+
+Example::
+
+  def update(title, author, book):
+      """
+      Updates information about a book and returns the updated object.
+
+      :param title: new title the book should be assigned
+      :type  title: basestring
+      :param author: new author that the book should be assigned
+      :type  author: fully.qualified.author
+      :param book: book object that will be updated
+      :type  book: fully.qualified.book
+
+      :raises BookNotFound: if book is not found
+
+      :return: updated book object
+      :rtype:  fully.qualified.book
+      """
+      if book is None:
+          raise BookNotFound
+      _do_update(title, author, book)
+      return book
+
+
+More details on the markup is described
+`here <http://sphinx-doc.org/domains.html#info-field-lists>`_.
 
 Include reasonable in-line comments where they might be helpful.
 


### PR DESCRIPTION
Our style guide was pretty thin on how we do doc blocks. Particularly since it is done differently in old and new code, it is valuable to make our expectations clear, and more valuable to have an example.

This also fixes a broken link to the Sphinx docs.