### PR TITLE
Upgrades kombu to 3.0.24-10

### DIFF
--- a/deps/python-kombu/1245.patch
+++ b/deps/python-kombu/1245.patch
@@ -1,0 +1,122 @@
+From d2409719a242002a5701c7d76e6d3a0184612fa6 Mon Sep 17 00:00:00 2001
+From: Brian Bouterse <bmbouter@gmail.com>
+Date: Fri, 2 Oct 2015 12:18:42 -0400
+Subject: [PATCH] Qpid transport can now connect as 'localhost'
+
+fixes celery/kombu#519
+https://github.com/celery/kombu/issues/519
+---
+ kombu/tests/transport/test_qpid.py | 20 ++++++++++----------
+ kombu/transport/qpid.py            |  2 --
+ 2 files changed, 10 insertions(+), 12 deletions(-)
+
+diff --git a/kombu/tests/transport/test_qpid.py b/kombu/tests/transport/test_qpid.py
+index f9719ca..75fa887 100644
+--- a/kombu/tests/transport/test_qpid.py
++++ b/kombu/tests/transport/test_qpid.py
+@@ -1714,7 +1714,7 @@ class TestTransportEstablishConnection(Case):
+             username=self.client.userid,
+             password=self.client.password,
+             sasl_mechanisms='PLAIN',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             port=5672,
+             transport='tcp',
+@@ -1724,7 +1724,7 @@ class TestTransportEstablishConnection(Case):
+         self.transport.establish_connection()
+         self.mock_conn.assert_called_once_with(
+             sasl_mechanisms='ANONYMOUS',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             port=5672,
+             transport='tcp',
+@@ -1736,7 +1736,7 @@ class TestTransportEstablishConnection(Case):
+         self.transport.establish_connection()
+         self.mock_conn.assert_called_once_with(
+             sasl_mechanisms='ANONYMOUS',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             new_param=new_param_value,
+             port=5672,
+@@ -1748,7 +1748,7 @@ class TestTransportEstablishConnection(Case):
+         self.transport.establish_connection()
+         self.mock_conn.assert_called_once_with(
+             sasl_mechanisms='ANONYMOUS',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             port=5672,
+             transport='tcp',
+@@ -1767,7 +1767,7 @@ class TestTransportEstablishConnection(Case):
+         self.transport.establish_connection()
+         self.mock_conn.assert_called_once_with(
+             sasl_mechanisms='EXTERNAL',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             port=5672,
+             transport='tcp',
+@@ -1780,7 +1780,7 @@ class TestTransportEstablishConnection(Case):
+         self.mock_conn.assert_called_once_with(
+             username=self.client.userid,
+             sasl_mechanisms='EXTERNAL',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             port=5672,
+             transport='tcp',
+@@ -1794,7 +1794,7 @@ class TestTransportEstablishConnection(Case):
+             username='someuser',
+             password='somepass',
+             sasl_mechanisms='PLAIN',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             port=5672,
+             transport='tcp',
+@@ -1805,7 +1805,7 @@ class TestTransportEstablishConnection(Case):
+         self.transport.establish_connection()
+         self.mock_conn.assert_called_once_with(
+             sasl_mechanisms='ANONYMOUS',
+-            host='127.0.0.1',
++            host='localhost',
+             timeout=4,
+             port=5672,
+             transport='tcp',
+@@ -1825,7 +1825,7 @@ class TestTransportEstablishConnection(Case):
+             timeout=4,
+             ssl_skip_hostname_check=False,
+             sasl_mechanisms='ANONYMOUS',
+-            host='127.0.0.1',
++            host='localhost',
+             ssl_keyfile='my_keyfile',
+             port=5672, transport='ssl',
+         )
+@@ -1844,7 +1844,7 @@ class TestTransportEstablishConnection(Case):
+             timeout=4,
+             ssl_skip_hostname_check=True,
+             sasl_mechanisms='ANONYMOUS',
+-            host='127.0.0.1',
++            host='localhost',
+             ssl_keyfile='my_keyfile',
+             port=5672, transport='ssl',
+         )
+diff --git a/kombu/transport/qpid.py b/kombu/transport/qpid.py
+index 0145e68..8e5dfe9 100644
+--- a/kombu/transport/qpid.py
++++ b/kombu/transport/qpid.py
+@@ -1632,8 +1632,6 @@ class Transport(base.Transport):
+         for name, default_value in items(self.default_connection_params):
+             if not getattr(conninfo, name, None):
+                 setattr(conninfo, name, default_value)
+-        if conninfo.hostname == 'localhost':
+-            conninfo.hostname = '127.0.0.1'
+         if conninfo.ssl:
+             conninfo.qpid_transport = 'ssl'
+             conninfo.transport_options['ssl_keyfile'] = conninfo.ssl[
+-- 
+2.4.3
+

--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.24
-Release:        9.pulp%{?dist}
+Release:        10.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages
@@ -22,6 +22,7 @@ Source0:        http://pypi.python.org/packages/source/k/%{srcname}/%{srcname}-%
 Patch0:         1212200.patch
 Patch1:         qpid_fixes.patch
 Patch2:         1168.patch
+Patch3:         1245.patch
 BuildArch:      noarch
 
 BuildRequires:  python2-devel
@@ -120,6 +121,7 @@ This subpackage is for python3
 
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 
 # manage requirements on rpm base
 sed -i 's/>=1.0.13,<1.1.0/>=1.3.0/' requirements/default.txt


### PR DESCRIPTION
Includes fix that allows kombu to connect on localhost

This was scratch built successfully on koji. See the [build results here](http://koji.katello.org/koji/taskinfo?taskID=353399).

closes #1245
https://pulp.plan.io/issues/1245