### PR TITLE
Causes a single set_content() call to only save files once

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -545,6 +545,7 @@ class FileContentUnit(ContentUnit):
             return
         with FileStorage() as storage:
             storage.put(document, document._source_location)
+            document._source_location = None
 
     def set_content(self, source_location):
         """

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -207,7 +207,8 @@ class TestFileContentUnit(unittest.TestCase):
         base.assert_called_once_with(sender, unit, **kwargs)
         _open.assert_called_once_with()
         close.assert_called_once_with()
-        put.assert_called_once_with(unit, unit._source_location)
+        put.assert_called_once_with(unit, '1234')
+        self.assertEqual(unit._source_location, None)
 
     @patch('pulp.server.db.model.FileStorage.put')
     @patch('pulp.server.db.model.FileStorage.open')


### PR DESCRIPTION
Here is some pseudocode to illustrate the undesirable behavior

```
unit = FileContentUnit()
unit.set_content('/the/source/file/path/')
unit.save() # automatically moves the file into place
unit.save() # the second call to save moves the same file again
```

With this change, only a second call to `set_content` would
cause a save to copy files around.