### PR TITLE
rm safe=true

### DIFF
--- a/nodes/test/unit/test_conduit.py
+++ b/nodes/test/unit/test_conduit.py
@@ -101,7 +101,7 @@ class QueryTests(ServerTests):
     def define_plugins(self):
         collection = ContentType.get_collection()
         for type_id in ALL_TYPES:
-            collection.save(dict(id=type_id, unit_key=UNIT_METADATA.keys()), safe=True)
+            collection.save(dict(id=type_id, unit_key=UNIT_METADATA.keys()))
 
     def test_query(self):
         num_units = 5

--- a/nodes/test/unit/test_plugins.py
+++ b/nodes/test/unit/test_plugins.py
@@ -196,7 +196,7 @@ class PluginTestBase(ServerTests):
 
     def define_plugins(self):
         collection = ContentType.get_collection()
-        collection.save(dict(id=self.TYPEDEF_ID, unit_key=self.UNIT_KEY.keys()), safe=True)
+        collection.save(dict(id=self.TYPEDEF_ID, unit_key=self.UNIT_KEY.keys()))
 
     def populate(self):
         # make content/ dir.
@@ -912,7 +912,7 @@ class ImporterTest(PluginTestBase):
         unit = collection.find_one({'N': 0})
         unit['age'] = 84
         unit['_last_updated'] -= 1
-        collection.update({'N': 0}, unit, safe=True)
+        collection.update({'N': 0}, unit)
         # Test
         importer = NodesHttpImporter()
         publisher = dist.publisher(repo, cfg)

--- a/playpen/metadata/migrate_rpms.py
+++ b/playpen/metadata/migrate_rpms.py
@@ -38,7 +38,7 @@ def _migrate_rpm_unit_repodata():
             rpm_unit["repodata"] = get_package_xml(rpm_unit['_storage_path'])
             modified = True
         if modified:
-            collection.save(rpm_unit, safe=True)
+            collection.save(rpm_unit)
 
 
 def get_package_xml(pkg_path):

--- a/playpen/mongodb/data-test.py
+++ b/playpen/mongodb/data-test.py
@@ -215,7 +215,6 @@ if (not skipcreate):
         {'$set': {
             'packages': r.packages,
         }},
-        safe=True
     )
 
     last_desc = None

--- a/playpen/mongodb/get_package_nevra.py
+++ b/playpen/mongodb/get_package_nevra.py
@@ -40,7 +40,7 @@ def load_data(db, count=10000, blob_size=16*1024):
         obj["extra8"] = blob
         obj["extra9"] = blob
         obj["extra10"] = blob
-        db.packages.save(obj, safe=True)
+        db.packages.save(obj)
 
 def run_query(db, count=1):
     q = []

--- a/server/pulp/plugins/types/database.py
+++ b/server/pulp/plugins/types/database.py
@@ -139,7 +139,7 @@ def clean():
 
     # Purge the types collection of all entries
     type_collection = ContentType.get_collection()
-    type_collection.remove(safe=True)
+    type_collection.remove()
 
 
 def type_units_collection(type_id):
@@ -270,7 +270,7 @@ def _create_or_update_type(type_def):
     if existing_type is not None:
         content_type._id = existing_type['_id']
     # XXX this still causes a potential race condition when 2 users are updating the same type
-    content_type_collection.save(content_type, safe=True)
+    content_type_collection.save(content_type)
 
 
 def _update_indexes(type_def, unique):

--- a/server/pulp/server/db/migrate/utils.py
+++ b/server/pulp/server/db/migrate/utils.py
@@ -27,7 +27,7 @@ def add_field_with_default_value(objectdb, field, default=None):
     for model in objectdb.find():
         if field not in model:
             model[field] = default
-            objectdb.save(model, safe=True)
+            objectdb.save(model)
 
 
 def change_field_type_with_default_value(objectdb, field, new_type, default_value):
