### PR TITLE
ref #865 - mongoengine modeling for shared storage.

### DIFF
--- a/server/pulp/server/content/storage.py
+++ b/server/pulp/server/content/storage.py
@@ -1,0 +1,218 @@
+import os
+import errno
+import shutil
+
+from hashlib import sha256
+
+from pulp.server.config import config
+
+
+def mkdir(path):
+    """
+    Create a directory at the specified path.
+    Directory (and intermediate) directories are only created if they
+    don't already exist.
+
+    :param path: The absolute path to the leaf directory to be created.
+    :type path: str
+    """
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+
+class ContentStorage(object):
+    """
+    Base class for content storage.
+    """
+
+    def put(self, unit, path):
+        """
+        Put the content (bits) associated with the specified content unit into storage.
+        The file (or directory) at the specified *path* is transferred into storage.
+
+        :param unit: The content unit to be stored.
+        :type unit: pulp.sever.db.model.ContentUnit
+        :param path: The absolute path to the file (or directory) to be stored.
+        :type path: str
+        """
+        raise NotImplementedError()
+
+    def get(self, unit):
+        """
+        Get the content (bits) associated with the specified content unit from storage.
+
+        Note: This method included for symmetry and to demonstrate
+              the full potential of this model.
+
+        :return: A file-like object used to stream the content.
+        :rtype: file
+        """
+        raise NotImplementedError()
+
+    def open(self):
+        """
+        Open the storage.
+        """
+        pass
+
+    def close(self):
+        """
+        Close the storage.
+        """
+        pass
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, *unused):
+        self.close()
+
+
+class FileStorage(ContentStorage):
+    """
+    Direct storage for files and directories.
+    """
+
+    def put(self, unit, path):
+        """
+        Put the content defined by the content unit into storage.
+        The file (or directory) at the specified *path* is transferred into storage.
+
+        :param unit: The content unit to be stored.
+        :type unit: pulp.sever.db.model.ContentUnit
+        :param path: The absolute path to the file (or directory) to be stored.
+        :type path: str
+        """
+        storage_dir = os.path.join(
+            config.get('server', 'storage_dir'),
+            'content',
+            'units')
+        destination = os.path.join(storage_dir, unit.unit_type_id, unit.id[0:4], unit.id)
+        mkdir(os.path.dirname(destination))
+        if os.path.isdir(path):
+            shutil.copytree(path, destination)
+        else:
+            shutil.copy(path, destination)
+        unit.storage_path = destination
+
+    def get(self, unit):
+        """
+        Get the content (bits) associated with the specified content unit from storage.
+
+        Note: This method included for symmetry and to demonstrate
+              the full potential of this model.
+
+        :return: A file-like object used to stream the content.
+        :rtype: file
+        """
+        pass
+
+
+class SharedStorage(ContentStorage):
+    """
+    Direct shared storage.
+
+    :ivar storage_id: A shared storage identifier.
+    :ivar storage_id: str
+    """
+
+    def __init__(self, storage_id):
+        """
+        :param storage_id: A shared storage identifier.
+        :ivar storage_id: str
+        """
+        super(SharedStorage, self).__init__()
+        self.storage_id = sha256(storage_id).hexdigest()
+
+    def put(self, unit, path=None):
+        """
+        Put the content (bits) associated with the specified content unit into storage.
+        The file (or directory) at the specified *path* is transferred into storage.
+
+        :param unit: The content unit to be stored.
+        :type unit: pulp.sever.db.model.ContentUnit
+        :param path: The absolute path to the file (or directory) to be stored.
+        :type path: str
+        """
+        self.link(unit)
+
+    def get(self, unit):
+        """
+        Get the content (bits) associated with the specified content unit from storage.
+
+        Note: This method included for symmetry and to demonstrate
+              the full potential of this model.
+
+        :return: A file-like object used to stream the content.
+        :rtype: file
+        """
+        pass
+
+    def open(self):
+        """
+        Open the shared storage.
+        The shared storage location is created as needed.
+        """
+        mkdir(self.content_dir)
+        mkdir(self.links_dir)
+
+    @property
+    def shared_dir(self):
+        """
+        The root location of the shared storage.
+
+        :return: The absolute path to the shared storage.
+        :rtype: str
+        """
+        storage_dir = os.path.join(
+            config.get('server', 'storage_dir'),
+            'content',
+            'shared')
+        path = os.path.join(storage_dir, self.storage_id)
+        return path
+
+    @property
+    def content_dir(self):
+        """
+        The location within the shared storage for storing content.
+
+        :return: The absolute path to the location within the
+            shared storage for storing content.
+        :rtype: str
+        """
+        path = os.path.join(self.shared_dir, 'content')
+        return path
+
+    @property
+    def links_dir(self):
+        """
+        The location within the shared storage for links.
+
+        :return: The absolute path to the location within the
+            shared storage for storing links.
+        :rtype: str
+        """
+        path = os.path.join(self.shared_dir, 'links')
+        return path
+
+    def link(self, unit):
+        """
+        Link the specified content unit (by id) to the shared content.
+
+        :param unit: The content unit to be linked.
+        :type unit: pulp.sever.db.model.ContentUnit
+        """
+        target = self.content_dir
+        link = os.path.join(self.links_dir, unit.id)
+        try:
+            os.symlink(target, link)
+        except OSError, e:
+            if e.errno == errno.EEXIST and os.path.islink(link) and os.readlink(link) == target:
+                pass  # identical
+            else:
+                raise
+        unit.storage_path = link

