### PR TITLE
tests no longer use "rpm" as a unit type ID, which had caused failure…

### DIFF
--- a/nodes/test/nodes_tests/test_plugins.py
+++ b/nodes/test/nodes_tests/test_plugins.py
@@ -142,7 +142,7 @@ class AgentConduit(Conduit):
 class PluginTestBase(ServerTests):
 
     REPO_ID = 'test-repo'
-    UNIT_TYPE_ID = 'rpm'
+    UNIT_TYPE_ID = 'notarealtype'
     UNIT_ID = 'test_unit_%d'
     UNIT_KEY = {'A': 'a', 'B': 'b', 'N': 0}
     UNIT_METADATA = {'name': 'Elvis', 'age': 42}


### PR DESCRIPTION
…s if pulp_rpm was installed