@@ -46,7 +46,7 @@ def change_field_type_with_default_value(objectdb, field, new_type, default_valu
     for model in objectdb.find():
             if not isinstance(model[field], new_type):
                 model[field] = default_value
-                objectdb.save(model, safe=True)
+                objectdb.save(model)
 
 
 def add_field_with_calculated_value(objectdb, field, callback=lambda m: None):
@@ -65,7 +65,7 @@ def add_field_with_calculated_value(objectdb, field, callback=lambda m: None):
     for model in objectdb.find():
         if field not in model:
             model[field] = callback(model)
-            objectdb.save(model, safe=True)
+            objectdb.save(model)
 
 
 def delete_field(objectdb, field):
@@ -80,7 +80,7 @@ def delete_field(objectdb, field):
         if field not in model:
             continue
         del model[field]
-        objectdb.save(model, safe=True)
+        objectdb.save(model)
 
 
 def migrate_field(objectdb,
@@ -108,4 +108,4 @@ def migrate_field(objectdb,
         model[to_field] = callback(model[from_field])
         if delete_from:
             del model[from_field]
-        objectdb.save(model, safe=True)
+        objectdb.save(model)

--- a/server/pulp/server/db/migrations/0001_bind_additions.py
+++ b/server/pulp/server/db/migrations/0001_bind_additions.py
@@ -29,4 +29,4 @@ def migrate(*args, **kwargs):
                 bind[key] = value
                 dirty = True
         if dirty:
-            collection.save(bind, safe=True)
+            collection.save(bind)

--- a/server/pulp/server/db/migrations/0003_bind_additions.py
+++ b/server/pulp/server/db/migrations/0003_bind_additions.py
@@ -19,4 +19,4 @@ def migrate(*args, **kwargs):
                 bind[key] = value
                 dirty = True
         if dirty:
-            collection.save(bind, safe=True)
+            collection.save(bind)

--- a/server/pulp/server/db/migrations/0004_content_unit_counts.py
+++ b/server/pulp/server/db/migrations/0004_content_unit_counts.py
@@ -24,4 +24,4 @@ def migrate(*args, **kwargs):
     """
     RepoManager().rebuild_content_unit_counts()
     repo_collection = Repo.get_collection()
-    repo_collection.update({}, {'$unset': {'content_unit_count': 1}}, safe=True)
+    repo_collection.update({}, {'$unset': {'content_unit_count': 1}})

--- a/server/pulp/server/db/migrations/0005_unit_last_updated.py
+++ b/server/pulp/server/db/migrations/0005_unit_last_updated.py
@@ -31,4 +31,4 @@ def migrate(*args, **kwargs):
         collection = connection.get_collection(name)
         for unit in collection.find(QUERY):
             unit[LAST_UPDATED] = NEVER
-            collection.save(unit, safe=True)
+            collection.save(unit)

--- a/server/pulp/server/db/migrations/0006_binding_config.py
+++ b/server/pulp/server/db/migrations/0006_binding_config.py
@@ -26,4 +26,4 @@ def migrate(*args, **kwargs):
     a binding_config of None.
     """
     collection = Bind.get_collection()
-    collection.update(QUERY, UPDATE, multi=True, safe=True)
+    collection.update(QUERY, UPDATE, multi=True)

--- a/server/pulp/server/db/migrations/0008_replace_cert_with_key.py
+++ b/server/pulp/server/db/migrations/0008_replace_cert_with_key.py
@@ -26,5 +26,5 @@ def migrate(*args, **kwargs):
     - Remove the certificate.
     """
     collection = Consumer.get_collection()
-    collection.update(KEY_QUERY, KEY_UPDATE, multi=True, safe=True)
-    collection.update(CRT_QUERY, CRT_UPDATE, multi=True, safe=True)
+    collection.update(KEY_QUERY, KEY_UPDATE, multi=True)
+    collection.update(CRT_QUERY, CRT_UPDATE, multi=True)

--- a/server/pulp/server/db/migrations/0010_utc_timestamps.py
+++ b/server/pulp/server/db/migrations/0010_utc_timestamps.py
@@ -43,4 +43,4 @@ def update_time_to_utc_on_collection(collection_name, field_name):
         if time.tzinfo != dateutils.utc_tz():
             time_utc = dateutils.to_utc_datetime(time)
             distributor[field_name] = dateutils.format_iso8601_datetime(time_utc)
-            collection.save(distributor, safe=True)
+            collection.save(distributor)

--- a/server/pulp/server/db/migrations/0011_permissions_schema_change.py
+++ b/server/pulp/server/db/migrations/0011_permissions_schema_change.py
@@ -13,4 +13,4 @@ def migrate(*args, **kwargs):
                 new_permission = dict(username=username, permissions=user_permission)
                 updated_permissions.append(new_permission)
             permission['users'] = updated_permissions
-            collection.save(permission, safe=True)
+            collection.save(permission)

--- a/server/pulp/server/db/migrations/0013_role_schema_change.py
+++ b/server/pulp/server/db/migrations/0013_role_schema_change.py
@@ -13,4 +13,4 @@ def migrate(*args, **kwargs):
                 resource_permission = dict(resource=resource, permission=permission)
                 updated_permissions.append(resource_permission)
             role['permissions'] = updated_permissions
-            collection.save(role, safe=True)
+            collection.save(role)

--- a/server/pulp/server/db/migrations/0017_distributor_last_published.py
+++ b/server/pulp/server/db/migrations/0017_distributor_last_published.py
@@ -14,4 +14,4 @@ def migrate(*args, **kwargs):
             # already migrated
             continue
         distributor[key] = parse_iso8601_datetime(last_publish)
-        collection.save(distributor, safe=True)
+        collection.save(distributor)

--- a/server/pulp/server/db/model/consumer.py
+++ b/server/pulp/server/db/model/consumer.py
@@ -216,7 +216,7 @@ class RepoProfileApplicability(Model):
         """
         Delete this RepoProfileApplicability object from the database.
         """
-        self.get_collection().remove({'_id': self._id}, safe=True)
+        self.get_collection().remove({'_id': self._id})
 
     def save(self):
         """
@@ -228,10 +228,10 @@ class RepoProfileApplicability(Model):
         new_document = {'profile_hash': self.profile_hash, 'repo_id': self.repo_id,
                         'profile': self.profile, 'applicability': self.applicability}
         if self._id is not None:
-            self.get_collection().update({'_id': self._id}, new_document, safe=True)
+            self.get_collection().update({'_id': self._id}, new_document)
         else:
             # Let's set the _id attribute to the newly created document
-            self._id = self.get_collection().insert(new_document, safe=True)
+            self._id = self.get_collection().insert(new_document)
 
 
 class UnitProfile(Model):

--- a/server/pulp/server/db/model/dispatch.py
+++ b/server/pulp/server/db/model/dispatch.py
@@ -247,7 +247,7 @@ class ScheduledCall(Model):
         if self._new:
             as_dict = self.as_dict()
             as_dict['_id'] = ObjectId(as_dict['_id'])
-            self.get_collection().insert(as_dict, safe=True)
+            self.get_collection().insert(as_dict)
             self._new = False
         else:
             as_dict = self.as_dict()

--- a/server/pulp/server/managers/auth/permission/cud.py
+++ b/server/pulp/server/managers/auth/permission/cud.py
@@ -40,7 +40,7 @@ class PermissionManager(object):
 
         # Creation
         create_me = Permission(resource=resource_uri)
-        Permission.get_collection().save(create_me, safe=True)
+        Permission.get_collection().save(create_me)
 
         # Retrieve the permission to return the SON object
         created = Permission.get_collection().find_one({'resource': resource_uri})
@@ -75,7 +75,7 @@ class PermissionManager(object):
             # unsupported
             raise PulpDataException(_("Update Keyword [%s] is not supported" % key))
 
-        Permission.get_collection().save(found, safe=True)
+        Permission.get_collection().save(found)
 
     @staticmethod
     def delete_permission(resource_uri):
@@ -97,7 +97,7 @@ class PermissionManager(object):
         if found is None:
             raise MissingResource(resource_uri)
 
-        Permission.get_collection().remove({'resource': resource_uri}, safe=True)
+        Permission.get_collection().remove({'resource': resource_uri})
 
     @staticmethod
     def grant(resource, login, operations):
@@ -138,7 +138,7 @@ class PermissionManager(object):
                 continue
             current_ops.append(o)
 
-        Permission.get_collection().save(permission, safe=True)
+        Permission.get_collection().save(permission)
 
     @staticmethod
     def revoke(resource, login, operations):
@@ -185,7 +185,7 @@ class PermissionManager(object):
             PermissionManager.delete_permission(resource)
             return
 
-        Permission.get_collection().save(permission, safe=True)
+        Permission.get_collection().save(permission)
 
     def grant_automatic_permissions_for_resource(self, resource):
         """
@@ -250,10 +250,10 @@ class PermissionManager(object):
                 continue
             permission_query_manager.delete_user_permission(permission, login)
             if len(permission['users']) > 0:
-                Permission.get_collection().save(permission, safe=True)
+                Permission.get_collection().save(permission)
             else:
                 # Delete entire permission if there are no more users
-                Permission.get_collection().remove({'resource': permission['resource']}, safe=True)
+                Permission.get_collection().remove({'resource': permission['resource']})
 
     def operation_name_to_value(self, name):
         """

--- a/server/pulp/server/managers/auth/role/cud.py
+++ b/server/pulp/server/managers/auth/role/cud.py
@@ -54,7 +54,7 @@ class RoleManager(object):
 
         # Creation
         create_me = Role(id=role_id, display_name=display_name, description=description)
-        Role.get_collection().save(create_me, safe=True)
+        Role.get_collection().save(create_me)
 
         # Retrieve the role to return the SON object
         created = Role.get_collection().find_one({'id': role_id})
@@ -93,7 +93,7 @@ class RoleManager(object):
             # unsupported
             raise PulpDataException(_("Update Keyword [%s] is not supported" % key))
 
-        Role.get_collection().save(role, safe=True)
+        Role.get_collection().save(role)
 
         # Retrieve the user to return the SON object
         updated = Role.get_collection().find_one({'id': role_id})
@@ -139,7 +139,7 @@ class RoleManager(object):
             user['roles'].remove(role_id)
             factory.user_manager().update_user(user['login'], Delta(user, 'roles'))
 
-        Role.get_collection().remove({'id': role_id}, safe=True)
+        Role.get_collection().remove({'id': role_id})
 
     @staticmethod
     def add_permissions_to_role(role_id, resource, operations):
@@ -184,7 +184,7 @@ class RoleManager(object):
         for user in users:
             factory.permission_manager().grant(resource, user['login'], operations)
 
-        Role.get_collection().save(role, safe=True)
+        Role.get_collection().save(role)
 
     @staticmethod
     def remove_permissions_from_role(role_id, resource, operations):
@@ -233,7 +233,7 @@ class RoleManager(object):
         if not current_ops:
             role['permissions'].remove(resource_permission)
 
-        Role.get_collection().save(role, safe=True)
+        Role.get_collection().save(role)
 
     @staticmethod
     def add_user_to_role(role_id, login):
@@ -260,7 +260,7 @@ class RoleManager(object):
             return
 
         user['roles'].append(role_id)
-        User.get_collection().save(user, safe=True)
+        User.get_collection().save(user)
 
         for item in role['permissions']:
             factory.permission_manager().grant(item['resource'], login,
@@ -296,7 +296,7 @@ class RoleManager(object):
             return
 
         user['roles'].remove(role_id)
-        User.get_collection().save(user, safe=True)
+        User.get_collection().save(user)
 
         for item in role['permissions']:
             other_roles = factory.role_query_manager().get_other_roles(role, user['roles'])
@@ -315,7 +315,7 @@ class RoleManager(object):
                                     'Role indicates users with admin privileges')
             role['permissions'] = [{'resource': '/',
                                     'permission': [CREATE, READ, UPDATE, DELETE, EXECUTE]}]
-            Role.get_collection().save(role, safe=True)
+            Role.get_collection().save(role)
 
     @staticmethod
     def get_role(role):

--- a/server/pulp/server/managers/auth/user/cud.py
+++ b/server/pulp/server/managers/auth/user/cud.py
@@ -73,7 +73,7 @@ class UserManager(object):
 
         # Creation
         create_me = User(login=login, password=hashed_password, name=name, roles=roles)
-        User.get_collection().save(create_me, safe=True)
+        User.get_collection().save(create_me)
 
         # Grant permissions
         permission_manager = factory.permission_manager()
@@ -146,7 +146,7 @@ class UserManager(object):
         if delta:
             raise InvalidValue(delta.keys())
 
-        User.get_collection().save(user, safe=True)
+        User.get_collection().save(user)
 
         # Retrieve the user to return the SON object
         updated = User.get_collection().find_one({'login': login})
@@ -183,7 +183,7 @@ class UserManager(object):
         permission_manager = factory.permission_manager()
         permission_manager.revoke_all_permissions_from_user(login)
 
-        User.get_collection().remove({'login': login}, safe=True)
+        User.get_collection().remove({'login': login})
 
     def ensure_admin(self):
         """

--- a/server/pulp/server/managers/consumer/bind.py
+++ b/server/pulp/server/managers/consumer/bind.py
@@ -71,7 +71,7 @@ class BindManager(object):
         collection = Bind.get_collection()
         try:
             bind = Bind(consumer_id, repo_id, distributor_id, notify_agent, binding_config)
-            collection.save(bind, safe=True)
+            collection.save(bind)
         except DuplicateKeyError:
             BindManager._update_binding(consumer_id, repo_id, distributor_id, notify_agent,
                                         binding_config)
@@ -99,7 +99,7 @@ class BindManager(object):
         binding = collection.find_one(query)
         binding['notify_agent'] = notify_agent
         binding['binding_config'] = binding_config
-        collection.save(binding, safe=True)
+        collection.save(binding)
 
     @staticmethod
     def _reset_bind(consumer_id, repo_id, distributor_id):
@@ -118,7 +118,7 @@ class BindManager(object):
         query = BindManager.bind_id(consumer_id, repo_id, distributor_id)
         query['deleted'] = True
         update = {'$set': {'deleted': False, 'consumer_actions': []}}
-        collection.update(query, update, safe=True)
+        collection.update(query, update)
 
     @staticmethod
     def unbind(consumer_id, repo_id, distributor_id):
@@ -289,7 +289,7 @@ class BindManager(object):
         # update document
         collection = Bind.get_collection()
         query = BindManager.bind_id(consumer_id, repo_id, distributor_id)
-        collection.update(query, {'$set': {'deleted': True}}, safe=True)
+        collection.update(query, {'$set': {'deleted': True}})
 
     @staticmethod
     def delete(consumer_id, repo_id, distributor_id, force=False):
@@ -318,7 +318,7 @@ class BindManager(object):
                 raise Exception('outstanding actions, not deleted')
         if not force:
             bind_id['deleted'] = True
-        collection.remove(bind_id, safe=True)
+        collection.remove(bind_id)
 
     def action_pending(self, consumer_id, repo_id, distributor_id, action, action_id):
         """
@@ -344,7 +344,7 @@ class BindManager(object):
             action=action,
             status=Bind.Status.PENDING)
         update = {'$push': {'consumer_actions': entry}}
-        collection.update(bind_id, update, safe=True)
+        collection.update(bind_id, update)
 
     def action_succeeded(self, consumer_id, repo_id, distributor_id, action_id):
         """
@@ -368,10 +368,10 @@ class BindManager(object):
             return
         # delete the action
         update = {'$pull': {'consumer_actions': {'id': action_id}}}
-        collection.update(bind_id, update, safe=True)
+        collection.update(bind_id, update)
         # purge all previous actions
         update = {'$pull': {'consumer_actions': {'timestamp': {'$lt': action['timestamp']}}}}
-        collection.update(bind_id, update, safe=True)
+        collection.update(bind_id, update)
 
     def action_failed(self, consumer_id, repo_id, distributor_id, action_id):
         """
@@ -389,7 +389,7 @@ class BindManager(object):
         query = self.bind_id(consumer_id, repo_id, distributor_id)
         query['consumer_actions.id'] = action_id
         update = {'$set': {'consumer_actions.$.status': Bind.Status.FAILED}}
-        collection.update(query, update, safe=True)
+        collection.update(query, update)
 
     def find_action(self, action_id):
         """

--- a/server/pulp/server/managers/consumer/cud.py
+++ b/server/pulp/server/managers/consumer/cud.py
@@ -76,7 +76,7 @@ class ConsumerManager(object):
 
         # Creation
         consumer = Consumer(consumer_id, display_name, description, notes, capabilities, rsa_pub)
-        _id = collection.save(consumer, safe=True)
+        _id = collection.save(consumer)
 
         # Generate certificate
         cert_gen_manager = factory.cert_generation_manager()
@@ -126,7 +126,7 @@ class ConsumerManager(object):
 
         # Database Updates
         try:
-            Consumer.get_collection().remove({'id': consumer_id}, safe=True)
+            Consumer.get_collection().remove({'id': consumer_id})
         except Exception:
             _logger.exception(
                 'Error updating database collection while removing consumer [%s]' % consumer_id)
@@ -177,7 +177,7 @@ class ConsumerManager(object):
             if key in delta:
                 consumer[key] = delta[key]
 
-        Consumer.get_collection().save(consumer, safe=True)
+        Consumer.get_collection().save(consumer)
 
         return consumer
 
@@ -214,8 +214,7 @@ class ConsumerManager(object):
         cls._validate_scheduled_operation(operation)
         Consumer.get_collection().update(
             {'_id': consumer_id},
-            {'$addToSet': {'schedules.%s' % operation: schedule_id}},
-            safe=True)
+            {'$addToSet': {'schedules.%s' % operation: schedule_id}})
 
     @classmethod
     def remove_schedule(cls, operation, consumer_id, schedule_id):
@@ -228,8 +227,7 @@ class ConsumerManager(object):
         cls._validate_scheduled_operation(operation)
         Consumer.get_collection().update(
             {'_id': consumer_id},
-            {'$pull': {'schedules.%s' % operation: schedule_id}},
-            safe=True)
+            {'$pull': {'schedules.%s' % operation: schedule_id}})
 
     @classmethod
     def list_schedules(cls, operation, consumer_id):

--- a/server/pulp/server/managers/consumer/group/cud.py
+++ b/server/pulp/server/managers/consumer/group/cud.py
@@ -65,7 +65,7 @@ class ConsumerGroupManager(object):
         collection = ConsumerGroup.get_collection()
         consumer_group = ConsumerGroup(group_id, display_name, description, consumer_ids, notes)
         try:
-            collection.insert(consumer_group, safe=True)
+            collection.insert(consumer_group)
         except DuplicateKeyError:
             raise pulp_exceptions.DuplicateResource(group_id), None, sys.exc_info()[2]
 
@@ -111,11 +111,10 @@ class ConsumerGroupManager(object):
                     unset_dict[newkey] = value
 
             if unset_dict:
-                collection.update({'id': group_id}, {'$unset': unset_dict},
-                                  safe=True)
+                collection.update({'id': group_id}, {'$unset': unset_dict})
 
         if updates:
-            collection.update({'id': group_id}, {'$set': updates}, safe=True)
+            collection.update({'id': group_id}, {'$set': updates})
         group = collection.find_one({'id': group_id})
         return group
 
@@ -128,7 +127,7 @@ class ConsumerGroupManager(object):
         """
         collection = validate_existing_consumer_group(group_id)
         # Delete from the database
-        collection.remove({'id': group_id}, safe=True)
+        collection.remove({'id': group_id})
 
     def remove_consumer_from_groups(self, consumer_id, group_ids=None):
         """
@@ -145,7 +144,7 @@ class ConsumerGroupManager(object):
         if group_ids is not None:
             spec = {'id': {'$in': group_ids}}
         collection = ConsumerGroup.get_collection()
-        collection.update(spec, {'$pull': {'consumer_ids': consumer_id}}, multi=True, safe=True)
+        collection.update(spec, {'$pull': {'consumer_ids': consumer_id}}, multi=True)
 
     @staticmethod
     def associate(group_id, criteria):
@@ -163,8 +162,7 @@ class ConsumerGroupManager(object):
         if consumer_ids:
             group_collection.update(
                 {'id': group_id},
-                {'$addToSet': {'consumer_ids': {'$each': consumer_ids}}},
-                safe=True)
+                {'$addToSet': {'consumer_ids': {'$each': consumer_ids}}})
         details = {'group_id': group_id}
         for consumer_id in consumer_ids:
             manager_factory.consumer_history_manager().record_event(consumer_id,
@@ -186,8 +184,7 @@ class ConsumerGroupManager(object):
         if consumer_ids:
             group_collection.update(
                 {'id': group_id},
-                {'$pullAll': {'consumer_ids': consumer_ids}},
-                safe=True)
+                {'$pullAll': {'consumer_ids': consumer_ids}})
         details = {'group_id': group_id}
         for consumer_id in consumer_ids:
             manager_factory.consumer_history_manager().record_event(consumer_id,
@@ -204,7 +201,7 @@ class ConsumerGroupManager(object):
         group_collection = validate_existing_consumer_group(group_id)
         set_doc = dict(('notes.' + k, v) for k, v in notes.items())
         if set_doc:
-            group_collection.update({'id': group_id}, {'$set': set_doc}, safe=True)
+            group_collection.update({'id': group_id}, {'$set': set_doc})
 
     def remove_notes(self, group_id, keys):
         """
@@ -216,7 +213,7 @@ class ConsumerGroupManager(object):
         """
         group_collection = validate_existing_consumer_group(group_id)
         unset_doc = dict(('notes.' + k, 1) for k in keys)
-        group_collection.update({'id': group_id}, {'$unset': unset_doc}, safe=True)
+        group_collection.update({'id': group_id}, {'$unset': unset_doc})
 
     def set_note(self, group_id, key, value):
         """

--- a/server/pulp/server/managers/consumer/history.py
+++ b/server/pulp/server/managers/consumer/history.py
@@ -85,7 +85,7 @@ class ConsumerHistoryManager(object):
             raise InvalidValue(invalid_values)
 
         event = ConsumerHistoryEvent(consumer_id, self._originator(), event_type, event_details)
-        ConsumerHistoryEvent.get_collection().save(event, safe=True)
+        ConsumerHistoryEvent.get_collection().save(event)
 
     def query(self, consumer_id=None, event_type=None, limit=None, sort='descending',
               start_date=None, end_date=None):

--- a/server/pulp/server/managers/consumer/profile.py
+++ b/server/pulp/server/managers/consumer/profile.py
@@ -61,7 +61,7 @@ class ProfileManager(object):
         except MissingResource:
             p = UnitProfile(consumer_id, content_type, profile)
         collection = UnitProfile.get_collection()
-        collection.save(p, safe=True)
+        collection.save(p)
         history_manager = factory.consumer_history_manager()
         history_manager.record_event(
             consumer_id,
@@ -80,7 +80,7 @@ class ProfileManager(object):
         """
         profile = ProfileManager.get_profile(consumer_id, content_type)
         collection = UnitProfile.get_collection()
-        collection.remove(profile, safe=True)
+        collection.remove(profile)
 
     def consumer_deleted(self, id):
         """

--- a/server/pulp/server/managers/content/catalog.py
+++ b/server/pulp/server/managers/content/catalog.py
@@ -58,7 +58,7 @@ class ContentCatalogManager(object):
         """
         collection = ContentCatalog.get_collection()
         entry = ContentCatalog(source_id, expires, type_id, unit_key, url)
-        collection.insert(entry, safe=True)
+        collection.insert(entry)
 
     def delete_entry(self, source_id, type_id, unit_key):
         """
@@ -73,7 +73,7 @@ class ContentCatalogManager(object):
         collection = ContentCatalog.get_collection()
         locator = ContentCatalog.get_locator(type_id, unit_key)
         query = {'source_id': source_id, 'locator': locator}
-        collection.remove(query, safe=True)
+        collection.remove(query)
 
     def purge(self, source_id):
         """
@@ -86,7 +86,7 @@ class ContentCatalogManager(object):
         """
         collection = ContentCatalog.get_collection()
         query = {'source_id': source_id}
-        result = collection.remove(query, safe=True)
+        result = collection.remove(query)
         return result['n']
 
     def purge_expired(self, grace_period=GRACE_PERIOD):
@@ -104,7 +104,7 @@ class ContentCatalogManager(object):
         now = ContentCatalog.get_expiration(0)
         timestamp = now - grace_period
         query = {'expiration': {'$lt': timestamp}}
-        result = collection.remove(query, safe=True)
+        result = collection.remove(query)
         return result['n']
 
     def purge_orphans(self, valid_ids):

--- a/server/pulp/server/managers/content/cud.py
+++ b/server/pulp/server/managers/content/cud.py
@@ -32,7 +32,7 @@ class ContentManager(object):
             '_last_updated': dateutils.now_utc_timestamp()
         }
         unit_doc.update(unit_metadata)
-        collection.insert(unit_doc, safe=True)
+        collection.insert(unit_doc)
         return unit_id
 
     def update_content_unit(self, content_type, unit_id, unit_metadata_delta):
@@ -47,7 +47,7 @@ class ContentManager(object):
         """
         unit_metadata_delta['_last_updated'] = dateutils.now_utc_timestamp()
         collection = content_types_db.type_units_collection(content_type)
-        collection.update({'_id': unit_id}, {'$set': unit_metadata_delta}, safe=True)
+        collection.update({'_id': unit_id}, {'$set': unit_metadata_delta})
 
     def remove_content_unit(self, content_type, unit_id):
         """
@@ -59,7 +59,7 @@ class ContentManager(object):
         @type unit_id: str
         """
         collection = content_types_db.type_units_collection(content_type)
-        collection.remove({'_id': unit_id}, safe=True)
+        collection.remove({'_id': unit_id})
 
     def link_referenced_content_units(self, from_type, from_id, to_type, to_ids):
         """
@@ -85,7 +85,7 @@ class ContentManager(object):
             if id_ in children:
                 continue
             children.append(id_)
-        collection.update({'_id': from_id}, parent, safe=True)
+        collection.update({'_id': from_id}, parent)
 
     def unlink_referenced_content_units(self, from_type, from_id, to_type, to_ids):
         """
@@ -106,4 +106,4 @@ class ContentManager(object):
         key = '_%s_references' % to_type
         children = set(parent.get(key, []))
         parent[key] = list(children.difference(to_ids))
-        collection.update({'_id': from_id}, parent, safe=True)
+        collection.update({'_id': from_id}, parent)

--- a/server/pulp/server/managers/event/crud.py
+++ b/server/pulp/server/managers/event/crud.py
@@ -56,7 +56,7 @@ class EventListenerManager(object):
         # Create the database entry
         el = EventListener(notifier_type_id, notifier_config, event_types)
         collection = EventListener.get_collection()
-        created_id = collection.save(el, safe=True)
+        created_id = collection.save(el)
         created = collection.find_one(created_id)
 
         return created
@@ -152,7 +152,7 @@ class EventListenerManager(object):
             existing['event_types'] = event_types
 
         # Update the database
-        collection.save(existing, safe=True)
+        collection.save(existing)
 
         # Reload to return
         existing = collection.find_one({'_id': ObjectId(event_listener_id)})

--- a/server/pulp/server/managers/repo/cud.py
+++ b/server/pulp/server/managers/repo/cud.py
@@ -72,7 +72,7 @@ class RepoManager(object):
 
         # Creation
         create_me = Repo(repo_id, display_name, description, notes)
-        Repo.get_collection().save(create_me, safe=True)
+        Repo.get_collection().save(create_me)
 
         # Retrieve the repo to return the SON object
         created = Repo.get_collection().find_one({'id': repo_id})
@@ -231,20 +231,20 @@ class RepoManager(object):
 
         # Database Updates
         try:
-            Repo.get_collection().remove({'id': repo_id}, safe=True)
+            Repo.get_collection().remove({'id': repo_id})
 
             # Remove all importers and distributors from the repo.
             # This is likely already done by the calls to other methods in
             # this manager, but in case those failed we still want to attempt
             # to keep the database clean.
-            RepoDistributor.get_collection().remove({'repo_id': repo_id}, safe=True)
-            RepoImporter.get_collection().remove({'repo_id': repo_id}, safe=True)
+            RepoDistributor.get_collection().remove({'repo_id': repo_id})
+            RepoImporter.get_collection().remove({'repo_id': repo_id})
 
-            RepoSyncResult.get_collection().remove({'repo_id': repo_id}, safe=True)
-            RepoPublishResult.get_collection().remove({'repo_id': repo_id}, safe=True)
+            RepoSyncResult.get_collection().remove({'repo_id': repo_id})
+            RepoPublishResult.get_collection().remove({'repo_id': repo_id})
 
             # Remove all associations from the repo
-            RepoContentUnit.get_collection().remove({'repo_id': repo_id}, safe=True)
+            RepoContentUnit.get_collection().remove({'repo_id': repo_id})
         except Exception, e:
             msg = _('Error updating one or more database collections while removing repo [%(r)s]')
             msg = msg % {'r': repo_id}
@@ -310,7 +310,7 @@ class RepoManager(object):
 
             repo['notes'] = existing_notes
 
-        repo_coll.save(repo, safe=True)
+        repo_coll.save(repo)
 
         return repo
 
@@ -339,7 +339,7 @@ class RepoManager(object):
 
         if delta:
             try:
-                repo_coll.update(spec, operation, safe=True)
+                repo_coll.update(spec, operation)
             except pymongo.errors.OperationFailure:
                 message = 'There was a problem updating repository %s' % repo_id
                 raise PulpExecutionException(message), None, sys.exc_info()[2]
@@ -381,7 +381,7 @@ class RepoManager(object):
         spec = {'id': repo_id}
         operation = {'$set': {field_name: dateutils.now_utc_datetime_with_tzinfo()}}
         repo_coll = Repo.get_collection()
-        repo_coll.update(spec, operation, safe=True)
+        repo_coll.update(spec, operation)
 
     @staticmethod
     def update_repo_and_plugins(repo_id, repo_delta, importer_config,
@@ -489,7 +489,7 @@ class RepoManager(object):
         if not isinstance(scratchpad, dict):
             raise ValueError('scratchpad must be a dict')
         collection = Repo.get_collection()
-        result = collection.update({'id': repo_id}, {'$set': {'scratchpad': scratchpad}}, safe=True)
+        result = collection.update({'id': repo_id}, {'$set': {'scratchpad': scratchpad}})
         if result['n'] == 0:
             raise MissingResource(repo_id=repo_id)
 
@@ -518,7 +518,7 @@ class RepoManager(object):
             key = 'scratchpad.%s' % k
             properties[key] = v
         collection = Repo.get_collection()
-        result = collection.update({'id': repo_id}, {'$set': properties}, safe=True)
+        result = collection.update({'id': repo_id}, {'$set': properties})
         if result['n'] == 0:
             raise MissingResource(repo_id=repo_id)
 
@@ -556,8 +556,7 @@ class RepoManager(object):
             for type_id in type_ids:
                 spec = {'repo_id': repo_id, 'unit_type_id': type_id}
                 counts[type_id] = association_collection.find(spec).count()
-            repo_collection.update({'id': repo_id}, {'$set': {'content_unit_counts': counts}},
-                                   safe=True)
+            repo_collection.update({'id': repo_id}, {'$set': {'content_unit_counts': counts}})
 
 
 create_and_configure_repo = task(RepoManager.create_and_configure_repo, base=Task)

--- a/server/pulp/server/managers/repo/distributor.py
+++ b/server/pulp/server/managers/repo/distributor.py
@@ -198,7 +198,7 @@ class RepoDistributorManager(object):
         # Database Update
         distributor = RepoDistributor(repo_id, distributor_id, distributor_type_id, clean_config,
                                       auto_publish)
-        distributor_coll.save(distributor, safe=True)
+        distributor_coll.save(distributor)
 
         return distributor
 
@@ -243,7 +243,7 @@ class RepoDistributorManager(object):
         distributor_instance.distributor_removed(transfer_repo, call_config)
 
         # Update the database to reflect the removal
-        distributor_coll.remove({'_id': repo_distributor['_id']}, safe=True)
+        distributor_coll.remove({'_id': repo_distributor['_id']})
 
     @staticmethod
     def update_distributor_config(repo_id, distributor_id, distributor_config, auto_publish=None):
@@ -330,7 +330,7 @@ class RepoDistributorManager(object):
 
         # If we got this far, the new config is valid, so update the database
         repo_distributor['config'] = merged_config
-        distributor_coll.save(repo_distributor, safe=True)
+        distributor_coll.save(repo_distributor)
 
         return repo_distributor
 
@@ -429,7 +429,7 @@ class RepoDistributorManager(object):
 
         # Update
         repo_distributor['scratchpad'] = contents
-        distributor_coll.save(repo_distributor, safe=True)
+        distributor_coll.save(repo_distributor)
 
     def add_publish_schedule(self, repo_id, distributor_id, schedule_id):
         """
@@ -445,8 +445,7 @@ class RepoDistributorManager(object):
         if schedule_id in distributor['scheduled_publishes']:
             return
         collection.update({'_id': distributor['_id']},
-                          {'$push': {'scheduled_publishes': schedule_id}},
-                          safe=True)
+                          {'$push': {'scheduled_publishes': schedule_id}})
 
     def remove_publish_schedule(self, repo_id, distributor_id, schedule_id):
         """
@@ -462,8 +461,7 @@ class RepoDistributorManager(object):
         if schedule_id not in distributor['scheduled_publishes']:
             return
         collection.update({'_id': distributor['_id']},
-                          {'$pull': {'scheduled_publishes': schedule_id}},
-                          safe=True)
+                          {'$pull': {'scheduled_publishes': schedule_id}})
 
     def list_publish_schedules(self, repo_id, distributor_id):
         """

--- a/server/pulp/server/managers/repo/group/cud.py
+++ b/server/pulp/server/managers/repo/group/cud.py
@@ -42,7 +42,7 @@ class RepoGroupManager(object):
         collection = RepoGroup.get_collection()
         repo_group = RepoGroup(group_id, display_name, description, repo_ids, notes)
         try:
-            collection.insert(repo_group, safe=True)
+            collection.insert(repo_group)
         except DuplicateKeyError:
             raise pulp_exceptions.DuplicateResource(group_id), None, sys.exc_info()[2]
         group = collection.find_one({'id': group_id})
@@ -142,10 +142,10 @@ class RepoGroupManager(object):
                     unset_dict[newkey] = value
 
             if unset_dict:
-                collection.update({'id': group_id}, {'$unset': unset_dict}, safe=True)
+                collection.update({'id': group_id}, {'$unset': unset_dict})
 
         if updates:
-            collection.update({'id': group_id}, {'$set': updates}, safe=True)
+            collection.update({'id': group_id}, {'$set': updates})
         group = collection.find_one({'id': group_id})
         return group
 
@@ -164,7 +164,7 @@ class RepoGroupManager(object):
             RepoGroupDistributorManager.remove_distributor(group_id, distributor['id'])
 
         # Delete from the database
-        collection.remove({'id': group_id}, safe=True)
+        collection.remove({'id': group_id})
 
     def remove_repo_from_groups(self, repo_id, group_ids=None):
         """
@@ -181,7 +181,7 @@ class RepoGroupManager(object):
         if group_ids is not None:
             spec = {'id': {'$in': group_ids}}
         collection = RepoGroup.get_collection()
-        collection.update(spec, {'$pull': {'repo_ids': repo_id}}, multi=True, safe=True)
+        collection.update(spec, {'$pull': {'repo_ids': repo_id}}, multi=True)
 
     @staticmethod
     def associate(group_id, criteria):
@@ -199,8 +199,7 @@ class RepoGroupManager(object):
         if not repo_ids:
             return
         group_collection.update({'id': group_id},
-                                {'$addToSet': {'repo_ids': {'$each': repo_ids}}},
-                                safe=True)
+                                {'$addToSet': {'repo_ids': {'$each': repo_ids}}})
 
     @staticmethod
     def unassociate(group_id, criteria):
@@ -218,8 +217,7 @@ class RepoGroupManager(object):
         if not repo_ids:
             return
         group_collection.update({'id': group_id},
-                                {'$pullAll': {'repo_ids': repo_ids}},
-                                safe=True)
+                                {'$pullAll': {'repo_ids': repo_ids}})
 
     def add_notes(self, group_id, notes):
         """
@@ -232,7 +230,7 @@ class RepoGroupManager(object):
         group_collection = validate_existing_repo_group(group_id)
         set_doc = dict(('notes.' + k, v) for k, v in notes.items())
         if set_doc:
-            group_collection.update({'id': group_id}, {'$set': set_doc}, safe=True)
+            group_collection.update({'id': group_id}, {'$set': set_doc})
 
     def remove_notes(self, group_id, keys):
         """
@@ -244,7 +242,7 @@ class RepoGroupManager(object):
         """
         group_collection = validate_existing_repo_group(group_id)
         unset_doc = dict(('notes.' + k, 1) for k in keys)
-        group_collection.update({'id': group_id}, {'$unset': unset_doc}, safe=True)
+        group_collection.update({'id': group_id}, {'$unset': unset_doc})
 
     def set_note(self, group_id, key, value):
         """

--- a/server/pulp/server/managers/repo/group/distributor.py
+++ b/server/pulp/server/managers/repo/group/distributor.py
@@ -227,7 +227,7 @@ class RepoGroupDistributorManager(object):
                 raise PulpExecutionException(), None, sys.exc_info()[2]
 
         # Clean up the database
-        distributor_coll.remove(distributor, safe=True)
+        distributor_coll.remove(distributor)
 
     @staticmethod
     def update_distributor_config(repo_group_id, distributor_id, distributor_config):
@@ -281,7 +281,7 @@ class RepoGroupDistributorManager(object):
 
         # If we got this far, the merged_config is valid
         distributor['config'] = merged_config
-        RepoGroupDistributor.get_collection().save(distributor, safe=True)
+        RepoGroupDistributor.get_collection().save(distributor)
 
         return distributor
 
@@ -312,7 +312,7 @@ class RepoGroupDistributorManager(object):
 
         distributor = RepoGroupDistributorManager.get_distributor(repo_group_id, distributor_id)
         distributor['scratchpad'] = contents
-        RepoGroupDistributor.get_collection().save(distributor, safe=True)
+        RepoGroupDistributor.get_collection().save(distributor)
 
 
 add_distributor = task(RepoGroupDistributorManager.add_distributor, base=Task)

--- a/server/pulp/server/managers/repo/group/publish.py
+++ b/server/pulp/server/managers/repo/group/publish.py
@@ -82,7 +82,7 @@ class RepoGroupPublishManager(object):
             result = RepoGroupPublishResult.error_result(
                 group_id, distributor_id, distributor['distributor_type_id'],
                 publish_start_timestamp, publish_end_timestamp, e, sys.exc_info()[2])
-            publish_result_coll.save(result, safe=True)
+            publish_result_coll.save(result)
 
             raise
 
@@ -115,7 +115,7 @@ class RepoGroupPublishManager(object):
                 group_id, distributor_id, distributor['distributor_type_id'],
                 publish_start_timestamp, publish_end_timestamp, summary, details)
 
-        publish_result_coll.save(result, safe=True)
+        publish_result_coll.save(result)
         return result
 
     def last_publish(self, group_id, distributor_id):

--- a/server/pulp/server/managers/repo/importer.py
+++ b/server/pulp/server/managers/repo/importer.py
@@ -129,7 +129,7 @@ class RepoImporterManager(object):
         importer_id = importer_type_id  # use the importer name as its repo ID
 
         importer = RepoImporter(repo_id, importer_id, importer_type_id, clean_config)
-        importer_coll.save(importer, safe=True)
+        importer_coll.save(importer)
 
         return importer
 
@@ -219,7 +219,7 @@ class RepoImporterManager(object):
         importer_instance.importer_removed(transfer_repo, call_config)
 
         # Update the database to reflect the removal
-        importer_coll.remove({'repo_id': repo_id}, safe=True)
+        importer_coll.remove({'repo_id': repo_id})
 
     @staticmethod
     def update_importer_config(repo_id, importer_config):
@@ -294,7 +294,7 @@ class RepoImporterManager(object):
 
         # If we got this far, the new config is valid, so update the database
         repo_importer['config'] = merged_config
-        importer_coll.save(repo_importer, safe=True)
+        importer_coll.save(repo_importer)
 
         serializer = serializers.ImporterSerializer(repo_importer)
         return serializer.data
@@ -345,7 +345,7 @@ class RepoImporterManager(object):
 
         # Update
         repo_importer['scratchpad'] = contents
-        importer_coll.save(repo_importer, safe=True)
+        importer_coll.save(repo_importer)
 
 
 remove_importer = task(RepoImporterManager.remove_importer, base=Task, ignore_result=True)

--- a/server/pulp/server/managers/repo/publish.py
+++ b/server/pulp/server/managers/repo/publish.py
@@ -125,13 +125,13 @@ class RepoPublishManager(object):
             # Reload the distributor in case the scratchpad is set by the plugin
             repo_distributor = distributor_coll.find_one(
                 {'repo_id': repo_id, 'id': distributor_id})
-            distributor_coll.save(repo_distributor, safe=True)
+            distributor_coll.save(repo_distributor)
 
             # Add a publish history entry for the run
             result = RepoPublishResult.error_result(
                 repo_id, repo_distributor['id'], repo_distributor['distributor_type_id'],
                 publish_start_timestamp, publish_end_timestamp, e, sys.exc_info()[2])
-            publish_result_coll.save(result, safe=True)
+            publish_result_coll.save(result)
 
             _logger.exception(
                 _('Exception caught from plugin during publish for repo [%(r)s]' % {'r': repo_id}))
@@ -142,7 +142,7 @@ class RepoPublishManager(object):
         # Reload the distributor in case the scratchpad is set by the plugin
         repo_distributor = distributor_coll.find_one({'repo_id': repo_id, 'id': distributor_id})
         repo_distributor['last_publish'] = datetime.utcnow()
-        distributor_coll.save(repo_distributor, safe=True)
+        distributor_coll.save(repo_distributor)
 
         # Add a publish entry
         if publish_report is not None and isinstance(publish_report, PublishReport):
@@ -170,7 +170,7 @@ class RepoPublishManager(object):
         result = RepoPublishResult.expected_result(
             repo_id, repo_distributor['id'], repo_distributor['distributor_type_id'],
             publish_start_timestamp, publish_end_timestamp, summary, details, result_code)
-        publish_result_coll.save(result, safe=True)
+        publish_result_coll.save(result)
         return result
 
     def auto_publish_for_repo(self, repo_id):

--- a/server/pulp/server/managers/repo/sync.py
+++ b/server/pulp/server/managers/repo/sync.py
@@ -195,10 +195,9 @@ class RepoSyncManager(object):
 
         finally:
             # Do an update instead of a save in case the importer has changed the scratchpad
-            importer_coll.update({'repo_id': repo_id}, {'$set': {'last_sync': sync_end_timestamp}},
-                                 safe=True)
+            importer_coll.update({'repo_id': repo_id}, {'$set': {'last_sync': sync_end_timestamp}})
             # Add a sync history entry for this run
-            sync_result_coll.save(result, safe=True)
+            sync_result_coll.save(result)
 
         return result
 

--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -91,7 +91,7 @@ class RepoUnitAssociationManager(object):
 
         # Create the database entry
         association = RepoContentUnit(repo_id, unit_id, unit_type_id)
-        RepoContentUnit.get_collection().save(association, safe=True)
+        RepoContentUnit.get_collection().save(association)
 
         manager = manager_factory.repo_manager()
 
@@ -328,7 +328,7 @@ class RepoUnitAssociationManager(object):
                     'unit_type_id': unit_type_id,
                     'unit_id': {'$in': unit_ids}
                     }
-            collection.remove(spec, safe=True)
+            collection.remove(spec)
 
             unique_count = sum(
                 1 for unit_id in unit_ids if not RepoUnitAssociationManager.association_exists(

--- a/server/pulp/server/managers/schedule/utils.py
+++ b/server/pulp/server/managers/schedule/utils.py
@@ -103,7 +103,7 @@ def delete(schedule_id):
         raise exceptions.MissingResource(schedule_id=schedule_id)
 
     schedule = ScheduledCall.get_collection().find_and_modify(
-        query=spec, remove=True, safe=True)
+        query=spec, remove=True)
     if schedule is None:
         raise exceptions.MissingResource(schedule_id=schedule_id)
 
@@ -115,7 +115,7 @@ def delete_by_resource(resource):
     :param resource:    string indicating a unique resource
     :type  resource:    basestring
     """
-    ScheduledCall.get_collection().remove({'resource': resource}, safe=True)
+    ScheduledCall.get_collection().remove({'resource': resource})
 
 
 def update(schedule_id, delta):
@@ -158,7 +158,7 @@ def update(schedule_id, delta):
         # schedule_id is invalid object_id.
         raise exceptions.MissingResource(schedule_id=schedule_id)
     schedule = ScheduledCall.get_collection().find_and_modify(
-        query=spec, update={'$set': delta}, safe=True, new=True)
+        query=spec, update={'$set': delta}, new=True)
     if schedule is None:
         raise exceptions.MissingResource(schedule_id=schedule_id)
     return ScheduledCall.from_db(schedule)

