### PR TITLE
Fix alias translation.

### DIFF
--- a/server/pulp/server/lazy/alias.py
+++ b/server/pulp/server/lazy/alias.py
@@ -47,13 +47,9 @@ class AliasTable(object):
         :return: A translated path.
         :rtype: str
         """
-        translated = None
+        translated = path
         for alias, real in sorted(self.table.items()):
             if path.startswith(alias):
-                real = os.path.realpath(real)
                 translated = path.replace(alias, real)
                 break
-        if translated:
-            return os.path.normpath(translated)
-        else:
-            return os.path.realpath(path)
+        return os.path.realpath(translated)


### PR DESCRIPTION
The translated alias was not resolving the symlinks properly and returning `/var/lib/pulp/published/...` paths instead of `/var/lib/pulp/content/...` paths.

Basically simplified in a way the ensures the os.path.realpath() is called on the returned path.