### PR TITLE
Adds login_method options to [tasks] section of server.conf

### DIFF
--- a/docs/user-guide/broker-settings.rst
+++ b/docs/user-guide/broker-settings.rst
@@ -84,6 +84,7 @@ commented lines for clarity.
     # cacert: /etc/pki/pulp/qpid/ca.crt
     # keyfile: /etc/pki/pulp/qpid/client.crt
     # certfile: /etc/pki/pulp/qpid/client.crt
+    # login_method:
 
 The default settings of a Pulp Consumer Agent are found in ``/etc/pulp/consumer/consumer.conf`` and
 assume Qpid is running on localhost at the default port (5672) without SSL and without
@@ -214,11 +215,29 @@ update ``<host>`` in the ``broker_url`` setting and the absolute path of the ``c
     cacert: /etc/pki/pulp/qpid/ca.crt
     keyfile: /etc/pki/pulp/qpid/client.crt
     certfile: /etc/pki/pulp/qpid/client.crt
+    # login_method:
 
 
 The Pulp Server <--> Pulp Worker communication allows the client key and client certificate to be
 stored in the same or different files. If the key and certificate are in the same file, set the
 same absolute path for both ``keyfile`` and ``certfile``.
+
+.. note::
+
+     If your Qpid broker requires authentication with ``auth=yes`` and requires SSL client
+     authentication with ``ssl-require-client-authentication=yes`` then you may want to have Pulp
+     authenticate using the ``EXTERNAL`` method. To configure this you will need to:
+
+          1. Set ``login_method`` to ``EXTERNAL``
+
+          2. Ensure that the broker string contains a username that is identical to the ``CN``
+             contained in the client certificate specified in the ``certfile`` setting of the
+             ``[tasks]`` section.
+
+     For example, if the ``cacert`` has ``CN=mypulpuser`` and connects to ``example.com`` on port
+     5671, then ``broker_url`` should be set to:
+
+          broker_url: qpid://mypulpuser@example.com:5671/
 
 
 Using Pulp with RabbitMQ
@@ -271,7 +290,9 @@ the adjustment to the ``transport`` setting in ``[messaging]`` and the protocol 
 ``broker_url`` in ``[tasks]``. Both of these sections are contained on the Pulp Server in
 ``/etc/pulp/server.conf``.
 
+If RabbitMQ is using strict SSL client certificate checking, you will need to set ``login_method``
+to ``EXTERNAL``. See :redmine:`1168` for more details.
+
 The ``/etc/pulp/consumer/consumer.conf`` file on each Pulp Consumer also needs to be updated to
 correspond with this change. Refer to the inline documentation in
 ``/etc/pulp/consumer/consumer.conf`` to set the configuration correctly.
-

--- a/docs/user-guide/qpid.rst
+++ b/docs/user-guide/qpid.rst
@@ -144,6 +144,7 @@ The following is an example of running the script:
   cacert: /etc/pki/pulp/qpid/ca.crt
   keyfile: /etc/pki/pulp/qpid/client.crt
   certfile: /etc/pki/pulp/qpid/client.crt
+  # login_method:
 
 
   Recommended properties in /etc/pulp/consumer/consumer.conf:

--- a/docs/user-guide/release-notes/2.6.x.rst
+++ b/docs/user-guide/release-notes/2.6.x.rst
@@ -5,8 +5,11 @@ Pulp 2.6 Release Notes
 Pulp 2.6.4
 ==========
 
-Pulp now connects to Qpid with the ANONYMOUS SASL authentication
-mechanism. This aligns with Qpid's default behavior.
+* Pulp now connects to Qpid with the ANONYMOUS SASL authentication mechanism by
+  default. This aligns with Qpid's default behavior.
+
+* A new setting named ``login_method`` has been added to the ``[tasks]`` section of server.conf.
+  See server.conf docs for more details.
 
 Bug Fixes
 ---------