--- a/server/pulp/server/webservices/views/users.py
+++ b/server/pulp/server/webservices/views/users.py
@@ -155,7 +155,7 @@ class UserResourceView(View):
         link = {'_href': reverse('user_resource',
                 kwargs={'login': login})}
         if Permission.get_collection().find_one({'resource': link['_href']}):
-            Permission.get_collection().remove({'resource': link}, safe=True)
+            Permission.get_collection().remove({'resource': link})
 
         return generate_json_response(result)
 

--- a/server/test/functional/test_content_sources.py
+++ b/server/test/functional/test_content_sources.py
@@ -183,7 +183,7 @@ class ContainerTest(TestCase):
             entry = ContentCatalog(source_id, EXPIRES, TYPE_ID, unit_key, url)
             entry_list.append(entry)
         for entry in entry_list:
-            collection.insert(entry, safe=True)
+            collection.insert(entry)
         return _dir, entry_list
 
 

--- a/server/test/unit/plugins/conduits/test_repo_publish.py
+++ b/server/test/unit/plugins/conduits/test_repo_publish.py
@@ -60,7 +60,7 @@ class RepoPublishConduitTests(base.PulpServerTests):
         last_publish = datetime.datetime(2015, 4, 29, 20, 23, 56, 0)
         repo_dist = RepoDistributor.get_collection().find_one({'repo_id': 'repo-1'})
         repo_dist['last_publish'] = last_publish
