### PR TITLE
Add get_downloader() to base importer.

### DIFF
--- a/server/test/unit/plugins/test_importer.py
+++ b/server/test/unit/plugins/test_importer.py
@@ -1,15 +1,62 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+from unittest import TestCase
 
-import mock
+from mock import patch, Mock
 
 from pulp.plugins.importer import Importer
 
 
-class TestImporter(unittest.TestCase):
+class TestImporter(TestCase):
 
-    @mock.patch('pulp.plugins.importer.sys.exit', autospec=True)
+    @patch('pulp.plugins.importer.LocalFileDownloader')
+    @patch('pulp.plugins.importer.importer_config_to_nectar_config')
+    def test_get_local_downloader(self, to_nectar, local):
+        url = 'file:///martin.com/test'
+        config = Mock()
+
+        # test
+        downloader = Importer.get_downloader(config, url)
+
+        # validation
+        to_nectar.assert_called_once_with(config.flatten.return_value)
+        local.assert_called_once_with(to_nectar.return_value)
+        self.assertEqual(downloader, local.return_value)
+
+    @patch('pulp.plugins.importer.HTTPThreadedDownloader')
+    @patch('pulp.plugins.importer.importer_config_to_nectar_config')
+    def test_get_http_downloader(self, to_nectar, http):
+        url = 'http://martin.com/test'
+        config = Mock()
+
+        # test
+        downloader = Importer.get_downloader(config, url)
+
+        # validation
+        to_nectar.assert_called_once_with(config.flatten.return_value)
+        http.assert_called_once_with(to_nectar.return_value)
+        self.assertEqual(downloader, http.return_value)
+
+    @patch('pulp.plugins.importer.HTTPThreadedDownloader')
+    @patch('pulp.plugins.importer.importer_config_to_nectar_config')
+    def test_get_https_downloader(self, to_nectar, http):
+        url = 'https://martin.com/test'
+        config = Mock()
+
+        # test
+        downloader = Importer.get_downloader(config, url)
+
+        # validation
+        to_nectar.assert_called_once_with(config.flatten.return_value)
+        http.assert_called_once_with(to_nectar.return_value)
+        self.assertEqual(downloader, http.return_value)
+
+    @patch('pulp.plugins.importer.importer_config_to_nectar_config', Mock())
+    def test_get_downloader_invalid_scheme(self):
+        url = 'ftpx://martin.com/test'
+        self.assertRaises(ValueError, Importer.get_downloader, Mock(), url)
+
+    @patch('pulp.plugins.importer.sys.exit', autospec=True)
     def test_cancel_sync_repo_calls_sys_exit(self, mock_sys_exit):
         Importer().cancel_sync_repo()
         mock_sys_exit.assert_called_once_with()


### PR DESCRIPTION
https://pulp.plan.io/issues/1281

I'm not 100% sold on this approach but seems reasonable.  Even for the docker importer which needs to make an API call to get a session key which it adds a a header to the downloader .. this will work.  The streamer would use it (something) like this:

```
entry = LazyCatalogEntry.objects.get(relative_path=<path with /var/lib/pulp/content stripped>)
config, plugin =  plugin_api.get_importe_by_id(entry.plugin_id)
downloader = plugin.get_downloader(config, entry.url, **entry.data)
```