### PR TITLE
Changes version of python-kombu in exteral_deps.json

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -46,7 +46,7 @@
     },
     {
         "name": "python-kombu",
-        "version": "3.0.24-10",
+        "version": "3.0.24-10.pulp",
         "platform": [ "el6", "el7", "fc22", "fc23"]
     },
     {


### PR DESCRIPTION
Our build script is failing right now because it is looking for the wrong version of python kombu. It was built in koji using the .pulp suffix after the version. 