### PR TITLE
sort sync and publish history by an indexed key

### DIFF
--- a/server/pulp/server/managers/repo/publish.py
+++ b/server/pulp/server/managers/repo/publish.py
@@ -340,8 +340,10 @@ class RepoPublishManager(object):
 
         # Retrieve the entries
         cursor = RepoPublishResult.get_collection().find(search_params)
-        # Sort the results on the 'started' field. By default, descending order is used
-        cursor.sort('started', direction=constants.SORT_DIRECTION[sort])
+        # Sort the results by the ObjectId field, which will effectively sort based on the start
+        # time of the event. This way of sorting is preferred because for a sufficiently large data
+        # set, the sort field must be an indexed field.
+        cursor.sort('_id', direction=constants.SORT_DIRECTION[sort])
         if limit is not None:
             cursor.limit(limit)
 

--- a/server/pulp/server/managers/repo/sync.py
+++ b/server/pulp/server/managers/repo/sync.py
@@ -294,8 +294,10 @@ class RepoSyncManager(object):
 
         # Retrieve the entries
         cursor = RepoSyncResult.get_collection().find(search_params)
-        # Sort the results on the 'started' field. By default, descending order is used
-        cursor.sort('started', direction=constants.SORT_DIRECTION[sort])
+        # Sort the results by the ObjectId field, which will effectively sort based on the start
+        # time of the event. This way of sorting is preferred because for a sufficiently large data
+        # set, the sort field must be an indexed field.
+        cursor.sort('_id', direction=constants.SORT_DIRECTION[sort])
         if limit is not None:
             cursor.limit(limit)
 


### PR DESCRIPTION
fixes #1043 

Original PR: https://github.com/pulp/pulp/pull/1965, reopened against 2.6-dev so it won't hold up the release. 