### PR TITLE
Adds support for write concern

### DIFF
--- a/common/pulp/common/error_codes.py
+++ b/common/pulp/common/error_codes.py
@@ -100,6 +100,8 @@ PLP0040 = Error("PLP0040", _("Database 'seeds' config must include at least one 
 PLP0041 = Error("PLP0041", _("Database 'replica_set' config must be specified when more than one "
                              "seed is provided. Refer to /etc/pulp/server.conf for proper use."),
                 [])
+PLP0043 = Error("PLP0043", _("Database 'write_concern' config can only be 'majority' or 'all'. "
+                             "Refer to /etc/pulp/server.conf for proper use."), [])
 
 # Create a section for general validation errors (PLP1000 - PLP2999)
 # Validation problems should be reported with a general PLP1000 error with a more specific

--- a/docs/user-guide/release-notes/2.7.x.rst
+++ b/docs/user-guide/release-notes/2.7.x.rst
@@ -52,6 +52,10 @@ New Features
 * Pulp properly connects to MongoDB replica sets. The `replica_set` setting in `database` section
   of `/etc/pulp/server.conf` must be provided for Pulp to connect to a replica set.
 
+* Pulp allows users to specify the write concern for MongoDB connection. The two options are
+  'majority' and 'all'. When 'all' is specified, the number of seeds listed will be used as the value
+  for 'w'. For installations without replica sets, all writes to the database will be acknowledged.
+
 
 Deprecation
 -----------

--- a/pulp.spec
+++ b/pulp.spec
@@ -312,6 +312,7 @@ Requires: python-httplib2
 Requires: python-isodate >= 0.5.0-1.pulp
 Requires: python-qpid
 Requires: python-nectar >= 1.1.6
+Requires: python-semantic-version >= 2.2.0
 Requires: httpd
 Requires: mod_ssl
 Requires: openssl

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -39,6 +39,11 @@
 #                    of the connection.
 # unsafe_autoretry:  If true, retry commands to the database if there is a connection error.
 #                    Warning: if set to true, this setting can result in duplicate records.
+# write_concern:     Write concern of 'majority' or 'all'. When 'all' is specified, 'w' is set to
+#                    number of seeds specified. For version of MongoDB < 2.6, replica_set must also
+#                    be specified. Please note that 'all' will cause Pulp to halt if any of the
+#                    replica set members is not available. 'majority' is used by default.
+
 
 [database]
 # name: pulp_database
@@ -52,6 +57,7 @@
 # verify_ssl: true
 # ca_path: /etc/pki/tls/certs/ca-bundle.crt
 # unsafe_autoretry: false
+# write_concern: majority
 
 
 # = Server =

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -34,6 +34,7 @@ _default_values = {
         'verify_ssl': 'true',
         'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
         'unsafe_autoretry': 'false',
+        'write_concern': 'majority',
     },
     'email': {
         'host': 'localhost',


### PR DESCRIPTION
Pulp now accepts a write concern for the MongoDB connection. All writes
to the database are now acknowledged. For replica sets, 'majority' or 'all'
members can be asked to acknowledge the write.