### PR TITLE
created fork of FileDistributor that works with models

### DIFF
--- a/server/pulp/plugins/file/distributor.py
+++ b/server/pulp/plugins/file/distributor.py
@@ -18,6 +18,8 @@ _logger = logging.getLogger(__name__)
 
 class FileDistributor(Distributor):
     """
+    DEPRECATED: please use the model_distributor.FileDistributor
+
     Distribute files on the filesystem.
     """
 

--- a/server/pulp/plugins/file/model_distributor.py
+++ b/server/pulp/plugins/file/model_distributor.py
@@ -1,0 +1,249 @@
+from gettext import gettext as _
+import csv
+import errno
+import logging
+import os
+import shutil
+import sys
+import traceback
+
+from pulp.common.plugins.distributor_constants import MANIFEST_FILENAME
+from pulp.common.plugins.progress import ProgressReport
+from pulp.plugins.distributor import Distributor
+
+
+BUILD_DIRNAME = 'build'
+
+_logger = logging.getLogger(__name__)
+
+
+class FileDistributor(Distributor):
+    """
+    Distribute files on the filesystem.
+    """
+
+    def __init__(self):
+        super(FileDistributor, self).__init__()
+        # Initialize instance variables used for writing out the metadata
+        self.metadata_file = None
+        self.metadata_csv_writer = None
+
+    @classmethod
+    def metadata(cls):
+        """
+        Advertise the capabilities of the mighty FileDistributor.
+
+        :return: The description of the impressive FileDistributor's capabilities.
+        :rtype:  dict
+        """
+        raise NotImplementedError()
+
+    def distributor_removed(self, repo, config):
+        """
+        Delete the published files from our filesystem
+
+        Please also see the superclass method definition for more documentation on this method.
+
+        :param repo: metadata describing the repository
+        :type  repo: pulp.plugins.model.Repository
+
+        :param config: plugin configuration
+        :type  config: pulp.plugins.config.PluginCallConfiguration
+        """
+        self.unpublish_repo(repo, config)
+
+    def publish_repo(self, repo, publish_conduit, config):
+        """
+        Publish the repository.
+
+        :param repo:            metadata describing the repo
+        :type  repo:            pulp.plugins.model.Repository
+        :param publish_conduit: The conduit for publishing a repo
+        :type  publish_conduit: pulp.plugins.conduits.repo_publish.RepoPublishConduit
+        :param config:          plugin configuration
+        :type  config:          pulp.plugins.config.PluginConfiguration
+        :param config_conduit: Configuration Conduit;
+        :type config_conduit: pulp.plugins.conduits.repo_validate.RepoConfigConduit
+        :return:                report describing the publish operation
+        :rtype:                 pulp.plugins.model.PublishReport
+        """
+        progress_report = FilePublishProgressReport(publish_conduit)
+        _logger.info(_('Beginning publish for repository <%(repo)s>') % {'repo': repo.id})
+
+        try:
+            progress_report.state = progress_report.STATE_IN_PROGRESS
+            units = publish_conduit.get_units()
+
+            # Set up an empty build_dir
+            build_dir = os.path.join(repo.working_dir, BUILD_DIRNAME)
+            # Let's erase the path at build_dir so we can be sure it's a clean directory
+            self._rmtree_if_exists(build_dir)
+            os.makedirs(build_dir)
+
+            self.initialize_metadata(build_dir)
+
+            try:
+                # process each unit
+                for unit in units:
+                    links_to_create = self.get_paths_for_unit(unit)
+                    self._symlink_unit(build_dir, unit, links_to_create)
+                    self.publish_metadata_for_unit(unit)
+            finally:
+                # Finalize the processing
+                self.finalize_metadata()
+
+            # Let's unpublish, and then republish
+            self.unpublish_repo(repo, config)
+
+            hosting_locations = self.get_hosting_locations(repo, config)
+            for location in hosting_locations:
+                shutil.copytree(build_dir, location, symlinks=True)
+
+            self.post_repo_publish(repo, config)
+
+            # Clean up our build_dir
+            self._rmtree_if_exists(build_dir)
+
+            # Report that we are done
+            progress_report.state = progress_report.STATE_COMPLETE
+            return progress_report.build_final_report()
+        except Exception, e:
+            _logger.error(str(e))
+            _logger.error(''.join(traceback.format_exception(*sys.exc_info())))
+            # Something failed. Let's put an error message on the report
+            progress_report.error_message = str(e)
+            progress_report.traceback = traceback.format_exc()
+            progress_report.state = progress_report.STATE_FAILED
+            report = progress_report.build_final_report()
+            return report
+
+    def unpublish_repo(self, repo, config):
+        """
+        Delete the published files from our filesystem
+
+        Please also see the superclass method definition for more documentation on this method.
+
+        :param repo: metadata describing the repository
+        :type  repo: pulp.plugins.model.Repository
+
+        :param config: plugin configuration
+        :type  config: pulp.plugins.config.PluginCallConfiguration
+        """
+        hosting_locations = self.get_hosting_locations(repo, config)
+        for location in hosting_locations:
+            self._rmtree_if_exists(location)
+
+    def validate_config(self, repo, config, config_conduit):
+        raise NotImplementedError()
+
+    def initialize_metadata(self, build_dir):
+        """
+        Initialize the metadata files that are going to be used for
+        :param build_dir: The working directory where the new metadata should be generated
+        :type build_dir: str
+        """
+        metadata_filename = os.path.join(build_dir, MANIFEST_FILENAME)
+        self.metadata_file = open(metadata_filename, 'w')
+        self.metadata_csv_writer = csv.writer(self.metadata_file)
+
+    def publish_metadata_for_unit(self, unit):
+        """
+        Publish the metadata for a single unit.
+        This should be writing to open file handles from the initialize_metadata call
+
+        :param unit: the unit for which metadata needs to be generated
+        :type unit: pulp.plugins.model.AssociatedUnit
+        """
+        self.metadata_csv_writer.writerow([unit.unit_key['name'], unit.unit_key['checksum'],
+                                           unit.unit_key['size']])
+
+    def finalize_metadata(self):
+        """
+        Do any work needed to finalize the metadata created from the initialize_metadata() or
+        the publish_metadata_for_unit() calls.  Usually this will be closing file handles
+        """
+        self.metadata_file.close()
+
+    def get_paths_for_unit(self, unit):
+        """
+        Get the paths within a target directory where this unit should be linked to
+
+        :param unit: The unit for which we want to return target paths
+        :type unit: pulp.plugins.model.AssociatedUnit
+        :return: a list of paths the unit should be linked to
+        :rtype: list of str
+        """
+        return [unit.unit_key['name'], ]
+
+    def get_hosting_locations(self, repo, config):
+        """
+        Get the paths on the filesystem where the build directory should be copied
+
+        :param repo: The repository that is going to be hosted
+        :type repo: pulp.plugins.model.Repository
+        :param config:    plugin configuration
+        :type  config:    pulp.plugins.config.PluginConfiguration
+        :return : list of paths on the filesystem where the build directory should be copied
+        :rtype list of str
+        """
+        return []
+
+    def post_repo_publish(self, repo, config):
+        """
+        API method that is called after the contents of a published repo have
+        been moved into place on the filesystem
+
+        :param repo: The repository that is going to be hosted
+        :type repo: pulp.plugins.model.Repository
+        :param config: the configuration for the repository
+        :type  config: pulp.plugins.config.PluginCallConfiguration
+        """
+        pass
+
+    def _symlink_unit(self, build_dir, unit, target_paths):
+        """
+        For each unit, put a symlink in the build dir that points to its canonical location on disk.
+
+        :param build_dir: The path on the local filesystem that we want to symlink the units into.
+                          This path should already exist.
+        :type  build_dir: basestring
+        :param unit:     The unit to be symlinked
+        :type  unit:     pulp.plugins.model.AssociatedUnit
+        :param target_paths: The list of paths the unit should be symlinked to.
+        :type  target_paths: list of L{str}
+        """
+        for target_path in target_paths:
+            # symlink_filename = os.path.join(build_dir, unit.unit_key['name'])
+            symlink_filename = os.path.join(build_dir, target_path)
+            if os.path.exists(symlink_filename) or os.path.islink(symlink_filename):
+                # There's already something there with the desired symlink filename. Let's try and
+                # see if it points at the right thing. If it does, we don't need to do anything. If
+                # it does not, we should remove what's there and add the correct symlink.
+                try:
+                    existing_link_path = os.readlink(symlink_filename)
+                    if existing_link_path == unit.storage_path:
+                        # We don't need to do anything more for this unit, move on to the next one
+                        continue
+                    # The existing symlink is incorrect, so let's remove it
+                    os.remove(symlink_filename)
+                except OSError, e:
+                    # This will happen if we attempt to call readlink() on a file that wasn't a
+                    # symlink.  We should remove the file and add the symlink. There error code
+                    # should be EINVAL.  If it isn't, something else is wrong and we should raise.
+                    if e.errno != errno.EINVAL:
+                        raise e
+                    # Remove the file that's at the symlink_filename path
+                    os.remove(symlink_filename)
+            # If we've gotten here, we've removed any existing file at the symlink_filename path,
+            # so now we should recreate it.
+            os.symlink(unit.storage_path, symlink_filename)
+
+    def _rmtree_if_exists(self, path):
+        """
+        If the given path exists, remove it recursively. Else, do nothing.
+
+        :param path: The path you want to recursively delete.
+        :type  path: basestring
+        """
+        if os.path.exists(path):
+            shutil.rmtree(path)

