### PR TITLE
Add policy extensions.

### DIFF
--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -91,6 +91,7 @@ class ContentView(View):
         host = request.environ['SERVER_NAME']
         port = request.environ['SERVER_PORT']
         query = request.environ['QUERY_STRING']
+        remote_ip = request.environ['REMOTE_ADDR']
 
         redirect_host = pulp_conf.get('lazy', 'redirect_host')
         redirect_port = pulp_conf.get('lazy', 'redirect_port')
@@ -105,7 +106,7 @@ class ContentView(View):
             query)
 
         url = URL(redirect)
-        signed = url.sign(key)
+        signed = url.sign(key, remote_ip=remote_ip)
         return HttpResponseRedirect(str(signed))
 
     def __init__(self, **kwargs):

--- a/server/srv/pulp/streamer_auth.wsgi
+++ b/server/srv/pulp/streamer_auth.wsgi
@@ -28,8 +28,9 @@ def allow_access(environ, host):
     :rtype:  bool
     """
     url = SignedURL(environ['REQUEST_URI'])
+    remote_ip = environ['REMOTE_ADDR']
     try:
-        url.validate(key)
+        url.validate(key, remote_ip=remote_ip)
         return True
     except NotValid, le:
         log.info(str(le))

--- a/server/test/functional/test_lazy_url.py
+++ b/server/test/functional/test_lazy_url.py
@@ -131,3 +131,11 @@ class TestSigning(TestCase):
         content = str(url)
         url = SignedURL(content.replace('signature=', 'age='))
         self.assertRaises(NotSigned, url.validate, PUB)
+
+    def test_signing_and_validation_with_extensions(self):
+        uri = '/content/jit.rpm'
+        extensions = dict(remote_ip='10.2.3.4')
+        url = URL('http://redhat.com{r}'.format(r=uri))
+        url = url.sign(KEY, **extensions)
+        resource = url.validate(PUB, **extensions)
+        self.assertEqual(resource, uri)

--- a/server/test/unit/server/content/web/test_views.py
+++ b/server/test/unit/server/content/web/test_views.py
@@ -67,6 +67,7 @@ class TestContentView(TestCase):
     @patch(MODULE + '.pulp_conf')
     @patch(MODULE + '.HttpResponseRedirect')
     def test_redirect(self, redirect, pulp_conf, url):
+        remote_ip = '172.10.08.20'
         scheme = 'http'
         host = 'localhost'
         port = 80
@@ -90,7 +91,8 @@ class TestContentView(TestCase):
             'SERVER_NAME': host,
             'SERVER_PORT': port,
             'REDIRECT_URL': redirect_path,
-            'QUERY_STRING': query
+            'QUERY_STRING': query,
+            'REMOTE_ADDR': remote_ip
         }
         request = Mock(environ=environ, path=path)
         key = Mock()
@@ -101,7 +103,7 @@ class TestContentView(TestCase):
         # validation
         url.assert_called_once_with(ContentView.urljoin(
             scheme, host, port, redirect_path, path, query))
-        url.return_value.sign.assert_called_once_with(key)
+        url.return_value.sign.assert_called_once_with(key, remote_ip=remote_ip)
         redirect.assert_called_once_with(str(url.return_value.sign.return_value))
         self.assertEqual(reply, redirect.return_value)
 


### PR DESCRIPTION
Add support for policy extensions.  Then, update the usage of signed urls in pulp to include the remote_ip in the policy extensions.  This ensures that when the signed url is used as part of the redirect, only the client getting redirected can use that url.

Does this seem valuable?

Also, 10 seconds seemed too short by default so changed it to 90 seconds.