### PR TITLE
Moves post_init functionality to attach_signals.

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -412,27 +412,15 @@ class ContentUnit(Document):
         This is provided as a class method so it can be called on subclasses
         and all the correct signals will be applied.
         """
-        signals.post_init.connect(cls.post_init_signal, sender=cls)
         signals.pre_save.connect(cls.pre_save_signal, sender=cls)
+
+        # Validate that the minimal set of fields has been defined
+        if not hasattr(cls, 'unit_key_fields'):
+            class_name = cls.__name__
+            raise exceptions.PulpCodedException(error_codes.PLP0035, class_name=class_name)
+
         # Create the named tuple here so it happens during server startup
         cls.NAMED_TUPLE = namedtuple(cls.unit_type_id.default, cls.unit_key_fields)
-
-    @classmethod
-    def post_init_signal(cls, sender, document):
-        """
-        The signal that is triggered before a unit is initialized
-
-        This is used to validate that the unit_key_fields attribute is set properly
-
-        :param sender: sender class
-        :type sender: object
-        :param document: Document that sent the signal
-        :type document: ContentUnit
-        :raises: PLP0035 if the unit_key_fields attribute has not been defined
-        """
-        if not hasattr(document, 'unit_key_fields'):
-            class_name = type(document).__name__
-            raise exceptions.PulpCodedException(error_codes.PLP0035, class_name=class_name)
 
     @classmethod
     def pre_save_signal(cls, sender, document, **kwargs):

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -51,34 +51,22 @@ class TestContentUnit(unittest.TestCase):
 
         ContentUnitHelper.attach_signals()
 
-        mock_signals.post_init.connect.assert_called_once_with(ContentUnitHelper.post_init_signal,
-                                                               sender=ContentUnitHelper)
         mock_signals.pre_save.connect.assert_called_once_with(ContentUnitHelper.pre_save_signal,
                                                               sender=ContentUnitHelper)
 
         self.assertEquals('foo', ContentUnitHelper.NAMED_TUPLE.__name__)
         self.assertEquals(('apple', 'pear'), ContentUnitHelper.NAMED_TUPLE._fields)
 
-    def test_post_init_signal_with_unit_key_fields_defined(self):
-        """
-        Test the init signal handler that validates the existence of the
-        unit_key_fields list
-        """
+    def test_attach_signals_without_unit_key_fields_defined(self):
         class ContentUnitHelper(model.ContentUnit):
-            unit_key_fields = ['id']
+            unit_type_id = StringField(default='foo')
 
-        model.ContentUnit.post_init_signal({}, ContentUnitHelper())
-
-    def test_post_init_signal_without_unit_key_fields_defined(self):
-        """
-        Test the init signal handler that raises an exception if the unit_key_fields list
-        has not been defined.
-        """
         try:
-            model.ContentUnit.post_init_signal({}, {})
+            ContentUnitHelper.attach_signals()
             self.fail("Previous call should have raised a PulpCodedException")
         except PulpCodedException, raised_error:
             self.assertEquals(raised_error.error_code, error_codes.PLP0035)
+            self.assertEqual(raised_error.error_data, {'class_name': 'ContentUnitHelper'})
 
     @patch('pulp.server.db.model.dateutils.now_utc_timestamp')
     def test_pre_save_signal(self, mock_now_utc):


### PR DESCRIPTION
This platform changes causes validation to happen earlier
before mongoengine begins its init. This causes a coded
exception to be raised earlier in the case that the model
definition is invalid.