### PR TITLE
sort sync and publish history by an indexed key

### DIFF
--- a/server/pulp/server/managers/repo/publish.py
+++ b/server/pulp/server/managers/repo/publish.py
@@ -340,8 +340,10 @@ class RepoPublishManager(object):
 
         # Retrieve the entries
         cursor = RepoPublishResult.get_collection().find(search_params)
-        # Sort the results on the 'started' field. By default, descending order is used
-        cursor.sort('started', direction=constants.SORT_DIRECTION[sort])
+        # Sort the results by the ObjectId field, which will effectively sort based on the start
+        # time of the event. This way of sorting is preferred because for a sufficiently large data
+        # set, the sort field must be an indexed field.
+        cursor.sort('_id', direction=constants.SORT_DIRECTION[sort])
         if limit is not None:
             cursor.limit(limit)
 

--- a/server/pulp/server/managers/repo/sync.py
+++ b/server/pulp/server/managers/repo/sync.py
@@ -294,8 +294,10 @@ class RepoSyncManager(object):
 
         # Retrieve the entries
         cursor = RepoSyncResult.get_collection().find(search_params)
-        # Sort the results on the 'started' field. By default, descending order is used
-        cursor.sort('started', direction=constants.SORT_DIRECTION[sort])
+        # Sort the results by the ObjectId field, which will effectively sort based on the start
+        # time of the event. This way of sorting is preferred because for a sufficiently large data
+        # set, the sort field must be an indexed field.
+        cursor.sort('_id', direction=constants.SORT_DIRECTION[sort])
         if limit is not None:
             cursor.limit(limit)
 


### PR DESCRIPTION
History results were sorted by the `started` key which was not indexed. Sorting with `_id` which is an ObjectId will result in similar sorting using an indexed key. 

From the mongo [docs](http://docs.mongodb.org/v2.4/reference/object-id/#objectid):
"sorting on an _id field that stores ObjectId values is roughly equivalent to sorting by creation time."

https://pulp.plan.io/issues/1043

This was branched from the merge-base of 2.6-testing and 2.7-testing. When merged, this feature branch will be manually merged into 2.7-testing as well as 2.7-dev. There will be some modification (removing the repetition) on the merge forward to master to account for a refactor: https://github.com/pulp/pulp/pull/1931.

 