### PR TITLE
2067 merge forward

### DIFF
--- a/common/pulp/common/dateutils.py
+++ b/common/pulp/common/dateutils.py
@@ -133,6 +133,22 @@ def now_utc_datetime_with_tzinfo():
     return datetime.datetime.now(tz=utc_tz())
 
 
+def ensure_tz(time_stamp):
+    """
+    Check a datetime that came from the database to ensure it has a timezone specified in UTC
+    Mongo doesn't include the TZ info so if no TZ is set this assumes UTC.
+
+    :param time_stamp: a datetime object to ensure has UTC tzinfo specified
+    :type time_stamp: datetime.datetime
+    :return: The time_stamp with a timezone specified
+    :rtype: datetime.datetime
+    """
+    if time_stamp:
+        time_stamp = to_utc_datetime(time_stamp, no_tz_equals_local_tz=False)
+
+    return time_stamp
+
+
 # iso8601 functions ------------------------------------------------------------
 
 def parse_iso8601_date(date_str):

--- a/common/test/unit/test_dateutils.py
+++ b/common/test/unit/test_dateutils.py
@@ -184,3 +184,33 @@ class TestNowDateTimeWithTzInfo(unittest.TestCase):
         self.assertTrue(hasattr(result, 'tzinfo'))
         self.assertEquals(result.tzinfo, dateutils.utc_tz())
         self.assertTrue(result >= comparator)
+
+
+class TestEnsureTzSpecified(unittest.TestCase):
+    """
+    Tests for recreating a tz object from a datetime in UTC.
+    """
+
+    def test_tz_not_specified(self):
+        """
+        Test that if a tz is not specified, it is added.
+        """
+        dt = datetime.datetime.utcnow()
+        new_date = dateutils.ensure_tz(dt)
+        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())
+
+    def test_none_object(self):
+        """
+        Ensure that if None is passed, return None.
+        """
+        dt = None
+        new_date = dateutils.ensure_tz(dt)
+        self.assertEquals(new_date, None)
+
+    def test_tz_specified(self):
+        """
+        Ensure that if the tz is already specified, it is used.
+        """
+        dt = datetime.datetime.now(dateutils.local_tz())
+        new_date = dateutils.ensure_tz(dt)
+        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())

--- a/server/pulp/plugins/conduits/repo_publish.py
+++ b/server/pulp/plugins/conduits/repo_publish.py
@@ -7,6 +7,7 @@ import logging
 import sys
 
 from pulp.server import exceptions as pulp_exceptions
