### PR TITLE
Add total/downloaded units to repository view.

### DIFF
--- a/docs/dev-guide/integration/rest-api/repo/retrieval.rst
+++ b/docs/dev-guide/integration/rest-api/repo/retrieval.rst
@@ -5,8 +5,9 @@ Retrieve a Single Repository
 ----------------------------
 
 Retrieves information on a single Pulp repository. The returned data includes
-general repository metadata and metadata describing any :term:`importers <importer>`
-and :term:`distributors <distributor>` associated with it.
+general repository metadata, metadata describing any :term:`importers <importer>`
+and :term:`distributors <distributor>` associated with it, and a count of how many
+content units have been stored locally for the repository.
 
 | :method:`get`
 | :path:`/v2/repositories/<repo_id>/`
@@ -14,7 +15,7 @@ and :term:`distributors <distributor>` associated with it.
 
 | :param_list:`get`
 
-* :param:`?details,bool,shortcut for including both distributors and importers`
+* :param:`?details,bool,shortcut for including distributors, importers, and content unit counts`
 * :param:`?importers,bool,include the "importers" attribute on each repository`
 * :param:`?distributors,bool,include the "distributors" attribute on each repository`
 
@@ -68,7 +69,9 @@ and :term:`distributors <distributor>` associated with it.
       "id": "harness_importer"
     }
   ],
-  "id": "harness_repo_1"
+  "id": "harness_repo_1",
+  "total_repository_units": 5,
+  "locally_stored_units": 3
  }
 
 

--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -170,7 +170,6 @@ class RepoResourceView(View):
         :rtype : django.http.HttpResponse
         :raises pulp_exceptions.MissingResource: if repo cannot be found
         """
-
         repo_obj = model.Repository.objects.get_repo_or_missing_resource(repo_id)
         repo = serializers.Repository(repo_obj).data
 
@@ -182,6 +181,10 @@ class RepoResourceView(View):
         if request.GET.get('distributors', 'false').lower() == 'true' or details:
             _merge_related_objects(
                 'distributors', manager_factory.repo_distributor_manager(), (repo,))
+        if details:
+            repo['total_repository_units'] = sum(repo['content_unit_counts'].itervalues())
+            total_missing = repo_controller.missing_unit_count(repo_obj.repo_id)
+            repo['locally_stored_units'] = repo['total_repository_units'] - total_missing
 
         return generate_json_response_with_pulp_encoder(repo)
 


### PR DESCRIPTION
This adds the following fields to the repository object returned from
the API ``v2/repositories/<repo-id>/?details=true``:
``total_content_units`` and ``total_units_downloaded``.

closes #1354