### PR TITLE
Do not delete worker if unresponsive.

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -182,9 +182,6 @@ def _delete_worker(name, normal_shutdown=False):
                                           state__in=constants.CALL_INCOMPLETE_STATES):
         cancel(task_status['task_id'])
 
-    # Delete working directory
-    common_utils.delete_worker_working_directory(name)
-
 
 @task
 def _release_resource(task_id):
@@ -593,4 +590,5 @@ def cleanup_old_worker(*args, **kwargs):
     name = kwargs['sender'].hostname
     _delete_worker(name, normal_shutdown=True)
     # Recreate a new working directory for worker that is starting now
+    common_utils.delete_worker_working_directory(name)
     common_utils.create_worker_working_directory(name)

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -844,13 +844,16 @@ class TestGetCurrentTaskId(unittest.TestCase):
 
 class TestCleanupOldWorker(unittest.TestCase):
 
+    @mock.patch('pulp.server.managers.repo._common.delete_worker_working_directory')
     @mock.patch('pulp.server.managers.repo._common.create_worker_working_directory')
     @mock.patch('pulp.server.async.tasks._delete_worker')
     def test_assert_calls__delete_worker_synchronously(self, mock__delete_worker,
-                                                       mock__create_worker_working_directory):
+                                                       mock__create_worker_working_directory,
+                                                       mock__delete_worker_working_directory):
         sender = mock.Mock()
         tasks.cleanup_old_worker(sender=sender)
         mock__delete_worker.assert_called_once_with(sender.hostname, normal_shutdown=True)
+        mock__delete_worker_working_directory.assert_called_once_with(sender.hostname)
         mock__create_worker_working_directory.assert_called_once_with(sender.hostname)
 
 


### PR DESCRIPTION
closes #1222
The worker may not be on the same machine as the scheduler, and this
cleanup will occur on worker startup anyway.