### PR TITLE
Pin the version of Mock that we use.

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 coverage
 flake8
-mock
+mock<1.1
 nose
 nosexcover
 unittest2


### PR DESCRIPTION
Pulp uses Mock in a way that is now broken[0] with the new version that was
recently released. This commit pins us to use Mock<1.1 to avoid the
problem for now. In the end, we should update our tests to use the new
Mock API as part of the work on issue #1135.

[0] https://github.com/testing-cabal/mock/issues/263

re #1135