### PR TITLE
ensure datetimes on distributors

### DIFF
--- a/common/pulp/common/dateutils.py
+++ b/common/pulp/common/dateutils.py
@@ -148,6 +148,22 @@ def now_utc_datetime_with_tzinfo():
     return datetime.datetime.now(tz=utc_tz())
 
 
+def ensure_tz(time_stamp):
+    """
+    Check a datetime that came from the database to ensure it has a timezone specified in UTC
+    Mongo doesn't include the TZ info so if no TZ is set this assumes UTC.
+
+    :param time_stamp: a datetime object to ensure has UTC tzinfo specified
+    :type time_stamp: datetime.datetime
+    :return: The time_stamp with a timezone specified
+    :rtype: datetime.datetime
+    """
+    if time_stamp:
+        time_stamp = to_utc_datetime(time_stamp, no_tz_equals_local_tz=False)
+
+    return time_stamp
+
+
 # iso8601 functions ------------------------------------------------------------
 
 def parse_iso8601_date(date_str):

--- a/common/test/unit/test_dateutils.py
+++ b/common/test/unit/test_dateutils.py
@@ -196,3 +196,33 @@ class TestNowDateTimeWithTzInfo(unittest.TestCase):
         self.assertTrue(hasattr(result, 'tzinfo'))
         self.assertEquals(result.tzinfo, dateutils.utc_tz())
         self.assertTrue(result >= comparator)
+
+
+class TestEnsureTzSpecified(unittest.TestCase):
+    """
+    Tests for recreating a tz object from a datetime in UTC.
+    """
+
+    def test_tz_not_specified(self):
+        """
+        Test that if a tz is not specified, it is added.
+        """
+        dt = datetime.datetime.utcnow()
+        new_date = dateutils.ensure_tz(dt)
+        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())
+
+    def test_none_object(self):
+        """
+        Ensure that if None is passed, return None.
+        """
+        dt = None
+        new_date = dateutils.ensure_tz(dt)
+        self.assertEquals(new_date, None)
+
+    def test_tz_specified(self):
+        """
+        Ensure that if the tz is already specified, it is used.
+        """
+        dt = datetime.datetime.now(dateutils.local_tz())
+        new_date = dateutils.ensure_tz(dt)
+        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())

--- a/server/pulp/plugins/conduits/repo_publish.py
+++ b/server/pulp/plugins/conduits/repo_publish.py
@@ -6,6 +6,7 @@ interacting with the Pulp server during a repo publish.
 import logging
 import sys
 
+from pulp.common import dateutils
 from pulp.plugins.conduits.mixins import (
     DistributorConduitException, RepoScratchPadMixin, RepoScratchpadReadMixin,
     DistributorScratchPadMixin, RepoGroupDistributorScratchPadMixin, StatusMixin,
@@ -62,7 +63,7 @@ class RepoPublishConduit(RepoScratchPadMixin, DistributorScratchPadMixin, Status
         try:
             repo_publish_manager = manager_factory.repo_publish_manager()
             last = repo_publish_manager.last_publish(self.repo_id, self.distributor_id)
-            return last
+            return dateutils.ensure_tz(last)
         except Exception, e:
             _logger.exception('Error getting last publish time for repo [%s]' % self.repo_id)
             raise DistributorConduitException(e), None, sys.exc_info()[2]

--- a/server/pulp/server/managers/repo/_common.py
+++ b/server/pulp/server/managers/repo/_common.py
@@ -23,22 +23,6 @@ from pulp.server import config as pulp_config
 from pulp.server.exceptions import PulpCodedException
 
 
-def _ensure_tz_specified(time_stamp):
-    """
-    Check a datetime that came from the database to ensure it has a timezone specified in UTC
-    Mongo doesn't include the TZ info so if no TZ is set this assumes UTC.
-
-    :param time_stamp: a datetime object to ensure has UTC tzinfo specified
-    :type time_stamp: datetime.datetime
-    :return: The time_stamp with a timezone specified
-    :rtype: datetime.datetime
-    """
-    if time_stamp:
-        time_stamp = dateutils.to_utc_datetime(time_stamp, no_tz_equals_local_tz=False)
-
-    return time_stamp
-
-
 def to_transfer_repo(repo_data):
     """
     Converts the given database representation of a repository into a plugin
@@ -53,8 +37,8 @@ def to_transfer_repo(repo_data):
     """
     r = Repository(repo_data['id'], repo_data['display_name'], repo_data['description'],
                    repo_data['notes'], content_unit_counts=repo_data['content_unit_counts'],
-                   last_unit_added=_ensure_tz_specified(repo_data.get('last_unit_added')),
-                   last_unit_removed=_ensure_tz_specified(repo_data.get('last_unit_removed')))
+                   last_unit_added=dateutils.ensure_tz(repo_data.get('last_unit_added')),
+                   last_unit_removed=dateutils.ensure_tz(repo_data.get('last_unit_removed')))
     return r
 
 

--- a/server/test/unit/plugins/conduits/test_repo_publish.py
+++ b/server/test/unit/plugins/conduits/test_repo_publish.py
@@ -65,7 +65,9 @@ class RepoPublishConduitTests(base.PulpServerTests):
         # Test - Last publish
         found = self.conduit.last_publish()
         self.assertTrue(isinstance(found, datetime.datetime))  # check returned format
-        self.assertEqual(repo_dist['last_publish'], found)
+
+        self.assertEqual(found.tzinfo, dateutils.utc_tz())
+        self.assertEqual(repo_dist['last_publish'], found.replace(tzinfo=None))
 
     @mock.patch('pulp.server.managers.repo.publish.RepoPublishManager.last_publish')
     def test_last_publish_with_error(self, mock_call):

--- a/server/test/unit/server/managers/repo/test_common.py
+++ b/server/test/unit/server/managers/repo/test_common.py
@@ -1,12 +1,11 @@
-import datetime
 import unittest
 
 import mock
 
 from pulp.common import dateutils
-from pulp.server.managers.repo._common import to_transfer_repo, _ensure_tz_specified,\
-    get_working_directory, delete_working_directory, create_worker_working_directory,\
-    delete_worker_working_directory
+from pulp.server.managers.repo._common import (
+    to_transfer_repo, get_working_directory, delete_working_directory,
+    create_worker_working_directory, delete_worker_working_directory)
 
 
 class TestToTransferRepo(unittest.TestCase):
@@ -45,24 +44,6 @@ class TestToTransferRepo(unittest.TestCase):
         repo = to_transfer_repo(data)
         self.assertEquals(None, repo.last_unit_added)
         self.assertEquals(None, repo.last_unit_removed)
-
-
-class TestEnsureTzSpecified(unittest.TestCase):
-
-    def test_tz_not_specified(self):
-        dt = datetime.datetime.utcnow()
-        new_date = _ensure_tz_specified(dt)
-        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())
-
-    def test_none_object(self):
-        dt = None
-        new_date = _ensure_tz_specified(dt)
-        self.assertEquals(new_date, None)
-
-    def test_tz_specified(self):
-        dt = datetime.datetime.now(dateutils.local_tz())
-        new_date = _ensure_tz_specified(dt)
-        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())
 
 
 class TestWorkingDirectory(unittest.TestCase):


### PR DESCRIPTION
closes https://pulp.plan.io/issues/1254

When saving datetimes to Mongo, tz information is stripped. We have to reconstruct the tzinfo (assuming UTC) so it can be compared with other datetimes.