### PR TITLE
Translate _id field specially to allow for ObjectIds

### DIFF
--- a/server/pulp/server/db/querysets.py
+++ b/server/pulp/server/db/querysets.py
@@ -31,6 +31,10 @@ class CriteriaQuerySet(QuerySet):
             query_set = query_set.filter(__raw__=criteria.spec)
 
         if criteria.fields is not None:
+            # if limiting the fields, we should always include the id, but id must be added after
+            # the translate because we don't want this turned into _id.
+            if 'id' not in criteria.fields:
+                criteria.fields.append('id')
             query_set = query_set.only(*criteria.fields)
 
         sort_list = []

--- a/server/test/unit/server/db/test_querysets.py
+++ b/server/test/unit/server/db/test_querysets.py
@@ -39,7 +39,7 @@ class TestCriteriaQuerySet(unittest.TestCase):
         qs_skip = qs_order_by.return_value.skip
         qs_limit = qs_skip.return_value.limit
 
-        qs_only.assert_called_once_with('field')
+        qs_only.assert_called_once_with('field', 'id')
         qs_order_by.assert_called_once_with('+field', '-other')
         qs_skip.assert_called_once_with(mock_crit.skip)
         qs_limit.assert_called_once_with(mock_crit.limit)
@@ -70,7 +70,7 @@ class TestCriteriaQuerySet(unittest.TestCase):
         qs_skip = qs_order_by.return_value.skip
         qs_limit = qs_skip.return_value.limit
 
-        qs_only.assert_called_once_with('field')
+        qs_only.assert_called_once_with('field', 'id')
         qs_order_by.assert_called_once_with('+field', '-other')
         qs_skip.assert_called_once_with('skip')
         qs_limit.assert_called_once_with('limit')

--- a/server/test/unit/server/webservices/views/test_search.py
+++ b/server/test/unit/server/webservices/views/test_search.py
@@ -282,8 +282,7 @@ class TestSearchView(unittest.TestCase):
         self.assertEqual(results.content, '["big money", "bigger money"]')
         self.assertEqual(results.status_code, 200)
         self.assertEqual(
-            FakeSearchView.model.objects.find_by_criteria.mock_calls[0][1][0]['fields'],
-            ['cash', 'id'])
+            FakeSearchView.model.objects.find_by_criteria.mock_calls[0][1][0]['fields'], ['cash'])
         self.assertEqual(
             FakeSearchView.model.objects.find_by_criteria.mock_calls[0][1][0]['filters'],
             {'money': {'$gt': 1000000}})


### PR DESCRIPTION
Using a criteria search by string representations of an ObjectId was broken in master for collections that have been converted to mongoengine. There is not a redmine issue for this because though this code exists in 2.7, no collections are affected, thus there has never been a release with this issue.

Thanks to @Ichimonji10 for smashing up my search code :)