### PR TITLE
add repository object to repo tranfer unit

### DIFF
--- a/server/pulp/plugins/model.py
+++ b/server/pulp/plugins/model.py
@@ -39,11 +39,13 @@ class Repository(object):
 
     :param last_unit_removed: UTC datetime of the last time a unit was removed from the repository
     :param last_unit_removed: datetime.datetime with tzinfo
+    :param repo_obj: repository object as defined by the mongoengine document
+    :type  repo_obj: pulp.server.db.model.Repository
     """
 
     def __init__(self, id, display_name=None, description=None, notes=None,
                  working_dir=None, content_unit_counts=None, last_unit_added=None,
-                 last_unit_removed=None):
+                 last_unit_removed=None, repo_obj=None):
         self.id = id
         self.display_name = display_name
         self.description = description
@@ -52,6 +54,7 @@ class Repository(object):
         self.content_unit_counts = content_unit_counts or {}
         self.last_unit_added = self._ensure_tz_specified(last_unit_added)
         self.last_unit_removed = self._ensure_tz_specified(last_unit_removed)
+        self.repo_obj = repo_obj
 
     def __str__(self):
         return 'Repository [%s]' % self.id

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -87,7 +87,7 @@ class Repository(Document):
         r = plugin_repo(self.repo_id, self.display_name, self.description, self.notes,
                         content_unit_counts=self.content_unit_counts,
                         last_unit_added=self.last_unit_added,
-                        last_unit_removed=self.last_unit_removed)
+                        last_unit_removed=self.last_unit_removed, repo_obj=self)
         return r
 
     def update_from_delta(self, repo_delta):

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -501,6 +501,7 @@ class TestRepository(unittest.TestCase):
         self.assertEquals({'units': 1}, repo.content_unit_counts)
         self.assertEquals(dt, repo.last_unit_added)
         self.assertEquals(dt, repo.last_unit_removed)
+        self.assertEquals(repo_obj, repo.repo_obj)
 
     def test_update_from_delta(self):
         """


### PR DESCRIPTION
Being able to access the repo object is a prereq for versioned repos.

@barnabycourt 