### PR TITLE
doc: improve epel-release instructions

### DIFF
--- a/docs/user-guide/installation.rst
+++ b/docs/user-guide/installation.rst
@@ -93,16 +93,11 @@ Repositories
 
    RHEL6::
 
-    $ sudo rpm -Uvh https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+    $ sudo yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
 
    RHEL7::
 
-    $ sudo rpm -Uvh https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
-
-.. note::
-   The above EPEL URLs change with each release of the epel-release package. If you receive a 404
-   error when attempting to install the above RPM, point your browser at the directory it is in and
-   look for the updated name of epel-release package.
+    $ sudo yum install http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 .. note::
    EPEL requires users of RHEL 6.x to enable the ``optional`` repository,


### PR DESCRIPTION
As of https://fedorahosted.org/epel/ticket/8 it is easier to install the epel-release RPM. Update our documentation to reflect this.