### PR TITLE
Add lazy option to pulp admin.

### DIFF
--- a/client_lib/pulp/client/validators.py
+++ b/client_lib/pulp/client/validators.py
@@ -8,6 +8,7 @@ import re
 from gettext import gettext as _
 
 from pulp.common import dateutils
+from pulp.common.plugins import importer_constants
 
 
 ID_REGEX_ALLOW_DOTS = re.compile(r'^[.\-_A-Za-z0-9]+$')
@@ -116,3 +117,20 @@ def id_validator_allow_dots(x):
         if ID_REGEX_ALLOW_DOTS.match(input_id) is None:
             raise ValueError(_('value must contain only letters, numbers, underscores, periods and '
                                'hyphens'))
+
+
+def download_policy_validator(x):
+    """
+    Download policy validator.
+
+    :param x: input value to be validated
+    :type  x: str or list
+
+    :raise ValueError: if the input is not a valid policy.
+    """
+    valid = (
+        importer_constants.DOWNLOAD_IMMEDIATE,
+        importer_constants.DOWNLOAD_BACKGROUND,
+        importer_constants.DOWNLOAD_ON_DEMAND)
+    if x not in valid:
+        raise ValueError(_('policy must be: ({p})'.format(p=' | '.join(valid))))

--- a/client_lib/test/unit/test_validators.py
+++ b/client_lib/test/unit/test_validators.py
@@ -1,6 +1,7 @@
 import unittest
 
 from pulp.client import validators
+from pulp.common.plugins import importer_constants
 
 
 class TestPositiveInt(unittest.TestCase):
@@ -136,3 +137,17 @@ class TestIdAllowDots(unittest.TestCase):
         # Multiple input
         self.assertRaises(ValueError, validators.id_validator_allow_dots, ['**invalid**', '!#$%'])
         self.assertRaises(ValueError, validators.id_validator_allow_dots, ['valid', '**invalid**'])
+
+
+class TestDownloadPolicyValidator(unittest.TestCase):
+
+    def test_valid(self):
+        valid = (
+            importer_constants.DOWNLOAD_IMMEDIATE,
+            importer_constants.DOWNLOAD_BACKGROUND,
+            importer_constants.DOWNLOAD_ON_DEMAND)
+        for policy in valid:
+            validators.download_policy_validator(policy)
+
+    def test_invalid(self):
+        self.assertRaises(ValueError, validators.download_policy_validator, '1234')

--- a/common/pulp/common/plugins/importer_constants.py
+++ b/common/pulp/common/plugins/importer_constants.py
@@ -80,11 +80,11 @@ KEY_UNITS_REMOVE_MISSING = 'remove_missing'
 KEY_UNITS_RETAIN_OLD_COUNT = 'retain_old_count'
 
 
-# Lazy
-# DISABLED - Content is downloaded immediately.
-# ACTIVE   - Content is downloaded in the background.
-# PASSIVE  - Content is downloaded on demand.
-LAZY_DISABLED = None
-LAZY_ACTIVE = 'active'
-LAZY_PASSIVE = 'passive'
-LAZY_MODE = 'lazy_mode'
+# Download policy (Lazy)
+# IMMEDIATE  - Content is downloaded immediately.
+# BACKGROUND - Content is downloaded in the background.
+# ON_DEMAND  - Content is downloaded on demand.
+DOWNLOAD_IMMEDIATE = 'immediate'
+DOWNLOAD_ON_DEMAND = 'on_demand'
+DOWNLOAD_BACKGROUND = 'background'
+DOWNLOAD_POLICY = 'download_policy'

--- a/server/pulp/plugins/util/importer_config.py
+++ b/server/pulp/plugins/util/importer_config.py
@@ -363,20 +363,20 @@ def validate_retain_old_count(config):
         raise ValueError(msg)
 
 
-def validate_lazy_mode(config):
+def validate_download_policy(config):
     """
-    Validate lazy content modes.
+    Validate download policy.
 
     :param config: A configuration.
     :type config: pulp.plugins.config.PluginCallConfiguration
     :raise ValueError: on failed.
     """
-    key = importer_constants.LAZY_MODE
-    lazy = config.get(key)
+    key = importer_constants.DOWNLOAD_POLICY
+    lazy = config.get(key, importer_constants.DOWNLOAD_IMMEDIATE)
     modes = [
-        importer_constants.LAZY_DISABLED,
-        importer_constants.LAZY_ACTIVE,
-        importer_constants.LAZY_PASSIVE
+        importer_constants.DOWNLOAD_IMMEDIATE,
+        importer_constants.DOWNLOAD_BACKGROUND,
+        importer_constants.DOWNLOAD_ON_DEMAND
     ]
     if lazy not in modes:
         raise ValueError(_('{k} must be: {m}').format(k=key, m=modes))
@@ -445,5 +445,5 @@ VALIDATIONS = (
     validate_validate_downloads,
     validate_remove_missing,
     validate_retain_old_count,
-    validate_lazy_mode,
+    validate_download_policy,
 )

--- a/server/test/unit/plugins/util/test_importer_config.py
+++ b/server/test/unit/plugins/util/test_importer_config.py
@@ -472,29 +472,29 @@ class RetainOldCountTests(unittest.TestCase):
             self.assertTrue('-1' in e[0])
 
 
-class TestLazyMode(unittest.TestCase):
+class TestDownloadPolicy(unittest.TestCase):
 
     def test_valid(self):
         # not specified
         config = PluginCallConfiguration({}, {})
-        importer_config.validate_lazy_mode(config)
+        importer_config.validate_download_policy(config)
         # off
         config = PluginCallConfiguration(
-            {importer_constants.LAZY_MODE: importer_constants.LAZY_DISABLED}, {})
-        importer_config.validate_lazy_mode(config)
+            {importer_constants.DOWNLOAD_POLICY: importer_constants.DOWNLOAD_IMMEDIATE}, {})
+        importer_config.validate_download_policy(config)
         # active
         config = PluginCallConfiguration(
-            {importer_constants.LAZY_MODE: importer_constants.LAZY_ACTIVE}, {})
-        importer_config.validate_lazy_mode(config)
+            {importer_constants.DOWNLOAD_POLICY: importer_constants.DOWNLOAD_BACKGROUND}, {})
+        importer_config.validate_download_policy(config)
         # passive
         config = PluginCallConfiguration(
-            {importer_constants.LAZY_MODE: importer_constants.LAZY_PASSIVE}, {})
-        importer_config.validate_lazy_mode(config)
+            {importer_constants.DOWNLOAD_POLICY: importer_constants.DOWNLOAD_ON_DEMAND}, {})
+        importer_config.validate_download_policy(config)
 
     def test_invalid(self):
         config = PluginCallConfiguration(
-            {importer_constants.LAZY_MODE: 'This is bad'}, {})
-        self.assertRaises(ValueError, importer_config.validate_lazy_mode, config)
+            {importer_constants.DOWNLOAD_POLICY: 'This is bad'}, {})
+        self.assertRaises(ValueError, importer_config.validate_download_policy, config)
 
 
 class ValidateIsNonRequiredBooleanTests(unittest.TestCase):


### PR DESCRIPTION
https://pulp.plan.io/issues/1201

I'm thinking we should revisit the branding on this feature.  The term *lazy* is fine for an informal reference to the feature (or internal code) but thinking we should use something better for CLI and API as it pertains to repositories. 

Perhaps something like:

CLI:
```
--download-policy=(immediate | background | on_demand)
```

API (importer configuration):
```
download_policy=(immediate | background | on_demand)
```

Thoughts?