### PR TITLE
refactor the search class to simplify use of GET and POST searches

### DIFF
--- a/server/pulp/server/webservices/views/search.py
+++ b/server/pulp/server/webservices/views/search.py
@@ -52,64 +52,56 @@ class SearchView(generic.View):
     @classmethod
     def _parse_args(cls, args):
         """
-        Some search views are required to be able to include extra information. This function
-        separates those flags from the search arguments.
-        :param args: Search parameters mixed with extra options. Any extra options should be
-                     removed and returned separately.
-        :type  args: django.http.QueryDict
+        Some search views can contain options in addition to parameters. This function separates
+        those options (which should be defined in the subclass) from the search arguments.
+        :param args: Search parameters mixed with extra options.
+        :type  args: dict
 
         :return: filtered search parameters and options
         :rtype:  tuple containing a 2 dicts
         """
-        search_params = {}
         options = {}
-
         for field in filter(args.__contains__, cls.optional_bool_fields):
-            value = args.get(field)
+            value = args.pop(field)
             if isinstance(value, basestring):
                 options[field] = value.lower() == 'true'
             else:
                 options[field] = value
 
         for field in filter(args.__contains__, cls.optional_string_fields):
-            options[field] = args.get(field)
+            options[field] = args.pop(field)
 
-        for field in args.iterkeys():
-            if field not in options:
-                search_params[field] = args.get(field)
-
-        return search_params, options
+        return args, options
 
     @auth_required(authorization.READ)
     def get(self, request, *args, **kwargs):
         """
-        Search for objects using an HTTP GET request.
+        Search for objects using an HTTP GET request. Parses the get parameters and builds a dict
+        that should be identical to the request body had this been a POST request.
 
         :param request: WSGI request object
         :type  request: django.core.handlers.wsgi.WSGIRequest
         :return:        HttpReponse containing a list of objects that were matched by the request
         :rtype:         django.http.HttpResponse
 
-        :raises InvalidValue: if filters is passed but is not valid JSON
+        :raises InvalidValue: if `filters` or `sort` is passed but is not valid JSON
         """
-        query, options = self._parse_args(request.GET)
-        fields = query.pop('field', '')
-        if fields:
-            query['fields'] = fields
-        filters = request.GET.get('filters')
-        if filters:
-            query['filters'] = filters
-
-        # Load query data structures from json
-        json_criteria_fields = ['filters', 'fields', 'sort']
-        for field in json_criteria_fields:
-            value = query.get(field)
-            if value:
+        search_params = {}
+        for field, value in request.GET.iteritems():
+            # These fields need to be loaded from json
+            if field in ['filters', 'sort']:
                 try:
-                    query[field] = json.loads(value)
+                    search_params[field] = json.loads(value)
                 except ValueError:
                     raise exceptions.InvalidValue(field)
+            # The user passes a set of singular values, and a list of values is extracted.
+            elif field == 'field':
+                search_params['fields'] = request.GET.getlist('field')
+            # All other fields are singluar, including options.
+            else:
+                search_params[field] = value
 
+        query, options = self._parse_args(search_params)
         return self._generate_response(query, options, *args, **kwargs)
 
     @auth_required(authorization.READ)
