### PR TITLE
Expose scratchpad in detailed repository serialization.

### DIFF
--- a/client_lib/pulp/client/commands/repo/cudl.py
+++ b/client_lib/pulp/client/commands/repo/cudl.py
@@ -355,6 +355,7 @@ class ListRepositoriesCommand(PulpCliCommand):
         query_params = {}
         if kwargs['details']:
             filters.append('notes')
+            filters.append('scratchpad')
             for p in ('importers', 'distributors'):
                 query_params[p] = True
                 filters.append(p)

--- a/client_lib/test/unit/client/commands/repo/test_cudl.py
+++ b/client_lib/test/unit/client/commands/repo/test_cudl.py
@@ -387,7 +387,7 @@ class ListRepositoriesCommandTests(base.PulpClientTests):
 
         render_kwargs = mock_call.call_args[1]
         expected = ['id', 'display_name', 'description', 'content_unit_counts',
-                    'notes', 'importers', 'distributors']
+                    'notes', 'scratchpad', 'importers', 'distributors']
         self.assertEqual(render_kwargs['filters'], expected)
         self.assertEqual(render_kwargs['order'], expected)
 
@@ -418,7 +418,7 @@ class ListRepositoriesCommandTests(base.PulpClientTests):
 
         render_kwargs = mock_call.call_args[1]
         expected = ['id', 'display_name', 'description', 'content_unit_counts',
-                    'notes', 'importers', 'distributors']
+                    'notes', 'scratchpad', 'importers', 'distributors']
         self.assertEqual(render_kwargs['filters'], expected)
         self.assertEqual(render_kwargs['order'], expected)
 

--- a/docs/dev-guide/integration/rest-api/repo/retrieval.rst
+++ b/docs/dev-guide/integration/rest-api/repo/retrieval.rst
@@ -48,6 +48,7 @@ and :term:`distributors <distributor>` associated with it.
     }
   ],
   "notes": {},
+  "scratchpad": {},
   "content_unit_counts": {},
   "last_unit_added": "2012-01-25T15:26:32Z",
   "last_unit_removed": "2012-01-25T15:26:32Z",
@@ -119,6 +120,7 @@ where there are no repositories.
       }
     ],
     "notes": {},
+    "scratchpad": {},
     "content_unit_counts": {},
     "importers": [
       {
@@ -188,6 +190,7 @@ array is returned in the case where there are no repositories.
       }
     ],
     "notes": {},
+    "scratchpad": {},
     "content_unit_counts": {},
     "last_unit_added": null,
     "last_unit_removed": null,
@@ -260,6 +263,7 @@ filter expressions may not be serializable as query parameters.
       }
     ],
     "notes": {},
+    "scratchpad": {},
     "content_unit_counts": {},
     "last_unit_added": null,
     "last_unit_removed": null,

--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -253,7 +253,7 @@ class Repository(ModelSerializer):
         """
         Contains information that the base serializer needs to properly handle a Repository object.
         """
-        exclude_fields = ['scratchpad']
+        exclude_fields = []
         remapped_fields = {'repo_id': 'id', 'id': '_id'}
 
     def get_href(self, instance):

--- a/server/test/unit/server/webservices/views/serializers/test_serializers.py
+++ b/server/test/unit/server/webservices/views/serializers/test_serializers.py
@@ -288,7 +288,7 @@ class TestRepository(unittest.TestCase):
         """
         Make sure that scratchpad is excluded.
         """
-        self.assertEquals(serializers.Repository.Meta.exclude_fields, ['scratchpad'])
+        self.assertEquals(serializers.Repository.Meta.exclude_fields, [])
         self.assertDictEqual(serializers.Repository.Meta.remapped_fields,
                              {'repo_id': 'id', 'id': '_id'})
 


### PR DESCRIPTION
https://pulp.plan.io/issues/1172

The scratchpad is used by plugins to store additional repository properties.