### PR TITLE
Renames last_updated to _last_updated on ContentUnit

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -396,8 +396,8 @@ class ContentUnit(AutoRetryDocument):
 
     :ivar id: content unit id
     :type id: mongoengine.StringField
-    :ivar last_updated: last time this unit was updated (since epoch, zulu time)
-    :type last_updated: mongoengine.IntField
+    :ivar _last_updated: last time this unit was updated (since epoch, zulu time)
+    :type _last_updated: mongoengine.IntField
     :ivar pulp_user_metadata: Bag of User supplied data to go along with this unit
     :type pulp_user_metadata: mongoengine.DictField
     :ivar storage_path: Location on disk where the content associated with this unit lives
@@ -414,7 +414,7 @@ class ContentUnit(AutoRetryDocument):
     unit_key_fields = tuple()
 
     id = StringField(primary_key=True)
-    last_updated = IntField(db_field='_last_updated', required=True)
+    _last_updated = IntField(required=True)
     pulp_user_metadata = DictField()
     storage_path = StringField(db_field='_storage_path')
 
@@ -451,7 +451,7 @@ class ContentUnit(AutoRetryDocument):
         """
         The signal that is triggered before a unit is saved, this is used to
         support the legacy behavior of generating the unit id and setting
-        the last_updated timestamp
+        the _last_updated timestamp
 
         :param sender: sender class
         :type sender: object
@@ -460,7 +460,7 @@ class ContentUnit(AutoRetryDocument):
         """
         if not document.id:
             document.id = str(uuid.uuid4())
-        document.last_updated = dateutils.now_utc_timestamp()
+        document._last_updated = dateutils.now_utc_timestamp()
 
     def get_repositories(self):
         """
@@ -551,8 +551,7 @@ class FileContentUnit(ContentUnit):
     def pre_save_signal(cls, sender, document, **kwargs):
         """
         The signal that is triggered before a unit is saved, this is used to
-        support the legacy behavior of generating the unit id and setting
-        the last_updated timestamp
+        move the unit file or directory into place.
 
         :param sender: sender class
         :type sender: object

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -49,9 +49,8 @@ class TestContentUnit(unittest.TestCase):
         self.assertTrue(isinstance(model.ContentUnit.id, StringField))
         self.assertTrue(model.ContentUnit.id.primary_key)
 
-        self.assertTrue(isinstance(model.ContentUnit.last_updated, IntField))
-        self.assertTrue(model.ContentUnit.last_updated.required)
-        self.assertEquals(model.ContentUnit.last_updated.db_field, '_last_updated')
+        self.assertTrue(isinstance(model.ContentUnit._last_updated, IntField))
+        self.assertTrue(model.ContentUnit._last_updated.required)
 
         self.assertTrue(isinstance(model.ContentUnit.pulp_user_metadata, DictField))
 
@@ -102,14 +101,14 @@ class TestContentUnit(unittest.TestCase):
 
         mock_now_utc.return_value = 'foo'
         helper = ContentUnitHelper()
-        helper.last_updated = 50
+        helper._last_updated = 50
 
         model.ContentUnit.pre_save_signal({}, helper)
 
         self.assertIsNotNone(helper.id)
 
         # make sure the last updated time has been updated
-        self.assertEquals(helper.last_updated, 'foo')
+        self.assertEquals(helper._last_updated, 'foo')
 
     def test_pre_save_signal_leaves_existing_id(self):
         """


### PR DESCRIPTION
The first-pass implementation of ContentUnit for mongoengine
used an attribute name of 'last_updated' to model the database
field named '_last_updated'. This is a nice chance, but it
forces multiple plugins to handle name translation for both
Criteria objects and serializers.

By modeling the attribute as the actual database name everything
becomes simpler. We can rename _last_updated to last_updated in
a future X release.