### PR TITLE
Fix the type of Repo model expected in the publish steps.

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -447,7 +447,7 @@ class PluginStep(Step):
         Return the repo associated with the step
 
         :returns: the repository for this action
-        :rtype: pulp.server.db.model.Repository
+        :rtype: pulp.plugins.model.Repository
         """
         if self.repo:
             return self.repo
@@ -1086,7 +1086,7 @@ class SaveUnitsStep(PluginStep):
     """
 
     def finalize(self):
-        repo_controller.rebuild_content_unit_counts(self.get_repo())
+        repo_controller.rebuild_content_unit_counts(self.get_repo().repo_obj)
 
 
 class GetLocalUnitsStep(SaveUnitsStep):

--- a/server/test/unit/plugins/util/test_publish_step.py
+++ b/server/test/unit/plugins/util/test_publish_step.py
@@ -1120,9 +1120,12 @@ class TestSaveUnitsStep(unittest.TestCase):
 
     @patch('pulp.plugins.util.publish_step.repo_controller')
     def test_finalize(self, mock_repo_controller):
-        step = publish_step.SaveUnitsStep('foo_type', repo='bar')
+        repo = MagicMock()
+        step = publish_step.SaveUnitsStep('foo_type', repo=repo)
+
         step.finalize()
-        mock_repo_controller.rebuild_content_unit_counts.assert_called_once_with('bar')
+
+        mock_repo_controller.rebuild_content_unit_counts.assert_called_once_with(repo.repo_obj)
 
 
 class TestCreateManifestStep(unittest.TestCase):


### PR DESCRIPTION
The publish steps were inconsistent in which of the two Repository models they worked with, mixing the APIs.
This commit documents that they only work with pulp.plugins.model.Repository and fixes an API usage so that
it works with that model instead of with the pulp.server.db.model.Repository model.