### PR TITLE
Update the download_one task to use the streamer.

### DIFF
--- a/server/pulp/server/constants.py
+++ b/server/pulp/server/constants.py
@@ -2,3 +2,5 @@ LOCAL_STORAGE = "/var/lib/pulp/"
 
 PULP_USER_METADATA_FIELDNAME = 'pulp_user_metadata'
 PULP_DJANGO_SETTINGS_MODULE = 'pulp.server.webservices.settings'
+
+PULP_STREAM_REQUEST_HEADER = 'Pulp-Stream-Request'


### PR DESCRIPTION
This also updates the streamer to check for a special HTTP header to
determine whether or not it should dispatch a task and changes the
streamer to use the new LazyCatalogEntry model.

I'm hesitant to write tests for the task just yet, since we may end up changing it quite a bit depending on whether we download entire content units or not.