### PR TITLE
drop checks for dropDups

### DIFF
--- a/server/pulp/plugins/types/database.py
+++ b/server/pulp/plugins/types/database.py
@@ -309,7 +309,7 @@ def _update_indexes(type_def, unique):
             LOG.debug('Ensuring index [%s] (unique: %s) on type definition [%s]' % (index, unique, type_def.id))
             mongo_index = index
 
-        index_name = collection.ensure_index(mongo_index, unique=unique, drop_dups=False)
+        index_name = collection.ensure_index(mongo_index, unique=unique)
 
         if index_name is not None:
             LOG.debug('Index [%s] created on type definition [%s]' % (index_name, type_def.id))

--- a/server/test/unit/server/db/test_manage.py
+++ b/server/test/unit/server/db/test_manage.py
@@ -326,13 +326,10 @@ class TestManageDB(MigrationTest):
         self.assertEqual(indexes['_id_']['key'], [(u'_id', 1)])
         # Make sure we have the unique constraint on all three attributes
         self.assertEqual(indexes['attribute_1_1_attribute_2_1_attribute_3_1']['unique'], True)
-        self.assertEqual(indexes['attribute_1_1_attribute_2_1_attribute_3_1']['dropDups'], False)
         self.assertEqual(indexes['attribute_1_1_attribute_2_1_attribute_3_1']['key'],
                          [(u'attribute_1', 1), (u'attribute_2', 1), (u'attribute_3', 1)])
-        # Make sure we indexes attributes 1 and 3
-        self.assertEqual(indexes['attribute_1_1']['dropDups'], False)
+        # Make sure we indexed attributes 1 and 3
         self.assertEqual(indexes['attribute_1_1']['key'], [(u'attribute_1', 1)])
-        self.assertEqual(indexes['attribute_3_1']['dropDups'], False)
         self.assertEqual(indexes['attribute_3_1']['key'], [(u'attribute_3', 1)])
         # Make sure we only have the indexes that we've hand inspected here
         self.assertEqual(indexes.keys(), [u'_id_', u'attribute_1_1_attribute_2_1_attribute_3_1',


### PR DESCRIPTION
The upgrade to fedora 23 revealed that the 'dropDups' property of mongo
indices was deprecated in 2.6 and removed in 2.7.

The removed 'dropDups' assertions weren't stricly necessary, since the
test is checking that the uniqueness contraint is applied, which it is.

dropDups only comes into play if it's explicitly requested, which we
never do.

https://pulp.plan.io/issues/1393

fixes #1393