### PR TITLE
removing a function that was deprecated 3.5 years ago

### DIFF
--- a/server/pulp/server/managers/repo/unit_association_query.py
+++ b/server/pulp/server/managers/repo/unit_association_query.py
@@ -24,57 +24,6 @@ _VALID_DIRECTIONS = (SORT_ASCENDING, SORT_DESCENDING)
 
 class RepoUnitAssociationQueryManager(object):
 
-    def get_unit_ids(self, repo_id, unit_type_id=None):
-        """
-        Get the ids of the content units associated with the repo. If more
-        than one association exists between a unit and the repository, the
-        unit ID will only be listed once.
-
-        DEPRECATED: the get_units calls should be used, limiting the returned
-          fields to just the IDs.
-
-        @param repo_id: identifies the repo
-        @type  repo_id: str
-
-        @param unit_type_id: optional; if specified only unit ids of the
-                             specified type are returned
-
-        @return: dict of unit type id: list of content unit ids
-        @rtype:  dict of str: list of str
-        """
-        unit_ids = {}
-        collection = RepoContentUnit.get_collection()
-
-        # This used to be one query and splitting out the results by unit
-        # type in memory. The problem is that we need to add in the distinct
-        # clause to eliminate the potential of multiple associations to the
-        # same unit. I don't think distinct will operate on two keys. I don't
-        # anticipate there will be a tremendous amount of unit types passed in
-        # so I'm not too worried about making one call per unit type.
-        # jdob - Dec 9, 2011
-
-        if unit_type_id is None:
-            unit_type_ids = []
-
-            # Get a list of all unit types that have at least one unit associated.
-            cursor = collection.find(spec={'repo_id': repo_id}, fields=['unit_type_id'])
-            for t in cursor.distinct('unit_type_id'):
-                unit_type_ids.append(t)
-        else:
-            unit_type_ids = [unit_type_id]
-
-        for type_id in unit_type_ids:
-
-            spec_doc = {'repo_id': repo_id,
-                        'unit_type_id': type_id}
-            cursor = collection.find(spec_doc)
-
-            for unit_id in cursor.distinct('unit_id'):
-                ids = unit_ids.setdefault(type_id, [])
-                ids.append(unit_id)
-
-        return unit_ids
-
     @staticmethod
     def find_by_criteria(criteria):
         """

--- a/server/test/unit/server/managers/repo/test_unit_association_query.py
+++ b/server/test/unit/server/managers/repo/test_unit_association_query.py
@@ -189,38 +189,6 @@ class UnitAssociationQueryTests(base.PulpServerTests):
         for i, unit_id in enumerate(self.units['delta']):
             make_association('repo-2', 'delta', unit_id, i)
 
-    @mock.patch('pulp.server.managers.repo.unit_association.repo_controller.update_last_unit_added')
-    def test_get_unit_ids(self, mock_update_last):
-
-        # Setup
-        repo_id = 'repo-1'
-        units = {'type-1': ['1-1', '1-2', '1-3'],
-                 'type-2': ['2-1', '2-2', '2-3']}
-
-        for type_id, unit_ids in units.items():
-            self.association_manager.associate_all_by_ids(repo_id, type_id, unit_ids)
-
-        # Test - No Type
-        all_units = self.manager.get_unit_ids(repo_id)
-
-        # Verify - No Type
-        self.assertTrue('type-1' in all_units)
-        self.assertTrue('type-2' in all_units)
-        self.assertEqual(3, len(all_units['type-1']))
-        self.assertEqual(3, len(all_units['type-2']))
-
-        # Test - By Type
-        type_1_units = self.manager.get_unit_ids(repo_id, 'type-1')
-
-        # Verify - By Type
-        self.assertTrue('type-1' in type_1_units)
-        self.assertFalse('type-2' in type_1_units)
-        for id in units['type-1']:
-            self.assertTrue(id in type_1_units['type-1'],
-                            '%s not in %s' % (id, ','.join(type_1_units['type-1'])))
-        for id in type_1_units['type-1']:
-            self.assertTrue(id in units['type-1'])
-
     @mock.patch('pulp.server.db.connection.PulpCollection.query')
     def test_find_by_criteria(self, mock_query):
         criteria = Criteria()


### PR DESCRIPTION
I confirmed that this doesn't get called anywhere in the platform or in our plugins.