-        RepoDistributor.get_collection().save(repo_dist, safe=True)
+        RepoDistributor.get_collection().save(repo_dist)
 
         # Test - Last publish
         found = self.conduit.last_publish()
@@ -117,7 +117,7 @@ class RepoGroupPublishConduitTests(base.PulpServerTests):
         repo_group_dist = self.distributor_manager.get_distributor(self.group_id,
                                                                    self.distributor_id)
         repo_group_dist['last_publish'] = dateutils.format_iso8601_datetime(last_publish)
-        RepoGroupDistributor.get_collection().save(repo_group_dist, safe=True)
+        RepoGroupDistributor.get_collection().save(repo_group_dist)
 
         # Test
         found = self.conduit.last_publish()

--- a/server/test/unit/server/db/migrations/test_0002_rename_http_notifier.py
+++ b/server/test/unit/server/db/migrations/test_0002_rename_http_notifier.py
@@ -24,7 +24,7 @@ class TestMigration0002(base.PulpServerTests):
             'notifier_type_id': 'rest-api',
             'event_types': ['*'],
             'notifier_config': {},
-        }, safe=True))
+        }))
         event_listener_factory = managers.factory.event_listener_manager()
 
         module = MigrationModule('pulp.server.db.migrations.0002_rename_http_notifier')._module

