### PR TITLE
Fix setting last_sync in repo controller.

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -588,7 +588,7 @@ def sync(repo_id, sync_config_override=None, scheduled_call_id=None):
 
     finally:
         # Do an update instead of a save in case the importer has changed the scratchpad
-        model.Importer.objects(repo_id=repo_obj.repo_id).update(last_sync=sync_end_timestamp)
+        model.Importer.objects(repo_id=repo_obj.repo_id).update(set__last_sync=sync_end_timestamp)
         # Add a sync history entry for this run
         sync_result_collection.save(sync_result, safe=True)
 

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -719,7 +719,7 @@ class TestSync(unittest.TestCase):
             mock_sync_result.removed_count, mock_sync_result.summary, mock_sync_result.details,
             'canceled'
         )
-        mock_model.Importer.objects().update.assert_called_once_with(last_sync=mock_now())
+        mock_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
         mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
                                                                   safe=True)
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
@@ -758,7 +758,7 @@ class TestSync(unittest.TestCase):
             mock_sync_result.removed_count, mock_sync_result.summary, mock_sync_result.details,
             'success'
         )
-        mock_model.Importer.objects().update.assert_called_once_with(last_sync=mock_now())
+        mock_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
         mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
                                                                   safe=True)
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
@@ -795,7 +795,7 @@ class TestSync(unittest.TestCase):
             mock_sync_result.removed_count, mock_sync_result.summary, mock_sync_result.details,
             'failed'
         )
-        mock_model.Importer.objects().update.assert_called_once_with(last_sync=mock_now())
+        mock_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
         mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
                                                                   safe=True)
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
@@ -827,7 +827,7 @@ class TestSync(unittest.TestCase):
             mock_now(), mock_now(), -1, -1, -1, mock_gettext(), mock_gettext(),
             'err'
         )
-        mock_model.Importer.objects().update.assert_called_once_with(last_sync=mock_now())
+        mock_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
         mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
                                                                   safe=True)
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())


### PR DESCRIPTION
Fixing:

```
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976) Traceback (most recent call last):
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)   File "/usr/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)     R = retval = fun(*args, **kwargs)
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)   File "/home/jortel/git/pulp/server/pulp/server/async/tasks.py", line 400, in __call__
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)     return super(Task, self).__call__(*args, **kwargs)
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)   File "/usr/lib/python2.7/site-packages/celery/app/trace.py", line 437, in __protected_call__
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)     return self.run(*args, **kwargs)
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)   File "/home/jortel/git/pulp/server/pulp/server/controllers/repository.py", line 663, in sync
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)     model.Importer.objects(repo_id=repo_obj.repo_id).update(last_sync=sync_end_timestamp)
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)   File "/home/jortel/git/pulp/server/pulp/server/db/querysets.py", line 62, in update
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)     super(CriteriaQuerySet, self).update(*args, **kwargs)
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)   File "/usr/lib/python2.7/site-packages/mongoengine/queryset/base.py", line 427, in update
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)     update = transform.update(queryset._document, **update)
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)   File "/usr/lib/python2.7/site-packages/mongoengine/queryset/transform.py", line 229, in update
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976)     raise InvalidQueryError("Updates must supply an operation "
Nov 05 14:45:01 localhost.localdomain pulp[11129]: celery.worker.job:ERROR: (11129-90976) InvalidQueryError: Updates must supply an operation eg: set__FIELD=value
```