### PR TITLE
Add downloaded field to file content unit.

### DIFF
--- a/common/pulp/common/error_codes.py
+++ b/common/pulp/common/error_codes.py
@@ -102,8 +102,12 @@ PLP0035 = Error("PLP0035", _("The ContentUnit model class %(class_name)s failed 
                              "attribute %(field_name)s correctly"), ['class_name', 'field_name'])
 PLP0036 = Error(
     "PLP0036",
-    _("The source_location: %(source_location)s specified for the content unit is invalid."),
-    ['source_location'])
+    _("Content unit must be saved before associated content files can be imported."),
+    [])
+PLP0037 = Error(
+    "PLP0037",
+    _("Content import of %(path)s failed - must be an existing file."),
+    ['path'])
 PLP0038 = Error("PLP0038", _("The unit model with id %(model_id)s and class "
                              "%(model_class)s failed to register. Another model has already "
                              "been registered with the same id."), ['model_id', 'model_class'])


### PR DESCRIPTION
https://pulp.plan.io/issues/1302

Mainly added the *downloaded* field to content unit.  Added *downloaded* to ContentUnit.  Replaced *set_content()* with *import_content()* and change behavior to *import* the content when it's called instead of setting _source_path and copying when the unit is saved.  Support for importing directories has been removed.  The *path* passed to import_content() must be an existing file.  Importers (rpm, puppet, docker) will be updated to call import_content() for each file downloaded instead of with the entire directory after it has all been downloaded.  This should not be an issue as both the puppet and rpm plugins are in the process of conversion to mongoengine on master.

I decided to leave *_storage_path* on ContentUnit.  After looking at orphan clean up, I became concerned that there were other parts of the system that expected *_storage_path* to exist on all content units and did not want to break things.  Or, take this on as part of the Lazy effort.

I also added controller functions to query for downloaded status of repositories.
