### PR TITLE
Configure the crane metadata after the migrations during dev setup.

### DIFF
--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -37,13 +37,6 @@ debug: true
 endpoint: pulp-devel:5001
 EOF
 
-    mkdir -p metadata/v1 metadata/v2
-    sudo mkdir -p /var/lib/pulp/published/docker/v1 /var/lib/pulp/published/docker/v2
-    sudo chown apache:apache /var/lib/pulp/published/docker/v1
-    sudo chown apache:apache /var/lib/pulp/published/docker/v2
-    sudo ln -s $HOME/devel/crane/metadata/v1 /var/lib/pulp/published/docker/v1/app
-    sudo ln -s $HOME/devel/crane/metadata/v2 /var/lib/pulp/published/docker/v2/app
-
     deactivate
     popd
 fi
@@ -83,6 +76,18 @@ setfacl -m user:apache:rwx $HOME
 
 echo "populating mongodb"
 sudo -u apache pulp-manage-db
+
+# If Crane is present, let's set up the publishing symlinks so that the app files can be used
+if [ -d $HOME/devel/crane ]; then
+    pushd $HOME/devel/crane
+    mkdir -p metadata/v1 metadata/v2
+    sudo mkdir -p /var/lib/pulp/published/docker/v1 /var/lib/pulp/published/docker/v2
+    sudo chown apache:apache /var/lib/pulp/published/docker/v1
+    sudo chown apache:apache /var/lib/pulp/published/docker/v2
+    sudo ln -s $HOME/devel/crane/metadata/v1 /var/lib/pulp/published/docker/v1/app
+    sudo ln -s $HOME/devel/crane/metadata/v2 /var/lib/pulp/published/docker/v2/app
+    popd
+fi
 
 # Enable and start the Pulp services
 echo "Starting more services"


### PR DESCRIPTION
There is a Docker migration that moves any files that are present in /var/lib/pulp/published/docker, which
caused the Crane setup to not be correct after a Vagrant up. This commit adds the needed Crane symlinks after
that migration so that the symlinks don't get moved.