--- a/server/bin/pulp-qpid-ssl-cfg
+++ b/server/bin/pulp-qpid-ssl-cfg
@@ -239,6 +239,7 @@ celery_require_ssl: true
 cacert: /etc/pki/pulp/qpid/ca.crt
 keyfile: /etc/pki/pulp/qpid/client.crt
 certfile: /etc/pki/pulp/qpid/client.crt
+# login_method:
 "
 
 echo ""

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -295,10 +295,8 @@
 # certfile: The absolute path to the PEM encoded certificate used for authentication to the message
 #     bus. The default value is '/etc/pki/pulp/qpid/client.crt'.
 #
-# broker_login_method: Select the login method used to connect to the broker. This should be left
-#     unset (use the broker default) except in special cases (e.g. do SSL client certificate
-#     authentication. For RabbitMQ with SSL client certificates, this needs to be 'EXTERNAL'.
-#
+# login_method: Select the SASL login method used to connect to the broker. This should be left
+#     unset except in special cases such as SSL client certificate authentication.
 
 [tasks]
 # broker_url: qpid://localhost/
@@ -306,6 +304,7 @@
 # cacert: /etc/pki/pulp/qpid/ca.crt
 # keyfile: /etc/pki/pulp/qpid/client.crt
 # certfile: /etc/pki/pulp/qpid/client.crt
+# login_method:
 
 
 # = Email =

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -295,6 +295,10 @@
 # certfile: The absolute path to the PEM encoded certificate used for authentication to the message
 #     bus. The default value is '/etc/pki/pulp/qpid/client.crt'.
 #
+# broker_login_method: Select the login method used to connect to the broker. This should be left
+#     unset (use the broker default) except in special cases (e.g. do SSL client certificate
+#     authentication. For RabbitMQ with SSL client certificates, this needs to be 'EXTERNAL'.
+#
 
 [tasks]
 # broker_url: qpid://localhost/

--- a/server/pulp/server/async/celery_instance.py
+++ b/server/pulp/server/async/celery_instance.py
@@ -77,6 +77,15 @@ celery.conf.update(CELERY_MONGODB_BACKEND_SETTINGS=create_mongo_config())
 celery.conf.update(CELERY_WORKER_DIRECT=True)
 
 
+def configure_login_method():
+    """
+    Configures the celery object with BROKER_LOGIN_METHOD if not default.
+    """
+    login_method = config.get('tasks', 'login_method')
+    if login_method is not '':
+        celery.conf.update(BROKER_LOGIN_METHOD=login_method)
+
+
 def configure_SSL():
     """
     Configures the celery object with BROKER_USE_SSL options
@@ -90,7 +99,5 @@ def configure_SSL():
         }
         celery.conf.update(BROKER_USE_SSL=BROKER_USE_SSL)
 
-        if config.has_option('tasks', 'broker_login_method'):
-            celery.conf.update(BROKER_LOGIN_METHOD=config.get('tasks', 'broker_login_method'))
-
 configure_SSL()
+configure_login_method()

--- a/server/pulp/server/async/celery_instance.py
+++ b/server/pulp/server/async/celery_instance.py
@@ -90,5 +90,7 @@ def configure_SSL():
         }
         celery.conf.update(BROKER_USE_SSL=BROKER_USE_SSL)
 
+        if config.has_option('tasks', 'broker_login_method'):
+            celery.conf.update(BROKER_LOGIN_METHOD=config.get('tasks', 'broker_login_method'))
 
 configure_SSL()

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -84,6 +84,7 @@ _default_values = {
         'cacert': '/etc/pki/pulp/qpid/ca.crt',
         'keyfile': '/etc/pki/pulp/qpid/client.crt',
         'certfile': '/etc/pki/pulp/qpid/client.crt',
+        'login_method': '',
     },
 }
 


### PR DESCRIPTION
Adds login_method options to [tasks] section of server.conf
    
If login_method is set, the value is used to configure the BROKER_LOGIN_METHOD Celery option. login_method defaults to '' which allows Celery to use its default values.

This change includes docs updates on practical usage of the new setting and a release note.

closes #1168
https://pulp.plan.io/issues/1168