### PR TITLE
Update the /pulp/content WSGI app to use 'path_info'.

### DIFF
--- a/server/etc/httpd/conf.d/pulp_content.conf
+++ b/server/etc/httpd/conf.d/pulp_content.conf
@@ -11,8 +11,7 @@ WSGIImportScript /srv/pulp/content.wsgi process-group=pulp-content application-g
     WSGIProcessGroup pulp-content
     WSGIApplicationGroup pulp-content
     SSLRenegBufferSize  1048576
-    SSLRequireSSL
-    SSLVerifyDepth 3
+    SSLVerifyDepth 9
     SSLOptions +StdEnvVars +ExportCertData
     SSLVerifyClient optional
 </Files>

--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -123,7 +123,7 @@ class ContentView(View):
         :rtype: django.http.HttpResponse
         """
         host = request.get_host()
-        path = os.path.realpath(request.path)
+        path = os.path.realpath(request.path_info)
         lazy_enabled = parse_bool(pulp_conf.get('lazy', 'enabled'))
 
         # Authorization


### PR DESCRIPTION
The reason 'path_info' is used rather than 'path' is because 'path' is the SCRIPT_NAME/PATH_INFO where the script name would be something like '/pulp/content' and path info is '/var/www/pub/pulp/....'. Interestingly, the script name is being derived as 'http:' or 'https:'. That's clearly not correct, but it doesn't affect us.

I also removed the SSLRequireSSL directive from the Apache
config, as both HTTP and HTTPS requests should be lazy.