### PR TITLE
ref #1136 - support agent task cancellation.

### DIFF
--- a/server/pulp/server/async/task_status_manager.py
+++ b/server/pulp/server/async/task_status_manager.py
@@ -128,6 +128,10 @@ class TaskStatusManager(object):
         else:
             finished = timestamp
 
+        select = {
+            'task_id': task_id,
+            'state': {'$ne': constants.CALL_CANCELED_STATE}
+        }
         update = {
             '$set': {
                 'finish_time': finished,
@@ -136,7 +140,7 @@ class TaskStatusManager(object):
             }
         }
 
-        collection.update({'task_id': task_id}, update, safe=True)
+        collection.update(select, update, safe=True)
 
     @staticmethod
     def set_task_failed(task_id, traceback=None, timestamp=None):

--- a/server/test/unit/server/async/test_task_status_manager.py
+++ b/server/test/unit/server/async/test_task_status_manager.py
@@ -288,7 +288,8 @@ class TaskStatusManagerTests(base.PulpServerTests):
 
         # validation
         select = {
-            'task_id': task_id
+            'task_id': task_id,
+            'state': {'$ne': constants.CALL_CANCELED_STATE}
         }
         update = {
             '$set': {
@@ -313,7 +314,8 @@ class TaskStatusManagerTests(base.PulpServerTests):
 
         # validation
         select = {
-            'task_id': task_id
+            'task_id': task_id,
+            'state': {'$ne': constants.CALL_CANCELED_STATE}
         }
         update = {
             '$set': {


### PR DESCRIPTION
https://pulp.plan.io/issues/1136

During the migration to celery, the agent task cancellation did not get wired up.