### PR TITLE
index task_status.task_id only once

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -234,7 +234,7 @@ class TaskStatus(Document, ReaperMixin):
     :type traceback:   None
     """
 
-    task_id = StringField(unique=True, required=True)
+    task_id = StringField(required=True)
     worker_name = StringField()
     tags = ListField(StringField())
     state = StringField(choices=constants.CALL_STATES, default=constants.CALL_WAITING_STATE)
@@ -254,7 +254,7 @@ class TaskStatus(Document, ReaperMixin):
     _ns = StringField(default='task_status')
 
     meta = {'collection': 'task_status',
-            'indexes': ['-task_id', '-tags', '-state'],
+            'indexes': ['-tags', '-state', {'fields': ['-task_id'], 'unique': True}],
             'allow_inheritance': False,
             'queryset_class': CriteriaQuerySet}
 


### PR DESCRIPTION
The task status model incorrectly generated 2 indexes for task_id. I believe that this will fix https://pulp.plan.io/issues/1092 but I have been unable to replicate the failure of the migration.

Regardless, this extra index must be dropped in 2.7.0 (where it first appears) so that we do not need to write a migration to remove it.

@dkliban, I would appreciate if you could try this on your system to see if it solves your issue.