### PR TITLE
The lazy catalog is now purged when an importer is deleted.

### DIFF
--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -7,7 +7,7 @@ Tests for the pulp.server.db.model module.
 from mock import patch, Mock
 
 from mongoengine import (ValidationError, BooleanField, DateTimeField, DictField, Document,
-                         IntField, ListField, StringField)
+                         IntField, ListField, StringField, signals)
 
 from pulp.common import error_codes, dateutils
 from pulp.common.compat import unittest
@@ -759,6 +759,16 @@ class TestImporter(unittest.TestCase):
         indexes = model.Importer._meta['indexes']
         self.assertDictEqual(
             indexes[0], {'fields': ['-repo_id', '-importer_type_id'], 'unique': True})
+
+    @patch('pulp.server.db.model.LazyCatalogEntry.objects')
+    def test_pre_delete(self, mock_lazy):
+        """Assert that the pre_delete signal deletes lazy catalog entries."""
+        model.Importer.pre_delete(None, Mock(id='fake'))
+        mock_lazy.assert_called_once_with(importer_id='fake')
+        mock_lazy.return_value.delete.assert_called_once_with()
+
+    def test_pre_delete_connect(self):
+        self.assertTrue(signals.pre_delete.has_receivers_for(model.Importer))
 
 
 class TestCeleryBeatLock(unittest.TestCase):


### PR DESCRIPTION
This commit adds a ``pre_delete`` signal to the Importer model which
handles the removal of catalog entries.

closes #1327