### PR TITLE
vagrant resizes the root volume when provisioning

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -10,8 +10,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
 
  # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
- config.hostmanager.enabled = true
- config.hostmanager.manage_host = true
+ # requires the vagrant-hostmanager plugin to be installed
+ if Vagrant.has_plugin?("vagrant-hostmanager")
+     config.hostmanager.enabled = true
+     config.hostmanager.manage_host = true
+ end
+
+ # Comment this out to prevent resizing the root filesystem to fill the base box disk
+ config.vm.provision "shell", inline: "sudo xfs_growfs /dev/vda3"
+ # the command args above must match the filesystems and devices used in the base box
 
  # Comment this line if you would like to disable the automatic update during provisioning
  config.vm.provision "shell", inline: "sudo dnf upgrade -y"


### PR DESCRIPTION
By default, the fedora-22 base box we use is built with a 40G disk. The partition table accurately reflects this size, but the filesystem is only using 5G of it. This change fixes that, by growing the filesystem to match the partition size:

```
==> dev: meta-data=/dev/vda3              isize=256    agcount=4, agsize=321792 blks
==> dev:          =                       sectsz=512   attr=2, projid32bit=1
==> dev:          =                       crc=0        finobt=0
==> dev: data     =                       bsize=4096   blocks=1287168, imaxpct=25
==> dev:          =                       sunit=0      swidth=0 blks
==> dev: naming   =version 2              bsize=4096   ascii-ci=0 ftype=0
==> dev: log      =internal               bsize=4096   blocks=2560, version=2
==> dev:          =                       sectsz=512   sunit=0 blks, lazy-count=1
==> dev: realtime =none                   extsz=4096   blocks=0, rtextents=0
==> dev: data blocks changed from 1287168 to 10199744
```

Note the last line is the block count; multiply by the block size (4096) to get the bytes.

I was also getting errors related to the Vagrantfile change in 3bf6d1f2a9eadb205e5f8b9c637ed42a7f2c834a that happened because I didn't have vagrant-hostmanager installed. This should fix those errors for other users that have not installed the plugin.