### PR TITLE
Add provider to shared storage location.

### DIFF
--- a/server/pulp/server/content/storage.py
+++ b/server/pulp/server/content/storage.py
@@ -116,17 +116,24 @@ class SharedStorage(ContentStorage):
     """
     Direct shared storage.
 
+    :ivar provider: A storage provider.
+        This defines the storage mechanism and qualifies the storage_id.
+    :type provider: str
     :ivar storage_id: A shared storage identifier.
     :ivar storage_id: str
     """
 
-    def __init__(self, storage_id):
+    def __init__(self, provider, storage_id):
         """
+        :param provider: A storage provider.
+            This defines the storage mechanism and qualifies the storage_id.
+        :type provider: str
         :param storage_id: A shared storage identifier.
         :ivar storage_id: str
         """
         super(SharedStorage, self).__init__()
         self.storage_id = sha256(storage_id).hexdigest()
+        self.provider = provider
 
     def put(self, unit, path=None):
         """
@@ -168,12 +175,12 @@ class SharedStorage(ContentStorage):
         :return: The absolute path to the shared storage.
         :rtype: str
         """
-        storage_dir = os.path.join(
+        return os.path.join(
             config.get('server', 'storage_dir'),
             'content',
-            'shared')
-        path = os.path.join(storage_dir, self.storage_id)
-        return path
+            'shared',
+            self.provider,
+            self.storage_id)
 
     @property
     def content_dir(self):

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -569,9 +569,21 @@ class SharedContentUnit(ContentUnit):
     }
 
     @property
+    def storage_provider(self):
+        """
+        The storage provider.
+        This defines the storage mechanism and qualifies the storage_id.
+
+        :return: The storage provider.
+        :rtype: str
+        """
+        raise NotImplementedError()
+
+    @property
     def storage_id(self):
         """
         The identifier for the shared storage location.
+
         :return: An identifier for shared storage.
         :rtype: str
         """
@@ -589,7 +601,7 @@ class SharedContentUnit(ContentUnit):
         :type document: SharedContentUnit
         """
         super(SharedContentUnit, cls).pre_save_signal(sender, document, **kwargs)
-        with SharedStorage(document.storage_id) as storage:
+        with SharedStorage(document.storage_provider, document.storage_id) as storage:
             storage.link(document)
 
 

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -236,15 +236,13 @@ class TestSharedContentUnit(unittest.TestCase):
 
     def test_abstract(self):
         unit = TestSharedContentUnit.TestUnit()
-        try:
-            unit.storage_id
-            self.fail('NotImplementedError expected and not raised')
-        except NotImplementedError:
-            pass
+        self.assertRaises(NotImplementedError, getattr, unit, 'storage_provider')
+        self.assertRaises(NotImplementedError, getattr, unit, 'storage_id')
 
     @patch('pulp.server.db.model.SharedStorage.link')
     @patch('pulp.server.db.model.SharedStorage.open')
     @patch('pulp.server.db.model.SharedStorage.close')
+    @patch('pulp.server.db.model.SharedContentUnit.storage_provider', 'git')
     @patch('pulp.server.db.model.SharedContentUnit.storage_id', '1234')
     def test_pre_save_signal(self, close, _open, link):
         sender = Mock()


### PR DESCRIPTION
https://pulp.plan.io/issues/1233

Add provider to shared storage and include it in the path.  This needed to be propagated to the shared content unit class.