### PR TITLE
Removing shutil.move and copytree where /var/cache/pulp is involved.

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -821,7 +821,7 @@ class SaveTarFilePublishStep(PublishStep):
         publish_dir_parent = os.path.dirname(self.publish_file)
         if not os.path.exists(publish_dir_parent):
             os.makedirs(publish_dir_parent, 0750)
-        shutil.move(os.path.join(self.source_dir, tar_file_name), self.publish_file)
+        shutil.copy(os.path.join(self.source_dir, tar_file_name), self.publish_file)
 
 
 class CreatePulpManifestStep(Step):


### PR DESCRIPTION
closes #1269 

I did not change move--> copy when
1) move was performed from /var/lib/pulp/ to /var/lib/pulp/
2) move was performed from /var/cache/pulp to /var/cache/pulp
3) in tests where it was not testing the code itself
4) under rel-eng directory

I did not change copytree in case where only symlinks were copied and param symlinks  was set to True https://docs.python.org/2/library/shutil.html#shutil.copytree for more info read 2nd paragraph