### PR TITLE
Adds group_id to TaskStatus model

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -300,6 +300,8 @@ class ReservedTaskMixin(object):
         :param tags:          A list of tags (strings) to place onto the task, used for searching
                               for tasks by tag
         :type  tags:          list
+        :param group_id:      The id to identify which group of tasks a task belongs to
+        :type  group_id:      uuid.UUID
         :return:              An AsyncResult instance as returned by Celery's apply_async
         :rtype:               celery.result.AsyncResult
         """
@@ -309,10 +311,12 @@ class ReservedTaskMixin(object):
         inner_task_id = str(uuid.uuid4())
         task_name = self.name
         tag_list = kwargs.get('tags', [])
+        group_id = kwargs.get('group_id', None)
 
         # Create a new task status with the task id and tags.
         task_status = TaskStatus(task_id=inner_task_id, task_type=task_name,
-                                 state=constants.CALL_WAITING_STATE, tags=tag_list)
+                                 state=constants.CALL_WAITING_STATE, tags=tag_list,
+                                 group_id=group_id)
         # To avoid the race condition where __call__ method below is called before
         # this change is propagated to all db nodes, using an 'upsert' here and setting
         # the task state to 'waiting' only on an insert.
@@ -344,12 +348,15 @@ class Task(CeleryTask, ReservedTaskMixin):
         :param tags:        A list of tags (strings) to place onto the task, used for searching for
                             tasks by tag
         :type  tags:        list
+        :param group_id:    The id that identifies which group of tasks a task belongs to
+        :type group_id:     uuid.UUID
         :return:            An AsyncResult instance as returned by Celery's apply_async
         :rtype:             celery.result.AsyncResult
         """
         routing_key = kwargs.get('routing_key',
                                  defaults.NAMESPACES['CELERY']['DEFAULT_ROUTING_KEY'].default)
         tag_list = kwargs.pop('tags', [])
+        group_id = kwargs.pop('group_id', None)
 
         async_result = super(Task, self).apply_async(*args, **kwargs)
         async_result.tags = tag_list
@@ -357,7 +364,8 @@ class Task(CeleryTask, ReservedTaskMixin):
         # Create a new task status with the task id and tags.
         task_status = TaskStatus(
             task_id=async_result.id, task_type=self.name,
-            state=constants.CALL_WAITING_STATE, worker_name=routing_key, tags=tag_list)
+            state=constants.CALL_WAITING_STATE, worker_name=routing_key, tags=tag_list,
+            group_id=group_id)
         # To avoid the race condition where __call__ method below is called before
         # this change is propagated to all db nodes, using an 'upsert' here and setting
         # the task state to 'waiting' only on an insert.

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -5,7 +5,7 @@ import uuid
 from collections import namedtuple
 
 from mongoengine import (DateTimeField, DictField, Document, DynamicField, IntField,
-                         ListField, StringField)
+                         ListField, StringField, UUIDField)
 from mongoengine import signals
 
 from pulp.common import constants, dateutils, error_codes
@@ -296,6 +296,8 @@ class TaskStatus(AutoRetryDocument, ReaperMixin):
     :type start_time:  basestring
     :ivar finish_time: ISO8601 representation of the time the task completed
     :type finish_time: basestring
+    :ivar group_id:    The id used to identify which  group of tasks a task belongs to
+    :type group_id:    uuid.UUID
     :ivar result:      return value of the callable, if any
     :type result:      any
     :ivar exception:   Deprecated. This is always None.
@@ -315,6 +317,7 @@ class TaskStatus(AutoRetryDocument, ReaperMixin):
     start_time = ISO8601StringField()
     finish_time = ISO8601StringField()
     result = DynamicField()
+    group_id = UUIDField(default=None)
 
     # These are deprecated, and will always be None
     exception = StringField()
@@ -324,7 +327,7 @@ class TaskStatus(AutoRetryDocument, ReaperMixin):
     _ns = StringField(default='task_status')
 
     meta = {'collection': 'task_status',
-            'indexes': ['-tags', '-state', {'fields': ['-task_id'], 'unique': True}],
+            'indexes': ['-tags', '-state', {'fields': ['-task_id'], 'unique': True}, '-group_id'],
             'allow_inheritance': False,
             'queryset_class': CriteriaQuerySet}
 

--- a/server/pulp/server/webservices/views/tasks.py
+++ b/server/pulp/server/webservices/views/tasks.py
@@ -68,9 +68,9 @@ class TaskCollectionView(View):
         """
         tags = request.GET.getlist('tag')
         if tags:
-            raw_tasks = TaskStatus.objects(tags__all=tags)
+            raw_tasks = TaskStatus.objects(tags__all=tags, group_id=None)
         else:
-            raw_tasks = TaskStatus.objects()
+            raw_tasks = TaskStatus.objects(group_id=None)
         serialized_task_statuses = [task_serializer(task) for task in raw_tasks]
         return generate_json_response_with_pulp_encoder(serialized_task_statuses)
 

--- a/server/test/unit/server/webservices/views/test_tasks.py
+++ b/server/test/unit/server/webservices/views/test_tasks.py
@@ -73,7 +73,8 @@ class TestTaskCollection(unittest.TestCase):
         task_collection = TaskCollectionView()
         response = task_collection.get(mock_request)
 
-        mock_task_status.objects.assert_called_once_with(tags__all=['mock_tag_1', 'mock_tag_2'])
+        mock_task_status.objects.assert_called_once_with(group_id=None, tags__all=['mock_tag_1',
+                                                                                   'mock_tag_2'])
         mock_resp.assert_called_once_with(['mock_1', 'mock_2'])
         mock_task_serializer.assert_has_calls([mock.call('mock_1'), mock.call('mock_2')])
         self.assertTrue(response is mock_resp.return_value)
@@ -96,7 +97,7 @@ class TestTaskCollection(unittest.TestCase):
         task_collection = TaskCollectionView()
         response = task_collection.get(mock_request)
 
-        mock_task_status.objects.assert_called_once_with()
+        mock_task_status.objects.assert_called_once_with(group_id=None)
         mock_resp.assert_called_once_with(['mock_1', 'mock_2'])
         mock_task_serializer.assert_has_calls([mock.call('mock_1'), mock.call('mock_2')])
         self.assertTrue(response is mock_resp.return_value)


### PR DESCRIPTION
TaskStatus has a group_id field. The group_id is used to group a set
of tasks together. The TaskStatus view selects only TaskStatus documents
that don't have a group_id set. The task_id field should only be set
when performing parallelized work.

https://pulp.plan.io/issues/1204
closes #1204