### PR TITLE
serialize tasks for emails

### DIFF
--- a/server/pulp/server/event/data.py
+++ b/server/pulp/server/event/data.py
@@ -6,6 +6,7 @@ from mongoengine.queryset import DoesNotExist
 import celery
 
 from pulp.server.db.model import TaskStatus
+from pulp.server.webservices.views.tasks import task_serializer
 
 
 # These types are used to form AMQP message topic names, so they must be
@@ -45,5 +46,5 @@ class Event(object):
         """
         d = {'event_type': self.event_type,
              'payload': self.payload,
-             'call_report': self.call_report}
+             'call_report': task_serializer(self.call_report)}
         return d


### PR DESCRIPTION
https://pulp.plan.io/issues/1255

2.7.0 includes the mongoengine conversion for TaskStatus. The TaskStatus serializer needs to be used in before a TaskStatus object can be dumped to json.