### PR TITLE
Fix pulp-selinux on RHEL 6

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -101,7 +101,6 @@ corecmd_exec_shell(celery_t)
 corecmd_read_bin_symlinks(celery_t)
 dev_read_urand(celery_t)
 files_rw_pid_dirs(celery_t)
-gpg_exec(celery_t) # needed for ostree
 kernel_read_system_state(celery_t)
 libs_exec_ldconfig(celery_t)
 logging_send_syslog_msg(celery_t)
@@ -144,6 +143,16 @@ optional_policy(`
         manage_dirs_pattern(celery_t, puppet_etc_t, puppet_etc_t)
         manage_files_pattern(celery_t, puppet_etc_t, puppet_etc_t)
     ')
+')
+
+######################################
+#
+# ostree needs to be able to execute gpg, but both ostree and the gpg_exec directive are
+# unavailable on el6.
+#
+
+ifndef(`distro_rhel6', `
+    gpg_exec(celery_t)
 ')
 
 ######################################


### PR DESCRIPTION
My previous PR (https://github.com/pulp/pulp/pull/2024) did not build on RHEL 6
due to the "gpg_exec" directive not existing. The ostree plugin is not
currently built for RHEL 6 anyway, so we can conditionalize both.