### PR TITLE
Fix error message on repo remove command

### DIFF
--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -1235,6 +1235,7 @@ class RepoUnassociate(View):
 
         task_tags = [tags.resource_tag(tags.RESOURCE_REPOSITORY_TYPE, repo_id),
                      tags.action_tag('unassociate')]
+        model.Repository.objects.get_repo_or_missing_resource(repo_id)
         async_result = unassociate_by_criteria.apply_async_with_reservation(
             tags.RESOURCE_REPOSITORY_TYPE, repo_id,
             [repo_id, criteria], tags=task_tags)

--- a/server/test/unit/server/webservices/views/test_repositories.py
+++ b/server/test/unit/server/webservices/views/test_repositories.py
@@ -2080,7 +2080,8 @@ class TestRepoUnunassociate(unittest.TestCase):
     @mock.patch(
         'pulp.server.webservices.views.repositories.UnitAssociationCriteria.from_client_input')
     @mock.patch('pulp.server.webservices.views.repositories.manager_factory')
-    def test_post_minimal(self, mock_factory, mock_crit, mock_unassociate, mock_tags):
+    @mock.patch('pulp.server.webservices.views.repositories.model.Repository.objects')
+    def test_post_minimal(self, mock_repo_qs, mock_factory, mock_crit, mock_unassociate, mock_tags):
         """
         Test that a task is created with the minimal body params.
         """


### PR DESCRIPTION
Adds repo validation for RepoUnassociate

closes [#1073](https://pulp.plan.io/issues/1073)