### PR TITLE
This commit fixes the permissions on the Docker publish folder.

### DIFF
--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -39,6 +39,8 @@ EOF
 
     mkdir -p metadata/v1 metadata/v2
     sudo mkdir -p /var/lib/pulp/published/docker/v1 /var/lib/pulp/published/docker/v2
+    sudo chown apache:apache /var/lib/pulp/published/docker/v1
+    sudo chown apache:apache /var/lib/pulp/published/docker/v2
     sudo ln -s $HOME/devel/crane/metadata/v1 /var/lib/pulp/published/docker/v1/app
     sudo ln -s $HOME/devel/crane/metadata/v2 /var/lib/pulp/published/docker/v2/app
 


### PR DESCRIPTION
Previously, the /var/lib/pulp/published/docker/v{1,2}/app folders were owned by root instead of apache, which
caused some problems during publishing. This commit fixes them to be owned by apache for Vagrant
installations.