--- a/server/test/unit/server/db/migrations/test_0003_bind_additions.py
+++ b/server/test/unit/server/db/migrations/test_0003_bind_additions.py
@@ -21,7 +21,7 @@ class BindAdditionMigrationTests(base.PulpServerTests):
                 'distributor_id': 'distributor_%s' % counter,
             }
 
-            coll.insert(bind_dict, safe=True)
+            coll.insert(bind_dict)
 
         # Test
         module = MigrationModule('pulp.server.db.migrations.0003_bind_additions')._module
@@ -51,7 +51,7 @@ class BindAdditionMigrationTests(base.PulpServerTests):
                 'distributor_id': 'distributor_%s' % counter,
             }
 
-            coll.insert(bind_dict, safe=True)
+            coll.insert(bind_dict)
 
         # Test
         module = MigrationModule('pulp.server.db.migrations.0003_bind_additions')._module

--- a/server/test/unit/server/db/migrations/test_0004_content_unit_counts.py
+++ b/server/test/unit/server/db/migrations/test_0004_content_unit_counts.py
@@ -19,7 +19,6 @@ class TestMigrationContentUnitCount(base.PulpServerTests):
         mock_update = mock_get_collection.return_value.update
         self.assertEqual(mock_update.call_count, 1)
 
-        self.assertTrue(mock_update.call_args[1].get('safe') is True)
         self.assertEqual(mock_update.call_args[0][0], {})
         self.assertEqual(mock_update.call_args[0][1], {'$unset': {'content_unit_count': 1}})
 

