### PR TITLE
ignore pyo files in addition to pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *svn*
 *.ipynb
 *.pyc
+*.pyo
 .project
 .pydevproject
 *.swp


### PR DESCRIPTION
In the process of messing around with python optimize settings today,
I managed to make a ton of pyo files, which should be ignored just like
pyc files