### PR TITLE
Add "psmash"  to the Vagrant bashrc

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -54,5 +54,11 @@ _paction() {
     done;
 }
 
+psmash() {
+    workon pulp-smash;
+    python -m unittest2 discover ~/devel/pulp-smash/pulp_smash;
+    deactivate;
+}
+
 export DJANGO_SETTINGS_MODULE=pulp.server.webservices.settings
 export CRANE_CONFIG_PATH=$HOME/devel/crane/crane.conf


### PR DESCRIPTION
Add a function to the Vagrant default bashrc to run the pulp-smash tests.