### PR TITLE
ContentUnit now models pulp_user_metadata as pulp_user_metadata

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -398,8 +398,8 @@ class ContentUnit(AutoRetryDocument):
     :type id: mongoengine.StringField
     :ivar last_updated: last time this unit was updated (since epoch, zulu time)
     :type last_updated: mongoengine.IntField
-    :ivar user_metadata: Bag of User supplied data to go along with this unit
-    :type user_metadata: mongoengine.DictField
+    :ivar pulp_user_metadata: Bag of User supplied data to go along with this unit
+    :type pulp_user_metadata: mongoengine.DictField
     :ivar storage_path: Location on disk where the content associated with this unit lives
     :type storage_path: mongoengine.StringField
 
@@ -415,7 +415,7 @@ class ContentUnit(AutoRetryDocument):
 
     id = StringField(primary_key=True)
     last_updated = IntField(db_field='_last_updated', required=True)
-    user_metadata = DictField(db_field='pulp_user_metadata')
+    pulp_user_metadata = DictField()
     storage_path = StringField(db_field='_storage_path')
 
     # For backward compatibility

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -53,8 +53,7 @@ class TestContentUnit(unittest.TestCase):
         self.assertTrue(model.ContentUnit.last_updated.required)
         self.assertEquals(model.ContentUnit.last_updated.db_field, '_last_updated')
 
-        self.assertTrue(isinstance(model.ContentUnit.user_metadata, DictField))
-        self.assertEquals(model.ContentUnit.user_metadata.db_field, 'pulp_user_metadata')
+        self.assertTrue(isinstance(model.ContentUnit.pulp_user_metadata, DictField))
 
         self.assertTrue(isinstance(model.ContentUnit.storage_path, StringField))
         self.assertEquals(model.ContentUnit.storage_path.db_field, '_storage_path')

--- a/server/test/unit/server/webservices/test_urls.py
+++ b/server/test/unit/server/webservices/test_urls.py
@@ -103,7 +103,7 @@ class TestDjangoContentUrls(unittest.TestCase):
 
     def test_match_content_unit_user_metadata_resource(self):
         """
-        Test url matching for content_unit_user_metadata_resourece.
+        Test url matching for content_unit_user_metadata_resource.
         """
         url = '/v2/content/units/mock-type/mock-unit/pulp_user_metadata/'
         url_name = 'content_unit_user_metadata_resource'


### PR DESCRIPTION
The first-pass implementation of ContentUnit for mongoengine
used an attribute name of 'user_metadata' to model the database
field named 'pulp_user_metadata'. This is a nice chance, but it
forces multiple plugins to handle name translation for both
Criteria objects and serializers.

By modeling the attribute as the actual database name everything
becomes simpler. We can rename pulp_user_metadata to
user_metadata in a future X release.