### PR TITLE
Removed pulp-manage-workers entry point from setup.py

### DIFF
--- a/server/pulp/server/async/manage_workers.py
+++ b/server/pulp/server/async/manage_workers.py
@@ -115,7 +115,7 @@ def _stop_workers():
         sys.exit(exit_code)
 
 
-def main():
+if __name__ == "__main__":
     """
     This is the entry point method that becomes pulp-manage-workers.
     """

--- a/server/setup.py
+++ b/server/setup.py
@@ -10,7 +10,6 @@ setup(
     author_email='pulp-list@redhat.com',
     entry_points={
         'console_scripts': [
-            '../libexec/pulp-manage-workers = pulp.server.async.manage_workers:main',
             'pulp-manage-db = pulp.server.db.manage:main',
         ]
     },

--- a/server/usr/lib/systemd/system/pulp_workers.service
+++ b/server/usr/lib/systemd/system/pulp_workers.service
@@ -5,8 +5,8 @@ After=network.target
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/usr/libexec/pulp-manage-workers start
-ExecStop=/usr/libexec/pulp-manage-workers stop
+ExecStart=/usr/bin/python -m  pulp.server.async.manage_workers start
+ExecStop=/usr/bin/python -m  pulp.server.async.manage_workers stop
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The lastest version of setuptools does not support '/' character in name of
install scripts. This patch removes the entry point which lived in
/usr/libexec/pulp-manage-workers. The unit file now uses the
'pulp.server.asynch.manage_workers' as a python module.