### PR TITLE
Add Celery Flower to the Vagrant dev box.

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -9,6 +9,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # explicitly mount the code using NFSv4.
  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
 
+ # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
+ config.hostmanager.enabled = true
+ config.hostmanager.manage_host = true
+
  # Comment this line if you would like to disable the automatic update during provisioning
  config.vm.provision "shell", inline: "sudo dnf upgrade -y"
 

--- a/playpen/ansible/roles/dev/files/flower.service
+++ b/playpen/ansible/roles/dev/files/flower.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Real-time monitor and web admin for Celery distributed task queue
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/flower --port=5555 --broker=qpid://localhost/
+
+[Install]
+WantedBy=multi-user.target

--- a/playpen/ansible/roles/dev/tasks/main.yml
+++ b/playpen/ansible/roles/dev/tasks/main.yml
@@ -43,5 +43,15 @@
       - tito
       - yum-utils
 
+- name: Install flower
+  pip: name=flower
+  sudo: yes
+
+- name: Install flower systemd unit
+  copy: src=flower.service dest=/etc/systemd/system/flower.service
+  sudo: yes
+
+- service: name=flower.service state=started enabled=yes
+
 - name: Install custom ~/.bashrc
   copy: src=bashrc dest=/home/{{ ansible_env.SUDO_USER }}/.bashrc


### PR DESCRIPTION
Flower is a web-based tool for monitoring and administrating Celery
clusters. This adds Flower to the Ansible dev playbook and includes a
systemd unit for the service. It is configured to run on port 5555.

This also adds hostname management to the example Vagrantfile. If this
is enabled, it is possible to access the Flower dashboard from your host
machine at http://dev.example.com:5555/.