### PR TITLE
Update the ContentUnit model with a `downloaded` field.

### DIFF
--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -6,7 +6,8 @@ Tests for the pulp.server.db.model module.
 
 from mock import patch, Mock
 
-from mongoengine import ValidationError, DateTimeField, DictField, Document, IntField, StringField
+from mongoengine import (ValidationError, DateTimeField, DictField, Document, IntField,
+                         StringField, BooleanField)
 
 from pulp.common import error_codes, dateutils
 from pulp.common.compat import unittest
@@ -58,6 +59,9 @@ class TestContentUnit(unittest.TestCase):
 
         self.assertTrue(isinstance(model.ContentUnit.storage_path, StringField))
         self.assertEquals(model.ContentUnit.storage_path.db_field, '_storage_path')
+
+        self.assertTrue(isinstance(model.ContentUnit.downloaded, BooleanField))
+        self.assertFalse(model.ContentUnit.downloaded.default)
 
         self.assertTrue(isinstance(model.ContentUnit._ns, StringField))
         self.assertTrue(model.ContentUnit._ns)


### PR DESCRIPTION
Furthermore, the `download_catalog_entry` method now checks
to see if all files in the content unit are present, and if they are, it 
will set the `downloaded` field on the ContentUnit to `True`.