### PR TITLE
Remove the -e from the bash provisioner.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         domain.cpus   = 4
     end
 
-    dev.vm.provision "shell", inline: "sudo -u vagrant bash -e /home/vagrant/devel/pulp/playpen/vagrant-setup.sh"
+    dev.vm.provision "shell", inline: "sudo -u vagrant bash /home/vagrant/devel/pulp/playpen/vagrant-setup.sh"
  end
 end

--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 
 # Let's add p{start,stop,restart,status} to the .bashrc
 if ! grep pstart ~/.bashrc; then


### PR DESCRIPTION
For some reason, the -e started causing provisioning failures recently.
I suspect that a Fedora update might have changed the behavior of that
flag, but I have not confirmed this. Since we are slowly switching from
the shell provisioner to Ansible I believe it is best to disable this
flag for now to get around the immediate issue.