### PR TITLE
move django settings environment variable to test runner

### DIFF
--- a/devel/pulp/devel/test_runner.py
+++ b/devel/pulp/devel/test_runner.py
@@ -5,8 +5,11 @@ pulp_puppet
 """
 
 import argparse
+import os
 import subprocess
 import sys
+
+os.environ['DJANGO_SETTINGS_MODULE'] = 'pulp.server.webservices.settings'
 
 
 def run_tests(packages, tests_all_platforms, tests_non_rhel5,

--- a/run-tests.py
+++ b/run-tests.py
@@ -24,8 +24,6 @@ paths_to_check = [
     'server/pulp/server/',
     'server/test/unit/']
 
-os.environ['DJANGO_SETTINGS_MODULE'] = 'pulp.server.webservices.settings'
-
 PACKAGES = [
     os.path.dirname(__file__),
     'pulp',


### PR DESCRIPTION
Sets the django settings environment in the test runner rather than in run-tests.py so the plugin tests can make use of it also.