### PR TITLE
Adjust the example Vagrantfile for the new F22 box location.

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -4,7 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
- config.vm.box = "https://download.gluster.org/pub/gluster/purpleidea/vagrant/fedora-22/fedora-22.box"
+ config.vm.box = "https://dl.fedoraproject.org/pub/alt/purpleidea/vagrant/fedora-22/fedora-22.box"
  # By default, Vagrant wants to mount the code in /vagrant with NFSv3, which will fail. Let's
  # explicitly mount the code using NFSv4.
  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false


### PR DESCRIPTION
I learned in a bug report I filed against vagrant-libvirt that the Fedora 22 Vagrant box we use has moved
locations[0]. This commit updates the example Vagrantfile to use the new location. There are 301 redirects in place
for the old location, so there is no immediate urgency for developers to adopt this change.

[0] https://github.com/pradels/vagrant-libvirt/issues/452#issuecomment-137332077