### PR TITLE
Add files to content unit.

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -104,6 +104,45 @@ def find_repo_content_units(
             yield_count += 1
 
 
+def find_units_not_downloaded(repository):
+    """
+    Find content units that have not been fully downloaded.
+
+    :param repository: A repository.
+    :type repository: model.Repository
+    :return: The requested units.
+    :rtype: generator
+    """
+    for unit in find_repo_content_units(repository, yield_content_unit=True):
+        query = dict(
+            unit_id=unit.id,
+            unit_type_id=unit.type_id,
+            downloaded=False)
+        q_set = model.UnitFile.objects(**query)
+        if q_set.count():
+            yield unit
+
+
+def has_all_units_downloaded(repository):
+    """
+    Get whether a repository contains units that have all been downloaded.
+
+    :param repository: A repository.
+    :type repository: model.Repository
+    :return: True if completely downloaded
+    :rtype: generator
+    """
+    for unit in model.RepositoryContentUnit.objects(repo_id=repository.repo_id):
+        query = dict(
+            unit_id=unit.id,
+            unit_type_id=unit.unit_type_id,
+            downloaded=False)
+        q_set = model.UnitFile.objects(**query)
+        if q_set.count():
+            return False
+    return True
+
+
 def rebuild_content_unit_counts(repository):
     """
     Update the content_unit_counts field on a Repository.

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -5,7 +5,7 @@ import uuid
 from collections import namedtuple
 
 from mongoengine import (DateTimeField, DictField, Document, DynamicField, IntField, ListField,
-                         StringField)
+                         StringField, BooleanField)
 from mongoengine import signals
 
 from pulp.common import constants, dateutils, error_codes
@@ -382,6 +382,34 @@ class TaskStatus(AutoRetryDocument, ReaperMixin):
 
 
 signals.post_save.connect(TaskStatus.post_save, sender=TaskStatus)
+
+
+class UnitFile(AutoRetryDocument):
+    """
+    A file associated with a content unit.
+
+    :ivar path: The absolute path to the file.
+    :type path: str
+    :ivar unit_id: A unit ID.
+    :type unit_id: str
+    :ivar unit_type_id: The unit type.
+    :type unit_type_id: str
+    :ivar downloaded: Indicates the file has been downloaded.
+    :type downloaded: bool
+    """
+
+    meta = {
+        'collection': 'unit_files',
+        'indexes': [
+            {'fields': ['path'], 'unique': True},
+            ('unit_id', 'unit_type_id')
+        ]
+    }
+
+    path = StringField(required=True)
+    unit_id = StringField(required=True)
+    unit_type_id = StringField(required=True)
+    downloaded = BooleanField(required=True, default=False)
 
 
 class ContentUnit(AutoRetryDocument):

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -6,7 +6,8 @@ Tests for the pulp.server.db.model module.
 
 from mock import patch, Mock
 
-from mongoengine import ValidationError, DateTimeField, DictField, Document, IntField, StringField
+from mongoengine import (
+    ValidationError, DateTimeField, DictField, Document, IntField, StringField, BooleanField)
 
 from pulp.common import error_codes, dateutils
 from pulp.common.compat import unittest
@@ -180,6 +181,16 @@ class TestContentUnit(unittest.TestCase):
             unit_type_id = StringField()
         my_unit = ContentUnitHelper(unit_type_id='apple')
         self.assertEqual(my_unit.type_id, 'apple')
+
+
+class TestUnitFile(unittest.TestCase):
+
+    def test_init(self):
+        model.UnitFile()
+        self.assertTrue(isinstance(model.UnitFile.path, StringField))
+        self.assertTrue(isinstance(model.UnitFile.unit_id, StringField))
+        self.assertTrue(isinstance(model.UnitFile.unit_type_id, StringField))
+        self.assertTrue(isinstance(model.UnitFile.downloaded, BooleanField))
 
 
 class TestFileContentUnit(unittest.TestCase):


### PR DESCRIPTION
https://pulp.plan.io/issues/1302

The *files* list on a unit is optional and only used by *lazy* content feature.  The importer should add files when creating the unit.  The lazy download tasks should update files when downloaded.
something like this:
```
try:
    file = UnitFile.objects.get(path=path)
    file.downloaded = True
    file.save()
except: DoesNotExist:
    # ignored
    pass
```