### PR TITLE
load data structures from GET json

### DIFF
--- a/server/pulp/server/webservices/views/search.py
+++ b/server/pulp/server/webservices/views/search.py
@@ -93,16 +93,22 @@ class SearchView(generic.View):
         :raises InvalidValue: if filters is passed but is not valid JSON
         """
         query, options = self._parse_args(request.GET)
-        filters = request.GET.get('filters')
-        if filters:
-            try:
-                query['filters'] = json.loads(filters)
-            except ValueError:
-                raise exceptions.InvalidValue('filters')
-
         fields = query.pop('field', '')
         if fields:
             query['fields'] = fields
+        filters = request.GET.get('filters')
+        if filters:
+            query['filters'] = filters
+
+        # Load query data structures from json
+        json_criteria_fields = ['filters', 'fields', 'sort']
+        for field in json_criteria_fields:
+            value = query.get(field)
+            if value:
+                try:
+                    query[field] = json.loads(value)
+                except ValueError:
+                    raise exceptions.InvalidValue(field)
 
         return self._generate_response(query, options, *args, **kwargs)
 

--- a/server/test/unit/server/webservices/views/test_search.py
+++ b/server/test/unit/server/webservices/views/test_search.py
@@ -27,7 +27,7 @@ class TestSearchView(unittest.TestCase):
 
         request = mock.MagicMock()
         # Simulate an empty POST body
-        request.GET = {'field': ['name', 'id'], 'filters': '{"name":"admin"}'}
+        request.GET = {'field': '["name", "id"]', 'filters': '{"name":"admin"}'}
         view = FakeSearchView()
         FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
 


### PR DESCRIPTION
https://pulp.plan.io/issues/312

The BZ originally led me to believe that the problem was with the `filters` field. In actuality, all fields will be passed as strings and need to be loaded from json. The `limit` and `skip` fields do not need to be included because they are cast to integers elsewhere.