@@ -126,10 +118,8 @@ class SearchView(generic.View):
         :raises MissingValue: if required param `criteria` is not passed in the body.
         """
         search_params, options = self._parse_args(request.body_as_json)
-        try:
-            # Retrieve the criteria from the POST data
-            query = search_params['criteria']
-        except KeyError:
+        query = search_params.get('criteria')
+        if query is None:
             raise exceptions.MissingValue(['criteria'])
         return self._generate_response(query, options, *args, **kwargs)
 

--- a/server/test/unit/server/webservices/views/test_search.py
+++ b/server/test/unit/server/webservices/views/test_search.py
@@ -18,6 +18,89 @@ class TestSearchView(unittest.TestCase):
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
                 new=assert_auth_READ())
     @mock.patch('pulp.server.webservices.views.search.criteria.Criteria.from_client_input')
+    def test_get_no_query_params(self, from_client_input):
+        """
+        Test the GET search handler without any parameters passed.
+        """
+        class FakeSearchView(search.SearchView):
+            model = mock.MagicMock()
+        request = mock.MagicMock()
+        request.GET = http.QueryDict('')
+        view = FakeSearchView()
+        FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
+
+        with mock.patch.object(FakeSearchView, '_generate_response',
+                               side_effect=FakeSearchView._generate_response) as _generate_response:
+            results = view.get(request)
+
+        self.assertEqual(type(results), http.HttpResponse)
+        self.assertEqual(results.content, '["big money", "bigger money"]')
+        self.assertEqual(results.status_code, 200)
+
+        _generate_response.assert_called_once_with({}, {})
+        from_client_input.assert_called_once_with({})
+
+    @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
+                new=assert_auth_READ())
+    @mock.patch('pulp.server.webservices.views.search.SearchView._generate_response')
+    def test_get_with_options(self, mock_gen_response):
+        """
+        Test the GET search handler without any search parameters passed, but with options.
+        """
+        class FakeSearchView(search.SearchView):
+            model = mock.MagicMock()
+            _parse_args = mock.MagicMock(return_value=('query', 'options'))
+
+        request = mock.MagicMock()
+        request.GET = http.QueryDict('details=true')
+        view = FakeSearchView()
+        results = view.get(request)
+
+        FakeSearchView._parse_args.assert_called_once_with({'details': 'true'})
+        mock_gen_response.assert_called_once_with('query', 'options')
+        self.assertTrue(results is mock_gen_response.return_value)
+
+    @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
+                new=assert_auth_READ())
+    @mock.patch('pulp.server.webservices.views.search.criteria.Criteria.from_client_input')
+    def test_get_with_json_field(self, from_client_input):
+        """
+        Test the GET search handler with a json field. This covers `filters` as well as `sort`.
+        """
+        class FakeSearchView(search.SearchView):
+            model = mock.MagicMock()
+
+        request = mock.MagicMock()
+        request.GET = http.QueryDict('filters={"name":"admin"}')
+        view = FakeSearchView()
+        FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
+
+        with mock.patch.object(FakeSearchView, '_generate_response',
+                               side_effect=FakeSearchView._generate_response) as _generate_response:
+            results = view.get(request)
+
+        self.assertEqual(type(results), http.HttpResponse)
+        self.assertEqual(results.content, '["big money", "bigger money"]')
+        self.assertEqual(results.status_code, 200)
+        _generate_response.assert_called_once_with({'filters': {"name": "admin"}}, {})
+        from_client_input.assert_called_once_with({'filters': {"name": "admin"}})
+
+    @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
+                new=assert_auth_READ())
+    @mock.patch('pulp.server.webservices.views.search.SearchView._parse_args')
+    def test_get_with_invalid_filters(self, mock_parse):
+        """
+        InvalidValue should be raised if param 'filters' is not json.
+        """
+        mock_parse.return_value = ({'mock': 'query'}, 'tuple')
+        search_view = search.SearchView()
+        mock_request = mock.MagicMock()
+        mock_request.GET = http.QueryDict('filters=invalid json')
+        self.assertRaises(exceptions.InvalidValue, search_view.get, mock_request)
+
+    @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
+                new=assert_auth_READ())
+    @mock.patch('pulp.server.webservices.views.search.criteria.Criteria.from_client_input')
     def test_get_with_fields(self, from_client_input):
         """
         Test the GET search handler with fields in the request.
@@ -26,8 +109,7 @@ class TestSearchView(unittest.TestCase):
             model = mock.MagicMock()
 
         request = mock.MagicMock()
-        # Simulate an empty POST body
-        request.GET = {'field': '["name", "id"]', 'filters': '{"name":"admin"}'}
+        request.GET = http.QueryDict('field=name&field=id&filters={"name":"admin"}')
         view = FakeSearchView()
         FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
 
@@ -47,50 +129,6 @@ class TestSearchView(unittest.TestCase):
 
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
                 new=assert_auth_READ())
