### PR TITLE
Updated lazy redirect_path default to match Apache conf.

### DIFF
--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -94,7 +94,7 @@ _default_values = {
         'enabled': 'false',
         'redirect_host': '',
         'redirect_port': '',
-        'redirect_path': '',
+        'redirect_path': '/streamer/',
     },
     'streamer': {
         'port': '8751',


### PR DESCRIPTION
The default path used in the Apache configuration[0] uses the path 'streamer'. The default config value for server.conf should match.

[0] https://github.com/pulp/pulp/blob/lazy-content/streamer/etc/httpd/conf.d/pulp_streamer.conf