--- a/server/test/unit/server/db/migrations/test_0005_unit_last_updated.py
+++ b/server/test/unit/server/db/migrations/test_0005_unit_last_updated.py
@@ -38,7 +38,7 @@ class TestMigration_0005(PulpServerTests):
         super(TestMigration_0005, self).setUp()
         for collection in [connection.get_collection(n, True) for n in TEST_COLLECTIONS]:
             for unit in TEST_UNITS:
-                collection.save(unit, safe=True)
+                collection.save(unit)
 
     def tearDown(self):
         super(TestMigration_0005, self).tearDown()

--- a/server/test/unit/server/db/migrations/test_0006_binding_config.py
+++ b/server/test/unit/server/db/migrations/test_0006_binding_config.py
@@ -43,7 +43,7 @@ class TestMigration_0006(PulpServerTests):
                 BINDING_CONFIG: conf,
                 NOTIFY_AGENT: True,
             }
-            collection.save(binding, safe=True)
+            collection.save(binding)
         # migrate
         module = MigrationModule(MIGRATION)._module
         module.migrate()

--- a/server/test/unit/server/db/migrations/test_0017_distributor_list_published.py
+++ b/server/test/unit/server/db/migrations/test_0017_distributor_list_published.py
@@ -46,6 +46,6 @@ class TestMigration(TestCase):
         self.assertEqual(
             collection.save.call_args_list,
             [
-                call({LAST_PUBLISH: parsed[0]}, safe=True),
-                call({LAST_PUBLISH: parsed[1]}, safe=True)
+                call({LAST_PUBLISH: parsed[0]}),
+                call({LAST_PUBLISH: parsed[1]})
             ])

