### PR TITLE
fixed orphan removal by type when the type uses mongoengine

### DIFF
--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -16,11 +16,11 @@ from pulp.plugins.config import PluginCallConfiguration
 from pulp.plugins.loader import api as plugin_api
 from pulp.server.async.tasks import Task
 from pulp.server.controllers import repository as repo_controller
+from pulp.server.controllers import units as units_controller
 from pulp.server.db import model
 from pulp.server.db.model.criteria import UnitAssociationCriteria
 from pulp.server.db.model.repository import RepoContentUnit
 import pulp.plugins.conduits._common as conduit_common_utils
-import pulp.plugins.types.database as types_db
 import pulp.server.exceptions as exceptions
 import pulp.server.managers.factory as manager_factory
 
@@ -416,14 +416,7 @@ def calculate_associated_type_ids(source_repo_id, associated_units):
 def create_transfer_units(associate_units, associated_unit_type_ids):
     unit_key_fields = {}
     for unit_type_id in associated_unit_type_ids:
-        type_def = types_db.type_definition(unit_type_id)
-        if type_def is not None:
-            # this is an "old style" model
-            unit_key_fields[unit_type_id] = type_def['unit_key']
-        else:
-            # this must be a mongoengine model
-            unit_model = plugin_api.get_unit_model_by_id(unit_type_id)
-            unit_key_fields[unit_type_id] = unit_model.unit_key_fields
+        unit_key_fields[unit_type_id] = units_controller.get_unit_key_fields_for_type(unit_type_id)
 
     transfer_units = []
     for unit in associate_units:

--- a/server/test/unit/server/managers/content/test_orphan.py
+++ b/server/test/unit/server/managers/content/test_orphan.py
@@ -153,28 +153,26 @@ class OrphanManagerGeneratorTests(OrphanManagerTests):
         orphans_2 = list(self.orphan_manager.generate_orphans_by_type(PHONY_TYPE_2.id))
         self.assertEqual(len(orphans_2), 1)
 
-    def test_generate_orphans_by_type_with_unit_keys_invalid_type(self):
+    @patch('pulp.server.controllers.units.get_unit_key_fields_for_type', spec_set=True)
+    def test_generate_orphans_by_type_with_unit_keys_invalid_type(self, mock_get_unit_key_fields):
         """
         Assert that when an invalid content type is passed to
         generate_orphans_by_type_with_unit_keys a MissingResource exception is raised.
         """
+        # simulate the type not being found
+        mock_get_unit_key_fields.side_effect = ValueError
+
         self.assertRaises(
             pulp_exceptions.MissingResource,
             OrphanManager.generate_orphans_by_type_with_unit_keys('Not a type').next)
 
-    def test_validate_type_valid_type(self):
-        unit_1 = gen_content_unit(PHONY_TYPE_1.id, self.content_root)
-        content_type_definition = self.orphan_manager.validate_type(PHONY_TYPE_1.id)
-        self.assertEqual(content_type_definition['id'], unit_1['_content_type_id'])
-
-    def test_validate_type_wrong_type(self):
-        self.assertRaises(
-            pulp_exceptions.MissingResource, OrphanManager.validate_type, 'foo')
-
-    def test_generate_orphans_by_type_with_unit_keys(self):
+    @patch('pulp.server.controllers.units.get_unit_key_fields_for_type', spec_set=True)
+    def test_generate_orphans_by_type_with_unit_keys(self, mock_get_unit_key_fields):
         """
         Assert that orphans are retrieved by type with unit keys correctly
         """
+        mock_get_unit_key_fields.return_value = ('id',)
+
         # Add two content units of different types
         unit_1 = gen_content_unit(PHONY_TYPE_1.id, self.content_root)
         gen_content_unit(PHONY_TYPE_2.id, self.content_root)


### PR DESCRIPTION
https://pulp.plan.io/issues/1215

Several places in the code, only two of which I touched here, need to know the
unit key fields for a given type ID. I created a new controller function that
takes care of finding that information regardless of whether the type is
defined the new way (mongonengine) or old way. The next step will be to use
that controller function in additional places, but that is beyond the scope of
this bug fix.

fixes #1215