### PR TITLE
Adds a new MongoEngine model for deferred downloads.

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -700,3 +700,30 @@ class LazyCatalogEntry(Document):
     checksum = StringField()
     checksum_algorithm = StringField(regex=ALG_REGEX)
     data = DictField()
+
+
+class DeferredDownload(Document):
+    """
+    A collection of units that have been handled by the streamer in the
+    passive lazy workflow that Pulp should download.
+
+    :ivar unit_id:      The associated content unit ID.
+    :type unit_id:      str
+    :ivar unit_type_id: The associated content unit type.
+    :type unit_type_id: str
+    """
+    meta = {
+        'collection': 'deferred_download',
+        'indexes': [
+            {
+                'fields': ['unit_id', 'unit_type_id'],
+                'unique': True
+            }
+        ]
+    }
+
+    unit_id = StringField(required=True)
+    unit_type_id = StringField(required=True)
+
+    # For backward compatibility
+    _ns = StringField(default='deferred_download')

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -590,3 +590,29 @@ class TestCeleryBeatLock(unittest.TestCase):
         Assert that the collection name is correct.
         """
         self.assertEquals(model.CeleryBeatLock._meta['collection'], 'celery_beat_lock')
+
+
+class TestDeferredDownload(unittest.TestCase):
+    """
+    Test the DeferredDownload class.
+    """
+
+    def test_model_superclass(self):
+        sample_model = model.DeferredDownload()
+        self.assertTrue(isinstance(sample_model, Document))
+
+    def test_attributes(self):
+        self.assertTrue(isinstance(model.DeferredDownload.unit_id, StringField))
+        self.assertTrue(model.DeferredDownload.unit_id.required)
+
+        self.assertTrue(isinstance(model.DeferredDownload.unit_type_id, StringField))
+        self.assertTrue(model.DeferredDownload.unit_type_id.required)
+
+        self.assertTrue(isinstance(model.DeferredDownload._ns, StringField))
+        self.assertEqual('deferred_download', model.DeferredDownload._ns.default)
+
+    def test_meta_collection(self):
+        """
+        Assert that the collection name is correct.
+        """
+        self.assertEquals(model.DeferredDownload._meta['collection'], 'deferred_download')


### PR DESCRIPTION
Deferred downloads is used by the passive lazy workflow to queue up
downloads processed by the streamer. A celerybeat task will use this
queue to download the units later.