--- a/server/test/unit/server/content/test_storage.py
+++ b/server/test/unit/server/content/test_storage.py
@@ -1,0 +1,255 @@
+import os
+
+from errno import EEXIST, EPERM
+from unittest import TestCase
+
+from mock import Mock, patch
+
+from pulp.server.content.storage import mkdir, ContentStorage, FileStorage, SharedStorage
+
+
+class TestMkdir(TestCase):
+
+    @patch('os.makedirs')
+    def test_succeeded(self, _mkdir):
+        path = 'path-123'
+        mkdir(path)
+        _mkdir.assert_called_once_with(path)
+
+    @patch('os.makedirs')
+    def test_already_exists(self, _mkdir):
+        path = 'path-123'
+        mkdir(path)
+        _mkdir.assert_called_once_with(path)
+        _mkdir.side_effect = OSError(EEXIST, path)
+
+    @patch('os.makedirs')
+    def test_other_exception(self, _mkdir):
+        path = 'path-123'
+        mkdir(path)
+        _mkdir.side_effect = OSError(EPERM, path)
+        self.assertRaises(OSError, mkdir, path)
+
+
+class TestContentStorage(TestCase):
+
+    def test_abstract(self):
+        storage = ContentStorage()
+        self.assertRaises(NotImplementedError, storage.put, None, None)
+        self.assertRaises(NotImplementedError, storage.get, None)
+
+    def test_open(self):
+        storage = ContentStorage()
+        storage.open()
+
+    def test_close(self):
+        storage = ContentStorage()
+        storage.close()
+
+    def test_enter(self):
+        storage = ContentStorage()
+        storage.open = Mock()
+        inst = storage.__enter__()
+        storage.open.assert_called_once_with()
+        self.assertEqual(inst, storage)
+
+    def test_exit(self):
+        storage = ContentStorage()
+        storage.close = Mock()
+        storage.__exit__()
+        storage.close.assert_called_once_with()
+
+
+class TestFileStorage(TestCase):
+
+    @patch('pulp.server.content.storage.shutil')
+    @patch('pulp.server.content.storage.config')
+    @patch('os.path.isdir', Mock(return_value=True))
+    def test_put_dir(self, config, shutil):
+        path_in = '/tmp/test/'
+        storage_dir = '/tmp/storage'
+        unit = Mock(id='0123456789', unit_type_id='ABC')
+        config.get = lambda s, p: {'server': {'storage_dir': storage_dir}}[s][p]
+        storage = FileStorage()
+
+        # test
+        storage.put(unit, path_in)
+
+        # validation
+        destination = os.path.join(
+            os.path.join(storage_dir, 'content', 'units', unit.unit_type_id),
+            unit.id[0:4], unit.id)
+        shutil.copytree.assert_called_once_with(path_in, destination)
+        self.assertEqual(unit.storage_path, destination)
+
+    @patch('pulp.server.content.storage.shutil')
+    @patch('pulp.server.content.storage.config')
+    @patch('os.path.isdir', Mock(return_value=False))
+    def test_put_file(self, config, shutil):
+        path_in = '/tmp/test'
+        storage_dir = '/tmp/storage'
+        unit = Mock(id='0123456789', unit_type_id='ABC')
+        config.get = lambda s, p: {'server': {'storage_dir': storage_dir}}[s][p]
+        storage = FileStorage()
+
+        # test
+        storage.put(unit, path_in)
+
+        # validation
+        destination = os.path.join(
+            os.path.join(storage_dir, 'content', 'units', unit.unit_type_id),
+            unit.id[0:4], unit.id)
+        shutil.copy.assert_called_once_with(path_in, destination)
+        self.assertEqual(unit.storage_path, destination)
+
+    def test_get(self):
+        storage = FileStorage()
+        storage.get(None)  # just for coverage
+
+
+class TestSharedStorage(TestCase):
+
+    @patch('pulp.server.content.storage.sha256')
+    def test_init(self, sha256):
+        storage_id = '1234'
+        storage = SharedStorage(storage_id)
+        sha256.assert_called_once_with(storage_id)
+        self.assertEqual(storage.storage_id, sha256.return_value.hexdigest.return_value)
+
+    @patch('pulp.server.content.storage.mkdir')
+    @patch('pulp.server.content.storage.SharedStorage.content_dir', 'abcd/')
+    @patch('pulp.server.content.storage.SharedStorage.links_dir', 'xyz/')
+    def test_open(self, _mkdir):
+        storage_id = '1234'
+        storage = SharedStorage(storage_id)
+        storage.open()
+        self.assertEqual(
+            _mkdir.call_args_list,
+            [
+                ((storage.content_dir,), {}),
+                ((storage.links_dir,), {}),
+            ])
+
+    @patch('pulp.server.content.storage.config')
+    def test_shared_dir(self, config):
+        storage_dir = '/tmp/storage'
+        config.get = lambda s, p: {'server': {'storage_dir': storage_dir}}[s][p]
+        storage = SharedStorage('1234')
+        self.assertEqual(
+            storage.shared_dir,
+            os.path.join(storage_dir, 'content', 'shared', storage.storage_id))
+
+    @patch('pulp.server.content.storage.SharedStorage.shared_dir', 'abcd/')
+    def test_content_dir(self):
+        storage = SharedStorage('1234')
+        self.assertEqual(
+            storage.content_dir,
+            os.path.join(storage.shared_dir, 'content'))
+
+    @patch('pulp.server.content.storage.SharedStorage.shared_dir', 'abcd/')
+    def test_links_dir(self):
+        storage = SharedStorage('1234')
+        self.assertEqual(
+            storage.links_dir,
+            os.path.join(storage.shared_dir, 'links'))
+
+    def test_put(self):
+        unit = Mock()
+        storage = SharedStorage('1234')
+        storage.link = Mock()
+        storage.put(unit)
+        storage.link.assert_called_once_with(unit)
+
+    def test_get(self):
+        storage = SharedStorage('1234')
+        storage.get(None)  # just for coverage
+
+    @patch('os.symlink')
+    @patch('pulp.server.content.storage.SharedStorage.content_dir', 'abcd/')
+    @patch('pulp.server.content.storage.SharedStorage.links_dir', 'xyz/')
+    def test_link(self, symlink):
+        unit = Mock(id='0123456789')
+        storage = SharedStorage('1234')
+
+        # test
+        storage.link(unit)
+
+        # validation
+        expected_path = os.path.join(storage.links_dir, unit.id)
+        symlink.assert_called_once_with(storage.content_dir, expected_path)
+        self.assertEqual(unit.storage_path, expected_path)
+
+    @patch('os.symlink')
+    @patch('os.readlink')
+    @patch('os.path.islink')
+    @patch('pulp.server.content.storage.SharedStorage.content_dir', 'abcd/')
+    @patch('pulp.server.content.storage.SharedStorage.links_dir', 'xyz/')
+    def test_duplicate_link(self, islink, readlink, symlink):
+        unit = Mock(id='0123456789')
+        storage = SharedStorage('1234')
+
+        islink.return_value = True
+        symlink.side_effect = OSError()
+        symlink.side_effect.errno = EEXIST
+        readlink.return_value = storage.content_dir
+
+        # test
+        storage.link(unit)
+        # note: not exception raised
+
+        # validation
+        expected_path = os.path.join(storage.links_dir, unit.id)
+        symlink.assert_called_once_with(storage.content_dir, expected_path)
+        self.assertEqual(unit.storage_path, expected_path)
+
+    @patch('os.symlink')
+    @patch('os.readlink')
+    @patch('os.path.islink')
+    @patch('pulp.server.content.storage.SharedStorage.content_dir', 'abcd/')
+    @patch('pulp.server.content.storage.SharedStorage.links_dir', 'xyz/')
+    def test_duplicate_nonlink(self, islink, readlink, symlink):
+        unit = Mock(id='0123456789')
+        storage = SharedStorage('1234')
+
+        islink.return_value = False  # not a link
+        symlink.side_effect = OSError()
+        symlink.side_effect.errno = EEXIST
+        readlink.return_value = storage.content_dir
+
+        # test
+        self.assertRaises(OSError, storage.link, unit)
+
+        # validation
+        expected_path = os.path.join(storage.links_dir, unit.id)
+        symlink.assert_called_once_with(storage.content_dir, expected_path)
+
+    @patch('os.symlink')
+    @patch('os.readlink')
+    @patch('os.path.islink')
+    @patch('pulp.server.content.storage.SharedStorage.content_dir', 'abcd/')
+    @patch('pulp.server.content.storage.SharedStorage.links_dir', 'xyz/')
+    def test_different_link_target(self, islink, readlink, symlink):
+        unit = Mock(id='0123456789')
+        storage = SharedStorage('1234')
+
+        islink.return_value = True
+        symlink.side_effect = OSError()
+        symlink.side_effect.errno = EEXIST
+        readlink.return_value = 'different link target'
+
+        # test
+        self.assertRaises(OSError, storage.link, unit)
+
+        # validation
+        expected_path = os.path.join(storage.links_dir, unit.id)
+        symlink.assert_called_once_with(storage.content_dir, expected_path)
+
+    @patch('os.symlink')
+    @patch('pulp.server.content.storage.SharedStorage.content_dir', 'abcd/')
+    @patch('pulp.server.content.storage.SharedStorage.links_dir', 'xyz/')
+    def test_link_failed(self, symlink):
+        unit = Mock(id='0123456789')
+        storage = SharedStorage('1234')
+        symlink.side_effect = OSError()
+        symlink.side_effect.errno = EPERM
+        self.assertRaises(OSError, storage.link, unit)


### PR DESCRIPTION
The ContentUnit remodeled to have (2) derived classes: FileContentUnit and SharedContentUnit.  All plugins currently subclassing ContentUnit will need to be changed to subclass FileContentUnit instead.

Content (bits) storage is delegated to ContentStorage classes.  These classes are focused on how content is stored.  They are not meant to address subjects like *Object Storage* but ARE modeled in such a way as to not be orthogonal.