--- a/server/test/unit/plugins/file/test_model_distributor.py
+++ b/server/test/unit/plugins/file/test_model_distributor.py
@@ -1,0 +1,259 @@
+import errno
+import os
+import shutil
+import tempfile
+import unittest
+
+from mock import Mock, MagicMock, patch
+
+from pulp.devel.mock_distributor import get_publish_conduit
+from pulp.plugins.file.distributor import FilePublishProgressReport
+from pulp.plugins.file.model_distributor import FileDistributor, BUILD_DIRNAME
+from pulp.plugins.model import Repository as OldRepoModel
+from pulp.server.db.model import Repository
+
+
+DATA_DIR = os.path.realpath("../../../data/")
+SAMPLE_RPM = 'pulp-test-package-0.3.1-1.fc11.x86_64.rpm'
+SAMPLE_FILE = 'test-override-pulp.conf'
+
+
+class FileDistributorTest(unittest.TestCase):
+    """
+    Tests the file distributor base class
+    """
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+        self.target_dir = os.path.join(self.temp_dir, "target")
+        self.repo = MagicMock(spec=Repository)
+        self.repo.repo_id = "foo"
+        self.repo.working_dir = self.temp_dir
+        self.old_repo_model = MagicMock(spec=OldRepoModel)
+        self.old_repo_model.repo_obj = self.repo
+        self.old_repo_model.id = "foo"
+        self.unit = MagicMock(unit_type_id='RPM', name=SAMPLE_RPM, size=1, checksum='sum1',
+                              unit_key={'name': SAMPLE_RPM, 'checksum': 'sum1', 'size': 1})
+        self.unit.storage_path = os.path.join(__file__, DATA_DIR, SAMPLE_RPM)
+        self.publish_conduit = get_publish_conduit(existing_units=[self.unit, ])
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def create_distributor_with_mocked_api_calls(self):
+        distributor = FileDistributor()
+        distributor.get_hosting_locations = Mock()
+        distributor.get_hosting_locations.return_value = [self.target_dir, ]
+        distributor.post_repo_publish = Mock()
+        return distributor
+
+    def test_metadata_not_implemented(self):
+        self.assertRaises(NotImplementedError, FileDistributor.metadata)
+
+    def test_validate_config_not_implemented(self):
+        distributor = FileDistributor()
+        self.assertRaises(NotImplementedError, distributor.validate_config, None, None, None)
+
+    def test_get_hosting_locations_not_implemented(self):
+        distributor = FileDistributor()
+        host_locations = distributor.get_hosting_locations(None, None)
+        self.assertEquals(0, len(host_locations))
+
+    def test_post_repo_publish_not_broken(self):
+        distributor = FileDistributor()
+        # ensure that this doesn't raise an error
+        distributor.post_repo_publish(None, None)
+
+    @patch('pulp.plugins.file.model_distributor.FileDistributor._symlink_unit')
+    @patch('pulp.server.controllers.repository.find_repo_content_units', spec_set=True)
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_repo_publish_api_calls(self, mock_get_working_dir, mock_find, mock_symlink):
+        mock_get_working_dir.return_value = self.temp_dir
+        mock_find.return_value = [self.unit]
+
+        distributor = self.create_distributor_with_mocked_api_calls()
+        result = distributor.publish_repo(self.old_repo_model, self.publish_conduit, {})
+        self.assertTrue(result.success_flag)
+        self.assertTrue(distributor.get_hosting_locations.called)
+        self.assertTrue(distributor.post_repo_publish.called)
+
+        # The publish_conduit should have had two set_progress calls. One to start the IN_PROGRESS
+        # state, and the second to mark it as complete
+        self.assertEqual(self.publish_conduit.set_progress.call_count, 2)
+        self.assertEqual(self.publish_conduit.set_progress.mock_calls[0][1][0]['state'],
+                         FilePublishProgressReport.STATE_IN_PROGRESS)
+        self.assertEqual(self.publish_conduit.set_progress.mock_calls[1][1][0]['state'],
+                         FilePublishProgressReport.STATE_COMPLETE)
+
+    def test_repo_publish_metadata_writing(self):
+        distributor = self.create_distributor_with_mocked_api_calls()
+        distributor.metadata_csv_writer = MagicMock()
+
+        distributor.publish_metadata_for_unit(self.unit)
+
+        writerow = distributor.metadata_csv_writer.writerow
+        writerow.assert_called_once_with([self.unit.unit_key['name'],
+                                         self.unit.unit_key['checksum'],
+                                         self.unit.unit_key['size']])
+
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    @patch('pulp.plugins.file.model_distributor._logger')
+    def test_repo_publish_handles_errors(self, mock_logger, mock_get_working_dir):
+        """
+        Make sure that publish() does the right thing with the report when there is an error.
+        """
+        mock_get_working_dir.return_value = self.temp_dir
+        distributor = self.create_distributor_with_mocked_api_calls()
+        distributor.post_repo_publish.side_effect = Exception('Rawr!')
+
+        report = distributor.publish_repo(self.old_repo_model, self.publish_conduit, {})
+
+        self.assertTrue(mock_logger.exception.called)
+
+        self.assertFalse(report.success_flag)
+        self.assertEqual(report.summary['state'], FilePublishProgressReport.STATE_FAILED)
+        self.assertEqual(report.summary['error_message'], 'Rawr!')
+        self.assertTrue('Rawr!' in report.summary['traceback'])
+
+        # The publish_conduit should have had two set_progress calls. One to start the IN_PROGRESS
+        # state, and the second to mark it as failed
+        self.assertEqual(self.publish_conduit.set_progress.call_count, 2)
+        self.assertEqual(self.publish_conduit.set_progress.mock_calls[0][1][0]['state'],
+                         FilePublishProgressReport.STATE_IN_PROGRESS)
+        self.assertEqual(self.publish_conduit.set_progress.mock_calls[1][1][0]['state'],
+                         FilePublishProgressReport.STATE_FAILED)
+
+    def test_distributor_removed_calls_unpublish(self):
+        distributor = self.create_distributor_with_mocked_api_calls()
+        distributor.unpublish_repo = Mock()
+        distributor.distributor_removed(self.repo, {})
+        self.assertTrue(distributor.unpublish_repo.called)
+
+    @patch('pulp.plugins.file.model_distributor.FileDistributor._rmtree_if_exists', spec_set=True)
+    def test_unpublish_repo(self, mock_rmtree):
+        distributor = self.create_distributor_with_mocked_api_calls()
+
+        distributor.unpublish_repo(self.old_repo_model, {})
+
+        mock_rmtree.assert_called_once_with(self.target_dir)
+
+    def test__rmtree_if_exists(self):
+        """
+        Let's just make sure this simple thing doesn't barf.
+        """
+        a_directory = os.path.join(self.temp_dir, 'a_directory')
+        test_filename = os.path.join(a_directory, 'test.txt')
+        os.makedirs(a_directory)
+        with open(test_filename, 'w') as test:
+            test.write("Please don't barf.")
+
+        # This should not cause any problems, and test.txt should still exist
+        distributor = self.create_distributor_with_mocked_api_calls()
+        distributor._rmtree_if_exists(os.path.join(self.temp_dir, 'fake_path'))
+        self.assertTrue(os.path.exists(test_filename))
+
+        # Now let's remove a_directory
+        distributor._rmtree_if_exists(a_directory)
+        self.assertFalse(os.path.exists(a_directory))
+
+    def test__symlink_units(self):
+        """
+        Make sure that the _symlink_units creates all the correct symlinks.
+        """
+
+        distributor = self.create_distributor_with_mocked_api_calls()
+
+        # There's some logic in _symlink_units to handle preexisting files and symlinks, so let's
+        # create some fakes to see if it does the right thing
+        build_dir = os.path.join(self.temp_dir, BUILD_DIRNAME)
+        os.makedirs(build_dir)
+        os.symlink('/some/weird/path',
+                   os.path.join(build_dir, self.unit.unit_key['name']))
+
+        distributor._symlink_unit(build_dir, self.unit, [self.unit.unit_key['name'], ])
+
+        expected_symlink_path = os.path.join(build_dir, self.unit.unit_key['name'])
+        self.assertTrue(os.path.islink(expected_symlink_path))
+        expected_symlink_destination = os.path.join(DATA_DIR, self.unit.unit_key['name'])
+        self.assertEqual(os.path.realpath(expected_symlink_path), expected_symlink_destination)
+
+    @patch('os.symlink', side_effect=os.symlink)
+    def test__symlink_units_existing_correct_link(self, symlink):
+        """
+        Make sure that the _symlink_units handles an existing correct link well.
+        """
+        # There's some logic in _symlink_units to handle preexisting files and symlinks, so let's
+        # create some fakes to see if it does the right thing
+        build_dir = os.path.join(self.temp_dir, BUILD_DIRNAME)
+        os.makedirs(build_dir)
+        expected_symlink_destination = os.path.join(DATA_DIR, self.unit.unit_key['name'])
+        os.symlink(expected_symlink_destination,
+                   os.path.join(build_dir, self.unit.unit_key['name']))
+        # Now let's reset the Mock so that we can make sure it doesn't get called during _symlink
+        symlink.reset_mock()
+
+        distributor = self.create_distributor_with_mocked_api_calls()
+        distributor._symlink_unit(build_dir, self.unit, [self.unit.unit_key['name']])
+
+        # The call count for symlink should be 0, because the _symlink_units call should have
+        # noticed that the symlink was already correct and thus should have skipped it
+        self.assertEqual(symlink.call_count, 0)
+        expected_symlink_path = os.path.join(build_dir, self.unit.unit_key['name'])
+        self.assertTrue(os.path.islink(expected_symlink_path))
+        self.assertEqual(os.path.realpath(expected_symlink_path),
+                         os.path.realpath(expected_symlink_destination))
+
+    @patch('os.readlink')
+    def test__symlink_units_os_error(self, mock_readlink):
+        """
+        Make sure that the _symlink_units handles an OSError correctly, for the case where it
+        doesn't raise EINVAL. We already have a test that raises EINVAL (test__symlink_units places
+        an ordinary file there.)
+        """
+        os_error = OSError()
+        # This would be an unexpected error for reading a symlink!
+        os_error.errno = errno.ENOSPC
+        mock_readlink.side_effect = os_error
+        # There's some logic in _symlink_units to handle preexisting files and symlinks, so let's
+        # create some fakes to see if it does the right thing
+        build_dir = os.path.join(self.temp_dir, BUILD_DIRNAME)
+        os.makedirs(build_dir)
+
+        expected_symlink_destination = os.path.join(DATA_DIR, self.unit.unit_key['name'])
+        os.symlink(expected_symlink_destination,
+                   os.path.join(build_dir, self.unit.unit_key['name']))
+
+        try:
+            distributor = self.create_distributor_with_mocked_api_calls()
+            distributor._symlink_unit(build_dir, self.unit, [self.unit.unit_key['name']])
+            self.fail('An OSError should have been raised, but was not!')
+        except OSError, e:
+            self.assertEqual(e.errno, errno.ENOSPC)
+
+    def test__symlink_units_EINVAL_os_error(self):
+        """
+        Make sure that the _symlink_units handles an OSError correctly, for the case where it
+        raises EINVAL. We already have a test that raises EINVAL (test__symlink_units places
+        an ordinary file there.)
+        """
+        os_error = OSError()
+        # This would be an unexpected error for reading a symlink!
+        os_error.errno = errno.EINVAL
+        with patch('os.readlink') as mock_readlink:
+            mock_readlink.side_effect = os_error
+            # There's some logic in _symlink_units to handle preexisting files and symlinks,
+            # so let's create some fakes to see if it does the right thing
+            build_dir = os.path.join(self.temp_dir, BUILD_DIRNAME)
+            os.makedirs(build_dir)
+
+            original_link = os.path.join(build_dir, self.unit.unit_key['name'])
+            old_target = os.path.join(DATA_DIR, SAMPLE_FILE)
+            os.symlink(old_target, original_link)
+
+            distributor = self.create_distributor_with_mocked_api_calls()
+            distributor._symlink_unit(build_dir, self.unit, [self.unit.unit_key['name']])
+
+        # make sure the symlink was deleted
+        self.assertTrue(os.path.islink(original_link))
+        created_link = os.readlink(original_link)
+        self.assertNotEqual(old_target, created_link)


### PR DESCRIPTION
https://pulp.plan.io/issues/1250

There are two commits in this PR. The first just makes a straight copy of the original distributor, and the second modifies it. Keeping both commits makes it clear what I had to change.