+from pulp.common import dateutils
 from pulp.plugins.conduits.mixins import (
     DistributorConduitException, RepoScratchPadMixin, RepoScratchpadReadMixin,
     DistributorScratchPadMixin, RepoGroupDistributorScratchPadMixin, StatusMixin,
@@ -67,7 +68,7 @@ class RepoPublishConduit(RepoScratchPadMixin, DistributorScratchPadMixin, Status
             distributor = collection.find_one({'repo_id': self.repo_id, 'id': self.distributor_id})
             if distributor is None:
                 raise pulp_exceptions.MissingResource(self.repo_id)
-            return distributor['last_publish']
+            return dateutils.ensure_tz(distributor['last_publish'])
         except Exception, e:
             _logger.exception('Error getting last publish time for repo [%s]' % self.repo_id)
             raise DistributorConduitException(e), None, sys.exc_info()[2]

--- a/server/pulp/plugins/model.py
+++ b/server/pulp/plugins/model.py
@@ -52,28 +52,12 @@ class Repository(object):
         self.notes = notes
         self.working_dir = working_dir
         self.content_unit_counts = content_unit_counts or {}
-        self.last_unit_added = self._ensure_tz_specified(last_unit_added)
-        self.last_unit_removed = self._ensure_tz_specified(last_unit_removed)
+        self.last_unit_added = dateutils.ensure_tz(last_unit_added)
+        self.last_unit_removed = dateutils.ensure_tz(last_unit_removed)
         self.repo_obj = repo_obj
 
     def __str__(self):
         return 'Repository [%s]' % self.id
-
-    @staticmethod
-    def _ensure_tz_specified(time_stamp):
-        """
-        Ensure that a datetime has a timezone specified in UTC. Mongo doesn't include the TZ info
-        so if no TZ is set this assumes UTC.
-
-        :param time_stamp: datetime object to ensure that tzinfo is specified
-        :type time_stamp:  datetime.datetime
-
-        :return: The time_stamp with a timezone specified
-        :rtype:  datetime.datetime
-        """
-        if time_stamp:
-            time_stamp = dateutils.to_utc_datetime(time_stamp, no_tz_equals_local_tz=False)
-        return time_stamp
 
 
 class RelatedRepository(Repository):

--- a/server/test/unit/plugins/conduits/test_repo_publish.py
+++ b/server/test/unit/plugins/conduits/test_repo_publish.py
@@ -64,7 +64,9 @@ class RepoPublishConduitTests(base.PulpServerTests):
         # Test - Last publish
         found = self.conduit.last_publish()
         self.assertTrue(isinstance(found, datetime.datetime))  # check returned format
-        self.assertEqual(repo_dist['last_publish'], found)
+
+        self.assertEqual(found.tzinfo, dateutils.utc_tz())
+        self.assertEqual(repo_dist['last_publish'], found.replace(tzinfo=None))
 
     @mock.patch('pulp.plugins.conduits.repo_publish.RepoDistributor')
     def test_last_publish_with_error(self, mock_dist):

--- a/server/test/unit/plugins/test_model.py
+++ b/server/test/unit/plugins/test_model.py
@@ -1,13 +1,11 @@
 """
 This module contains tests for pulp.plugins.model.
 """
-import datetime
 import functools
 import unittest
 
 import mock
 
-from pulp.common import dateutils
 from pulp.plugins.model import Unit, Repository
 from pulp.server import constants
 
@@ -131,7 +129,7 @@ class TestRepository(unittest.TestCase):
         self.assertEquals(None, repo.last_unit_added)
         self.assertEquals(None, repo.last_unit_removed)
 
-    @mock.patch('pulp.plugins.model.Repository._ensure_tz_specified')
+    @mock.patch('pulp.plugins.model.dateutils.ensure_tz')
     def test_init_with_values(self, mock_tz):
         """
         Make sure that the repo contains the appropriate values following initialization.
@@ -154,30 +152,6 @@ class TestRepository(unittest.TestCase):
         self.assertTrue(repo.last_unit_added is mock_tz.return_value)
         self.assertTrue(repo.last_unit_removed is mock_tz.return_value)
         mock_tz.assert_has_calls([mock.call(1), mock.call(2)])
-
-    def test_ensure_tz_not_specified(self):
-        """
-        Make sure that a date without a timezone is given one.
-        """
-        dt = datetime.datetime.utcnow()
-        new_date = Repository._ensure_tz_specified(dt)
-        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())
-
-    def test_ensure_tz_none_object(self):
-        """
-        Test _ensure_tz_specified with None.
-        """
-        dt = None
-        new_date = Repository._ensure_tz_specified(dt)
-        self.assertEquals(new_date, None)
-
-    def test_ensure_tz_specified(self):
-        """
-        If the timezone is specified, the result should be the same.
-        """
-        dt = datetime.datetime.now(dateutils.local_tz())
-        new_date = Repository._ensure_tz_specified(dt)
-        self.assertEquals(new_date.tzinfo, dateutils.utc_tz())
 
     def test_str(self):
         repo = Repository('foo')


### PR DESCRIPTION
I moved _ensure_tz_specified to the Repository class in master here: https://github.com/pulp/pulp/pull/1931.

This functionality needed to be used more generally, and I moved it to common: https://github.com/pulp/pulp/pull/2067

The merge forward required some changes that warrant another review.