### PR TITLE
Ensure all values in ScheduledCall are serialized

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -21,6 +21,7 @@ from pulp.server.db.connection import UnsafeRetry
 from pulp.server.compat import digestmod
 from pulp.server.db.fields import ISO8601StringField, UTCDateTimeField
 from pulp.server.db.model.reaper_base import ReaperMixin
+from pulp.server.db.model import base
 from pulp.server.db.querysets import CriteriaQuerySet, RepoQuerySet
 from pulp.server.util import Singleton
 from pulp.server.webservices.views import serializers
@@ -1085,7 +1086,7 @@ class Distributor(AutoRetryDocument):
         return 'pulp:distributor:{0}:{1}'.format(self.repo_id, self.distributor_id)
 
 
-class SystemUser(object):
+class SystemUser(base.Model):
     """
     Singleton user class that represents the "system" user (i.e. no user).
 

--- a/server/pulp/server/db/model/dispatch.py
+++ b/server/pulp/server/db/model/dispatch.py
@@ -201,7 +201,15 @@ class ScheduledCall(Model):
         :return:    dictionary of public keys and values
         :rtype:     dict
         """
-        return {
+
+        # If principal is a User object, serialize it. If it does not have a serializer, it is
+        # a SystemUser which is already a dict.
+        try:
+            serial_principal = self.principal.serializer(self.principal).data
+        except AttributeError:
+            serial_principal = self.principal
+
+        dict_repr = {
             '_id': str(self._id),
             'args': self.args,
             'consecutive_failures': self.consecutive_failures,
@@ -213,13 +221,15 @@ class ScheduledCall(Model):
             'last_run_at': self.last_run_at,
             'last_updated': self.last_updated,
             'next_run': self.calculate_next_run(),
-            'principal': self.principal,
+            'principal': serial_principal,
             'remaining_runs': self.remaining_runs,
             'resource': self.resource,
             'schedule': self.schedule,
             'task': self.task,
             'total_run_count': self.total_run_count,
         }
+
+        return dict_repr
 
     def for_display(self):
         """

--- a/server/pulp/server/managers/auth/principal.py
+++ b/server/pulp/server/managers/auth/principal.py
@@ -19,8 +19,8 @@ class PrincipalManager(object):
         """
         Get the current user of the system,
         returning the default system user if there isn't one.
-        @return: current user of the system
-        @rtype: User or dict
+        :return: current user of the system
+        :rtype: pulp.server.db.model.User or pulp.server.db.model.SystemUser
         """
         return getattr(_PRINCIPAL_STORAGE, 'principal', model.SystemUser())
 
@@ -28,8 +28,8 @@ class PrincipalManager(object):
         """
         Set the current user of the system to the provided principal,
         if no principal is provided, set the current user to the system user.
-        @param principal: current user
-        @type principal: User or None
+        :param principal: current user
+        :type  principal: pulp.server.db.model.User or pulp.server.db.model.SystemUser
         """
         _PRINCIPAL_STORAGE.principal = principal or model.SystemUser()
 
@@ -42,7 +42,7 @@ class PrincipalManager(object):
     def is_system_principal(self):
         """
         Determine if the current user is the default system user.
-        @return: true if the current user is the system user, false otherwise
-        @rtype: bool
+        :return: true if the current user is the system user, false otherwise
+        :rtype: bool
         """
         return self.get_principal() is model.SystemUser()


### PR DESCRIPTION
https://pulp.plan.io/issues/1381

`ScheduledCall` model uses `as_dict` to serialize in preparation for a pymongo insert which cannot handle Mongoengine objects.

The `SystemUser` is such a basic object that the simplest path was just to have it inherit from dict (via the old base model) instead of writing a serializer for it. Treating it as a dict has always worked before, this is the most obvious way to ensure that the behavior doesn't change.