### PR TITLE
Apache 2.4 now starts without a conf file in /etc/pulp/vhost80/

### DIFF
--- a/server/etc/httpd/conf.d/pulp_apache_24.conf
+++ b/server/etc/httpd/conf.d/pulp_apache_24.conf
@@ -51,7 +51,7 @@ WSGIImportScript /srv/pulp/webservices.wsgi process-group=pulp application-group
 </Files>
 
 <VirtualHost *:80>
-    Include /etc/pulp/vhosts80/*.conf
+    IncludeOptional /etc/pulp/vhosts80/*.conf
 </VirtualHost>
 
 


### PR DESCRIPTION
In Apache 2.4 when an 'Include' command fails to match any file
Apache will fail to start. This is avoided by using the
'IncludeOptional' command. In 2.2 the 'Include' command acts in a
similar fashion to the 'IncludeOptional' command in 2.4, so that
configuration remains unchanged.

Closes #293