-    @mock.patch('pulp.server.webservices.views.search.criteria.Criteria.from_client_input')
-    def test_get_without_fields(self, from_client_input):
-        """
-        Test the GET search handler without any fields specified in the request.
-        """
-        class FakeSearchView(search.SearchView):
-            model = mock.MagicMock()
-
-        request = mock.MagicMock()
-        # Simulate an empty POST body
-        request.GET = {'filters': '{"name":"admin"}'}
-        view = FakeSearchView()
-        FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
-
-        with mock.patch.object(FakeSearchView, '_generate_response',
-                               side_effect=FakeSearchView._generate_response) as _generate_response:
-            results = view.get(request)
-
-        self.assertEqual(type(results), http.HttpResponse)
-        self.assertEqual(results.content, '["big money", "bigger money"]')
-        self.assertEqual(results.status_code, 200)
-        # This is actually a bug, but the intention of this Django port was to behave exactly like
-        # The webpy handlers did, bugs included. When #312 is fixed, the tests below should fail,
-        # because the get() handler should have deserialized the filters instead of leaving them as
-        # strings. Please modify these assertions to have the correct behavior.
-        # https://pulp.plan.io/issues/312
-        _generate_response.assert_called_once_with({'filters': {"name": "admin"}}, {})
-        from_client_input.assert_called_once_with({'filters': {"name": "admin"}})
-
-    @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
-                new=assert_auth_READ())
-    @mock.patch('pulp.server.webservices.views.search.SearchView._parse_args')
-    def test_get_with_invalid_filters(self, mock_parse):
-        """
-        InvalidValue should be raised if param 'filters' is not json.
-        """
-        mock_parse.return_value = ({'mock': 'query'}, 'tuple')
-        search_view = search.SearchView()
-        mock_request = mock.MagicMock()
-        mock_request.GET = http.QueryDict('filters=invalid json')
-        self.assertRaises(exceptions.InvalidValue, search_view.get, mock_request)
-
-    @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
-                new=assert_auth_READ())
     def test_post(self):
         """
         Test the POST search under normal conditions.
@@ -99,7 +137,6 @@ class TestSearchView(unittest.TestCase):
             model = mock.MagicMock()
 
         request = mock.MagicMock()
-        # Simulate an empty POST body
         request.body = '{"criteria": {"filters": {"money": {"$gt": 1000000}}}}'
         view = FakeSearchView()
         FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
@@ -288,7 +325,7 @@ class TestParseArgs(unittest.TestCase):
         """
         Test that options are populated and optional fields are removed from args.
         """
-        args = http.QueryDict('opt_bool=true&opt_str=hi&non-optional=field')
+        args = {'opt_bool': 'true', 'opt_str': 'hi', 'non-optional': 'field'}
 
         search_params, options = self.fake_search._parse_args(args)
 
@@ -297,44 +334,42 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(options['opt_str'], 'hi')
 
     def test_parse_args_converts_true(self):
-        args = http.QueryDict('opt_bool=true')
+        args = {'opt_bool': 'true'}
 
         params, options = self.fake_search._parse_args(args)
 
         self.assertTrue(options['opt_bool'] is True)
 
     def test_parse_args_converts_TRUE(self):
-        args = http.QueryDict('opt_bool=TRUE')
+        args = {'opt_bool': 'TRUE'}
 
         params, options = self.fake_search._parse_args(args)
 
         self.assertTrue(options['opt_bool'] is True)
 
     def test_parse_args_converts_false(self):
-        args = http.QueryDict('opt_bool=false')
+        args = {'opt_bool': 'false'}
 
         params, options = self.fake_search._parse_args(args)
 
         self.assertTrue(options['opt_bool'] is False)
 
     def test_parse_args_converts_FALSE(self):
-        args = http.QueryDict('opt_bool=FALSE')
+        args = {'opt_bool': 'FALSE'}
 
         params, options = self.fake_search._parse_args(args)
 
         self.assertTrue(options['opt_bool'] is False)
 
     def test_parse_args_preserves_true(self):
-        args = http.QueryDict('', mutable=True)
-        args['opt_bool'] = True
+        args = {'opt_bool': True}
 
         params, options = self.fake_search._parse_args(args)
 
         self.assertTrue(options['opt_bool'] is True)
 
     def test_parse_args_preserves_false(self):
-        args = http.QueryDict('', mutable=True)
-        args['opt_bool'] = False
+        args = {'opt_bool': False}
 
         params, options = self.fake_search._parse_args(args)
 


### PR DESCRIPTION
The base class for search was originally implemented for POST searches only and expanded to also apply to GET searches. This resulted in some mess and some bugs which are corrected here.

https://pulp.plan.io/issues/312

closes: #312