--- a/server/test/unit/server/db/migrations/test_migration_0010.py
+++ b/server/test/unit/server/db/migrations/test_migration_0010.py
@@ -21,7 +21,7 @@ class TestMigration(unittest.TestCase):
 
         mock_connection.get_collection.assert_called_once_with('foo')
         self.assertEquals(unit['bar'], utc_value)
-        collection.save.assert_called_once_with(unit, safe=True)
+        collection.save.assert_called_once_with(unit)
 
     @mock.patch('pulp.server.db.migrations.0010_utc_timestamps.connection')
     def test_time_to_utc_on_collection_skips_utc(self, mock_connection):

--- a/server/test/unit/server/db/model/test_dispatch.py
+++ b/server/test/unit/server/db/model/test_dispatch.py
@@ -666,7 +666,7 @@ class TestScheduledCallSave(unittest.TestCase):
 
         expected = call.as_dict()
         expected['_id'] = bson.ObjectId(expected['_id'])
-        mock_insert.assert_called_once_with(expected, safe=True)
+        mock_insert.assert_called_once_with(expected)
         self.assertFalse(call._new)
 
 

--- a/server/test/unit/server/db/test_reaper.py
+++ b/server/test/unit/server/db/test_reaper.py
@@ -105,7 +105,7 @@ class TestReapExpiredDocuments(base.PulpServerTests):
     def test_leave_unexpired_entries(self, getfloat):
         chec = ConsumerHistoryEvent.get_collection()
         event = ConsumerHistoryEvent('consumer', 'originator', 'consumer_registered', {})
-        chec.insert(event, safe=True)
+        chec.insert(event)
         self.assertTrue(chec.find({'_id': event['_id']}).count() == 1)
         # Let's mock getfloat to pretend that the user said they want to reap things that are a day
         # old. This means that the event should not get reaped.
@@ -120,7 +120,7 @@ class TestReapExpiredDocuments(base.PulpServerTests):
     def test_remove_expired_entries(self, getfloat):
         chec = ConsumerHistoryEvent.get_collection()
         event = ConsumerHistoryEvent('consumer', 'originator', 'consumer_registered', {})
-        chec.insert(event, safe=True)
+        chec.insert(event)
         self.assertTrue(chec.find({'_id': event['_id']}).count() == 1)
         # Let's mock getfloat to pretend that the user said they want to reap things from the
         # future, which should make the event we just created look old enough to delete

--- a/server/test/unit/server/managers/consumer/group/test_cud.py
+++ b/server/test/unit/server/managers/consumer/group/test_cud.py
@@ -40,8 +40,8 @@ class ConsumerGroupTests(base.PulpServerTests):
     def tearDown(self):
         super(ConsumerGroupTests, self).tearDown()
         self.manager = None
-        Consumer.get_collection().remove(safe=True)
-        ConsumerGroup.get_collection().remove(safe=True)
+        Consumer.get_collection().remove()
+        ConsumerGroup.get_collection().remove()
 
     def _create_consumer(self, consumer_id):
         manager = managers_factory.consumer_manager()

--- a/server/test/unit/server/managers/content/test_orphan.py
+++ b/server/test/unit/server/managers/content/test_orphan.py
@@ -65,13 +65,13 @@ def associate_content_unit_with_repo(content_unit):
                                         content_unit['_id'],
                                         content_unit['_content_type_id'])
     collection = RepoContentUnit.get_collection()
-    collection.insert(repo_content_unit, safe=True)
+    collection.insert(repo_content_unit)
 
 
 def unassociate_content_unit_from_repo(content_unit):
     spec = {'unit_id': content_unit['_id']}
     collection = RepoContentUnit.get_collection()
