### PR TITLE
import unittest2 in compat module

### DIFF
--- a/common/pulp/common/compat.py
+++ b/common/pulp/common/compat.py
@@ -1,16 +1,4 @@
 # -*- coding: utf-8 -*-
-#
-# Copyright © 2012 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 """
 This module contains a few items that we have come to love from versions of Python that are newer
 than 2.4. Because we love those things so much, we have brought them into this file so that our code
@@ -20,6 +8,7 @@ import __builtin__
 import pkgutil
 
 import backports.pkgutil
+
 
 def check_builtin(module):
     """
@@ -38,18 +27,14 @@ def check_builtin(module):
     return wrap
 
 
-################################################
 # This provides json.
-################################################
 try:
     import json
 except ImportError:
-    import simplejson as json
+    import simplejson as json  # noqa
 
 
-################################################
 # This provides the builtin, all.
-################################################
 @check_builtin(__builtin__)
 def all(iterable):
     """
@@ -62,9 +47,7 @@ def all(iterable):
     return True
 
 
-################################################
 # This provides the builtin, any.
-################################################
 @check_builtin(__builtin__)
 def any(iterable):
     """
@@ -77,9 +60,13 @@ def any(iterable):
     return False
 
 
-################################################
 # This provides pkgutil.iter_modules.
-################################################
 @check_builtin(pkgutil)
 def iter_modules(*args, **kwargs):
     return backports.pkgutil.iter_modules(*args, **kwargs)
+
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa

--- a/server/test/unit/base.py
+++ b/server/test/unit/base.py
@@ -1,11 +1,8 @@
 from copy import deepcopy
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 import mock
 
+from pulp.common.compat import unittest
 from pulp.server.async import celery_instance
 from pulp.server.db.model import TaskStatus, ReservedResource, Worker
 from pulp.server.managers import factory as manager_factory

--- a/server/test/unit/plugins/loader/test_manager.py
+++ b/server/test/unit/plugins/loader/test_manager.py
@@ -1,13 +1,10 @@
 import pkg_resources
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 import mock
 import mongoengine
 
 from pulp.common import error_codes
+from pulp.common.compat import unittest
 from pulp.plugins.loader import manager
 from pulp.server import exceptions
 from pulp.server.db.model import ContentUnit

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -1,12 +1,8 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 from mock import MagicMock, patch
 import mock
 import mongoengine
 
+from pulp.common.compat import unittest
 from pulp.plugins.loader import exceptions as plugin_exceptions
 from pulp.plugins.model import PublishReport
 from pulp.server.controllers import repository as repo_controller

--- a/server/test/unit/server/controllers/test_units.py
+++ b/server/test/unit/server/controllers/test_units.py
@@ -1,12 +1,7 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
-
 from mock import MagicMock, patch
 import mongoengine
 
+from pulp.common.compat import unittest
 from pulp.server.controllers import units as units_controller
 from pulp.server.db import model
 

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -9,15 +9,11 @@ from tempfile import mkdtemp
 
 from mock import patch
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 import mongoengine
 from mongoengine import DateTimeField, DictField, Document, IntField, StringField
 
 from pulp.common import error_codes, dateutils
+from pulp.common.compat import unittest
 from pulp.devel.unit.util import touch
 from pulp.server.exceptions import PulpCodedException
 from pulp.server.db import model

--- a/server/test/unit/server/webservices/views/serializers/test_serializers.py
+++ b/server/test/unit/server/webservices/views/serializers/test_serializers.py
@@ -1,10 +1,6 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 import mock
 
+from pulp.common.compat import unittest
 # The serializers module should not normally be an starting point for imports, so we need to import
 # the criteria module before serializers to prevent a circular import. This is only an issue when
 # running this test module by itself, and will be fixed when pulp.server.db.model becomes a true


### PR DESCRIPTION
In order to use new things like `self.assertDictEqual`, we are increasingly using unittest2 in older versions of python. By moving this import to the compat module, we can avoid doing this same import magic in every test module.