### PR TITLE
Adds error logging to platform base FileDistributor exceptions

### DIFF
--- a/server/pulp/plugins/file/distributor.py
+++ b/server/pulp/plugins/file/distributor.py
@@ -107,6 +107,7 @@ class FileDistributor(Distributor):
             progress_report.state = progress_report.STATE_COMPLETE
             return progress_report.build_final_report()
         except Exception, e:
+            _logger.exception(e)
             # Something failed. Let's put an error message on the report
             progress_report.error_message = str(e)
             progress_report.traceback = traceback.format_exc()

--- a/server/test/unit/plugins/file/test_distributor.py
+++ b/server/test/unit/plugins/file/test_distributor.py
@@ -97,7 +97,8 @@ class FileDistributorTest(unittest.TestCase):
             self.assertEquals(row[1], self.unit.unit_key['checksum'])
             self.assertEquals(row[2], str(self.unit.unit_key['size']))
 
-    def test_repo_publish_handles_errors(self):
+    @patch('pulp.plugins.file.distributor._logger')
+    def test_repo_publish_handles_errors(self, mock_logger):
         """
         Make sure that publish() does the right thing with the report when there is an error.
         """
@@ -105,6 +106,8 @@ class FileDistributorTest(unittest.TestCase):
 
         distributor.post_repo_publish.side_effect = Exception('Rawr!')
         report = distributor.publish_repo(self.repo, self.publish_conduit, {})
+
+        self.assertTrue(mock_logger.exception.called)
 
         self.assertFalse(report.success_flag)
         self.assertEqual(report.summary['state'], FilePublishProgressReport.STATE_FAILED)


### PR DESCRIPTION
Write the exception and its traceback to the log at error level
when FileDistributor publish has an error.

https://pulp.plan.io/issues/1248
closes #1248