-    collection.remove(spec, safe=True)
+    collection.remove(spec)
 
 
 class OrphanManagerInstantiationTests(base.PulpServerTests):
@@ -99,7 +99,7 @@ class OrphanManagerTests(base.PulpServerTests):
 
     def tearDown(self):
         super(OrphanManagerTests, self).tearDown()
-        RepoContentUnit.get_collection().remove(safe=True)
+        RepoContentUnit.get_collection().remove()
         content_type_db.clean()
         if os.path.exists(self.content_root):  # can be removed by delete operations
             shutil.rmtree(self.content_root)

--- a/server/test/unit/server/managers/repo/group/test_cud.py
+++ b/server/test/unit/server/managers/repo/group/test_cud.py
@@ -39,9 +39,9 @@ class RepoGroupTests(PulpServerTests):
     def tearDown(self):
         super(RepoGroupTests, self).tearDown()
         self.manager = None
-        Repo.get_collection().remove(safe=True)
-        RepoGroup.get_collection().remove(safe=True)
-        RepoGroupDistributor.get_collection().remove(safe=True)
+        Repo.get_collection().remove()
+        RepoGroup.get_collection().remove()
+        RepoGroupDistributor.get_collection().remove()
 
     def _create_repo(self, repo_id):
         manager = managers_factory.repo_manager()

--- a/server/test/unit/server/managers/repo/test_cud.py
+++ b/server/test/unit/server/managers/repo/test_cud.py
@@ -61,7 +61,6 @@ class RepoManagerTests(base.ResourceReservationTests):
         repo_col.update.assert_called_once_with(
             {'id': 'repo1'},
             {'$set': {'content_unit_counts': {'rpm': 6, 'srpm': 6}}},
-            safe=True
         )
 
     @mock.patch('pulp.server.db.model.repository.Repo.get_collection')
@@ -537,7 +536,7 @@ class RepoManagerTests(base.ResourceReservationTests):
 
         self.manager.update_unit_count(*ARGS)
         mock_update.assert_called_once_with({'id': 'repo-123'},
-                                            {'$inc': {'content_unit_counts.rpm': 7}}, safe=True)
+                                            {'$inc': {'content_unit_counts.rpm': 7}})
 
     def test_update_unit_count_with_db(self):
         """

--- a/server/test/unit/server/managers/repo/test_publish.py
+++ b/server/test/unit/server/managers/repo/test_publish.py
@@ -486,7 +486,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoPublishResult.expected_result(
                 'test_sort', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
-            RepoPublishResult.get_collection().insert(r, safe=True)
+            RepoPublishResult.get_collection().insert(r)
 
         # Test that returned entries are in ascending order by time
         entries = self.publish_manager.publish_history('test_sort', 'test_dist',
@@ -512,7 +512,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoPublishResult.expected_result(
                 'test_sort', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
-            RepoPublishResult.get_collection().insert(r, safe=True)
+            RepoPublishResult.get_collection().insert(r)
 
         # Test that returned entries are in descending order by time
         entries = self.publish_manager.publish_history('test_sort', 'test_dist',
@@ -547,7 +547,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoPublishResult.expected_result(
                 'test_date', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
-            RepoPublishResult.get_collection().insert(r, safe=True)
+            RepoPublishResult.get_collection().insert(r)
 
         # Verify
         self.assertEqual(3, len(self.publish_manager.publish_history('test_date', 'test_dist')))
@@ -573,7 +573,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoPublishResult.expected_result(
                 'test_date', 'test_dist', 'bar', date_string % str(i), date_string % str(i + 1),
                 'test-summary', 'test-details', RepoPublishResult.RESULT_SUCCESS)
-            RepoPublishResult.get_collection().insert(r, safe=True)
+            RepoPublishResult.get_collection().insert(r)
 
         # Verify that all entries retrieved have dates prior to the given end date
         end_date = '2013-06-01T12:00:03Z'
@@ -721,4 +721,4 @@ def add_result(repo_id, dist_id, offset):
         repo_id, dist_id, 'bar', dateutils.format_iso8601_datetime(started),
         dateutils.format_iso8601_datetime(completed), 'test-summary', 'test-details',
         RepoPublishResult.RESULT_SUCCESS)
-    RepoPublishResult.get_collection().insert(r, safe=True)
+    RepoPublishResult.get_collection().insert(r)

--- a/server/test/unit/server/managers/repo/test_sync.py
+++ b/server/test/unit/server/managers/repo/test_sync.py
@@ -455,7 +455,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoSyncResult.expected_result('test_sort', 'foo', 'bar', date_string % str(i),
                                                date_string % str(i + 1), 1, 1, 1, '', '',
                                                RepoSyncResult.RESULT_SUCCESS)
-            RepoSyncResult.get_collection().save(r, safe=True)
+            RepoSyncResult.get_collection().save(r)
 
         # Test sort by ascending start date
         entries = self.sync_manager.sync_history(repo_id='test_sort', sort=constants.SORT_ASCENDING)
@@ -476,7 +476,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoSyncResult.expected_result('test_sort', 'foo', 'bar', date_string % str(i),
                                                date_string % str(i + 1), 1, 1, 1, '', '',
                                                RepoSyncResult.RESULT_SUCCESS)
-            RepoSyncResult.get_collection().save(r, safe=True)
+            RepoSyncResult.get_collection().save(r)
 
         # Test sort by descending start date
         entries = self.sync_manager.sync_history(repo_id='test_sort',
@@ -513,7 +513,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoSyncResult.expected_result('test_repo', 'foo', 'bar', date_string % str(i),
                                                date_string % str(i + 1), 1, 1, 1, '', '',
                                                RepoSyncResult.RESULT_SUCCESS)
-            RepoSyncResult.get_collection().save(r, safe=True)
+            RepoSyncResult.get_collection().save(r)
 
         # Verify three entries in test_repo
         self.assertEqual(3, len(self.sync_manager.sync_history('test_repo')))
@@ -541,7 +541,7 @@ class RepoSyncManagerTests(base.PulpServerTests):
             r = RepoSyncResult.expected_result('test_repo', 'foo', 'bar', date_string % str(i),
                                                date_string % str(i + 1), 1, 1, 1, '', '',
                                                RepoSyncResult.RESULT_SUCCESS)
-            RepoSyncResult.get_collection().save(r, safe=True)
+            RepoSyncResult.get_collection().save(r)
 
         # Verify three entries in test_repo
         self.assertEqual(3, len(self.sync_manager.sync_history('test_repo')))
@@ -660,4 +660,4 @@ def add_result(repo_id, offset):
         repo_id, 'foo', 'bar', dateutils.format_iso8601_datetime(started),
         dateutils.format_iso8601_datetime(completed), 1, 1, 1, '', '',
         RepoSyncResult.RESULT_SUCCESS)
-    RepoSyncResult.get_collection().save(r, safe=True)
+    RepoSyncResult.get_collection().save(r)

--- a/server/test/unit/server/managers/repo/test_unit_association_query.py
+++ b/server/test/unit/server/managers/repo/test_unit_association_query.py
@@ -79,7 +79,7 @@ class UnitAssociationQueryTests(base.PulpServerTests):
     def clean(self):
         super(UnitAssociationQueryTests, self).clean()
         database.clean()
-        RepoContentUnit.get_collection().remove(safe=True)
+        RepoContentUnit.get_collection().remove()
 
     def setUp(self):
         super(UnitAssociationQueryTests, self).setUp()
@@ -169,7 +169,7 @@ class UnitAssociationQueryTests(base.PulpServerTests):
                                                  'unit_id': unit_id})
             a['created'] = self.timestamps[index]
             a['updated'] = self.timestamps[index]
-            association_collection.save(a, safe=True)
+            association_collection.save(a)
 
         #   Alpha
         for i, unit_id in enumerate(self.units['alpha']):

--- a/server/test/unit/server/managers/schedule/test_utils.py
+++ b/server/test/unit/server/managers/schedule/test_utils.py
@@ -232,7 +232,7 @@ class TestDeleteByResource(unittest.TestCase):
 
         utils.delete_by_resource('resource1')
 
-        mock_remove.assert_called_once_with({'resource': 'resource1'}, safe=True)
+        mock_remove.assert_called_once_with({'resource': 'resource1'})
 
 
 class TestUpdate(unittest.TestCase):


### PR DESCRIPTION
Remove the deprecated safe=True from all calls to PyMongo.

closes #1065