### PR TITLE
Trim down `pstatus` function in .bashrc

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -48,10 +48,7 @@ ptests() {
 }
 
 _paction() {
-
-    for s in goferd httpd pulp_workers pulp_celerybeat pulp_resource_manager; do
-        sudo systemctl $1 $s;
-    done;
+    sudo systemctl $1 goferd httpd pulp_workers pulp_celerybeat pulp_resource_manager
 }
 
 psmash() {


### PR DESCRIPTION
The various systemd commands accept multiple arguments. Why use a for loop if
a simpler expression suffices?