### PR TITLE
Fixes mongoengine model usage that did not have kwargs

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -71,7 +71,7 @@ def _queue_reserved_task(name, task_id, resource_id, inner_args, inner_kwargs):
         # No worker is ready for this work, so we need to wait
         time.sleep(0.25)
 
-    ReservedResource(task_id, worker['name'], resource_id).save()
+    ReservedResource(task_id=task_id, worker_name=worker['name'], resource_id=resource_id).save()
 
     inner_kwargs['routing_key'] = worker.name
     inner_kwargs['exchange'] = DEDICATED_QUEUE_EXCHANGE

--- a/server/pulp/server/managers/consumer/agent.py
+++ b/server/pulp/server/managers/consumer/agent.py
@@ -85,7 +85,7 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_REPOSITORY_DISTRIBUTOR_TYPE, distributor_id),
             tags.action_tag(tags.ACTION_AGENT_BIND)
         ]
-        task = TaskStatus(task_id, 'agent', tags=task_tags).save()
+        task = TaskStatus(task_id=task_id, worker_name='agent', tags=task_tags).save()
 
         # agent request
         consumer_manager = managers.consumer_manager()
@@ -137,7 +137,7 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_REPOSITORY_DISTRIBUTOR_TYPE, distributor_id),
             tags.action_tag(tags.ACTION_AGENT_UNBIND)
         ]
-        task = TaskStatus(task_id, 'agent', tags=task_tags).save()
+        task = TaskStatus(task_id=task_id, worker_name='agent', tags=task_tags).save()
 
         # agent request
         manager = managers.consumer_manager()
@@ -185,7 +185,7 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_CONSUMER_TYPE, consumer_id),
             tags.action_tag(tags.ACTION_AGENT_UNIT_INSTALL)
         ]
-        task = TaskStatus(task_id, 'agent', tags=task_tags).save()
+        task = TaskStatus(task_id=task_id, worker_name='agent', tags=task_tags).save()
 
         # agent request
         manager = managers.consumer_manager()
@@ -231,7 +231,7 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_CONSUMER_TYPE, consumer_id),
             tags.action_tag(tags.ACTION_AGENT_UNIT_UPDATE)
         ]
-        task = TaskStatus(task_id, 'agent', tags=task_tags).save()
+        task = TaskStatus(task_id=task_id, worker_name='agent', tags=task_tags).save()
 
         # agent request
         manager = managers.consumer_manager()
@@ -275,7 +275,7 @@ class AgentManager(object):
             tags.resource_tag(tags.RESOURCE_CONSUMER_TYPE, consumer_id),
             tags.action_tag(tags.ACTION_AGENT_UNIT_UNINSTALL)
         ]
-        task = TaskStatus(task_id, 'agent', tags=task_tags).save()
+        task = TaskStatus(task_id=task_id, worker_name='agent', tags=task_tags).save()
 
         # agent request
         manager = managers.consumer_manager()

--- a/server/pulp/server/webservices/views/tasks.py
+++ b/server/pulp/server/webservices/views/tasks.py
@@ -94,7 +94,7 @@ class TaskResourceView(View):
 
         task_dict = task_serializer(task)
         if 'worker_name' in task_dict:
-            queue_name = Worker(task_dict['worker_name'], datetime.now()).queue_name
+            queue_name = Worker(name=task_dict['worker_name'], last_heartbeat=datetime.now()).queue_name
             task_dict.update({'queue': queue_name})
         return generate_json_response_with_pulp_encoder(task_dict)
 

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -66,8 +66,9 @@ class TestQueueReservedTask(ResourceReservationTests):
         self.mock_get_worker_for_reservation.return_value = Worker(
             name='worker1', last_heartbeat=datetime.utcnow())
         tasks._queue_reserved_task('task_name', 'my_task_id', 'my_resource_id', [1, 2], {'a': 2})
-        self.mock_reserved_resource.assert_called_once_with('my_task_id', 'worker1',
-                                                            'my_resource_id')
+        self.mock_reserved_resource.assert_called_once_with(task_id='my_task_id',
+                                                            worker_name='worker1',
+                                                            resource_id='my_resource_id')
         self.mock_reserved_resource.return_value.save.assert_called_once_with()
 
     def test_dispatches_inner_task(self):

--- a/server/test/unit/server/managers/consumer/test_agent.py
+++ b/server/test/unit/server/managers/consumer/test_agent.py
@@ -111,7 +111,7 @@ class TestAgentManager(TestCase):
             repo_id=repo_id,
             distributor_id=distributor_id)
 
-        mock_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
+        mock_task_status.assert_called_with(task_id=task_id, worker_name='agent', tags=task_tags)
         mock_agent.bind.assert_called_with(mock_context.return_value, agent_bindings, options)
         mock_bind_manager.action_pending.assert_called_with(
             consumer['id'], repo_id, distributor_id, Bind.Action.BIND, task_id)
@@ -175,7 +175,7 @@ class TestAgentManager(TestCase):
             repo_id=repo_id,
             distributor_id=distributor_id)
 
-        mock_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
+        mock_task_status.assert_called_with(task_id=task_id, worker_name='agent', tags=task_tags)
         mock_agent.unbind.assert_called_with(mock_context.return_value, agent_bindings, options)
         mock_bind_manager.action_pending.assert_called_with(
             consumer['id'], repo_id, distributor_id, Bind.Action.UNBIND, task_id)
@@ -227,7 +227,7 @@ class TestAgentManager(TestCase):
         ]
 
         mock_consumer_manager.get_consumer.assert_called_with(consumer['id'])
-        mock_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
+        mock_task_status.assert_called_with(task_id=task_id, worker_name='agent', tags=task_tags)
         mock_context.assert_called_with(consumer, task_id=task_id, consumer_id=consumer['id'])
         mock_profiler.install_units.assert_called_with(consumer, [unit], options, {}, ANY)
         mock_agent.install.assert_called_with(mock_context.return_value, [unit], options)
@@ -282,7 +282,7 @@ class TestAgentManager(TestCase):
 
         mock_consumer_manager.get_consumer.assert_called_with(consumer['id'])
         mock_context.assert_called_with(consumer, task_id=task_id, consumer_id=consumer['id'])
-        mock_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
+        mock_task_status.assert_called_with(task_id=task_id, worker_name='agent', tags=task_tags)
         mock_profiler.update_units.assert_called_with(consumer, [unit], options, {}, ANY)
         mock_agent.update.assert_called_with(mock_context.return_value, [unit], options)
 
@@ -334,7 +334,7 @@ class TestAgentManager(TestCase):
 
         mock_consumer_manager.get_consumer.assert_called_with(consumer['id'])
         mock_context.assert_called_with(consumer, task_id=task_id, consumer_id=consumer['id'])
-        mock_task_status.assert_called_with(task_id, 'agent', tags=task_tags)
+        mock_task_status.assert_called_with(task_id=task_id, worker_name='agent', tags=task_tags)
         mock_profiler.uninstall_units.assert_called_with(consumer, [unit], options, {}, ANY)
         mock_agent.uninstall.assert_called_with(mock_context.return_value, [unit], options)
         mock_factory.consumer_history_manager().record_event.assert_called_with(


### PR DESCRIPTION
The upgrade to mongoengine 0.9.0 revealed that parts of the
Pulp codebase which used mongoengine models did not specify
kwargs. This raises an exception (as it should) in mongoengine
0.9.0.

I audited the existing models on 2.7-testing, fixed those, and
I updated the tests to match.

re #934
https://pulp.plan.io/issues/934