### PR TITLE
Lazy RedirectView no longer returns HTTP 500.

### DIFF
--- a/server/pulp/server/webservices/views/lazy.py
+++ b/server/pulp/server/webservices/views/lazy.py
@@ -73,7 +73,12 @@ class RedirectView(View):
         :return: A redirect or not-found response.
         :rtype: django.http.HttpResponse
         """
-        path = request.environ['REDIRECT_URL']
+        try:
+            path = request.environ['REDIRECT_URL']
+        except KeyError:
+            # Not redirected by ErrorDocument
+            return HttpResponseNotFound()
+
         query = request.environ.get('REDIRECT_QUERY_STRING', '')
         scheme = request.environ['REQUEST_SCHEME']
         host = request.environ['SERVER_NAME']

--- a/server/test/unit/server/webservices/views/test_lazy.py
+++ b/server/test/unit/server/webservices/views/test_lazy.py
@@ -12,8 +12,9 @@ MODULE = 'pulp.server.webservices.views.lazy'
 class TestRedirectView(TestCase):
 
     @patch(MODULE + '.pulp_conf')
+    @patch(MODULE + '.Key.load')
     @patch(MODULE + '.AliasTable.load')
-    def test_init(self, load, pulp_conf):
+    def test_init(self, alias_load, key_load, pulp_conf):
         key_path = '/tmp/rsa.key'
         conf = {
             'authentication': {
@@ -28,7 +29,8 @@ class TestRedirectView(TestCase):
 
         # validation
         self.assertTrue(isinstance(view.alias, AliasTable))
-        load.assert_called_once_with()
+        alias_load.assert_called_once_with()
+        key_load.assert_called_once_with(key_path)
 
     @patch(MODULE + '.Key.load', Mock())
     @patch(MODULE + '.AliasTable.load', Mock())
@@ -128,4 +130,12 @@ class TestRedirectView(TestCase):
         # validation
         self.assertFalse(url.called)
         http_not_found.assert_called_once_with(path)
+        self.assertEqual(reply, http_not_found.return_value)
+
+    @patch(MODULE + '.HttpResponseNotFound')
+    @patch(MODULE + '.Key.load', Mock())
+    @patch(MODULE + '.AliasTable.load', Mock())
+    def test_get_no_redirect(self, http_not_found):
+        reply = RedirectView().get(Mock(environ={}))
+        http_not_found.assert_called_once_with()
         self.assertEqual(reply, http_not_found.return_value)


### PR DESCRIPTION
If the URL that mapped to the Lazy RedirectView was queried
directly rather than being the result of an internal redirect
via Apache's ErrorDocument, the client would get a 500.

A 404 felt like the best response to me, but I would welcome other suggestions.