### PR TITLE
Add the importer ObjectId to the RepoSyncConduit.

### DIFF
--- a/nodes/test/nodes_tests/test_plugins.py
+++ b/nodes/test/nodes_tests/test_plugins.py
@@ -676,7 +676,9 @@ class ImporterTest(PluginTestBase):
             configuration = PluginCallConfiguration(configuration, {})
             conduit = RepoSyncConduit(
                 self.REPO_ID,
-                constants.HTTP_IMPORTER)
+                constants.HTTP_IMPORTER,
+                'abc123'
+            )
 
         with mock_config.patch({'server': {'storage_dir': self.childfs}}):
             importer.sync_repo(repo, conduit, configuration)
@@ -722,7 +724,9 @@ class ImporterTest(PluginTestBase):
             configuration = PluginCallConfiguration(configuration, {})
             conduit = RepoSyncConduit(
                 self.REPO_ID,
-                constants.HTTP_IMPORTER)
+                constants.HTTP_IMPORTER,
+                'abc123'
+            )
 
         with mock_config.patch({'server': {'storage_dir': self.childfs}}):
             importer.sync_repo(repo, conduit, configuration)
@@ -763,7 +767,9 @@ class ImporterTest(PluginTestBase):
             configuration = PluginCallConfiguration(configuration, {})
             conduit = RepoSyncConduit(
                 self.REPO_ID,
-                constants.HTTP_IMPORTER)
+                constants.HTTP_IMPORTER,
+                'abc123'
+            )
 
         with mock_config.patch({'server': {'storage_dir': self.childfs}}):
             importer.sync_repo(repo, conduit, configuration)
@@ -806,7 +812,9 @@ class ImporterTest(PluginTestBase):
             configuration = PluginCallConfiguration(configuration, {})
             conduit = RepoSyncConduit(
                 self.REPO_ID,
-                constants.HTTP_IMPORTER)
+                constants.HTTP_IMPORTER,
+                'abc123'
+            )
 
         with mock_config.patch({'server': {'storage_dir': self.childfs}}):
             importer.sync_repo(repo, conduit, configuration)
@@ -848,7 +856,9 @@ class ImporterTest(PluginTestBase):
             configuration = PluginCallConfiguration(configuration, {})
             conduit = RepoSyncConduit(
                 self.REPO_ID,
-                constants.HTTP_IMPORTER)
+                constants.HTTP_IMPORTER,
+                'abc123'
+            )
 
         with mock_config.patch({'server': {'storage_dir': self.childfs}}):
             importer.sync_repo(repo, conduit, configuration)
@@ -898,7 +908,9 @@ class ImporterTest(PluginTestBase):
             configuration = PluginCallConfiguration(configuration, {})
             conduit = RepoSyncConduit(
                 self.REPO_ID,
-                constants.HTTP_IMPORTER)
+                constants.HTTP_IMPORTER,
+                'abc123'
+            )
 
         with mock_config.patch({'server': {'storage_dir': self.childfs}}):
             importer.sync_repo(repo, conduit, configuration)
@@ -944,7 +956,9 @@ class ImporterTest(PluginTestBase):
             configuration = PluginCallConfiguration(configuration, {})
             conduit = RepoSyncConduit(
                 self.REPO_ID,
-                constants.HTTP_IMPORTER)
+                constants.HTTP_IMPORTER,
+                'abc123'
+            )
 
         with mock_config.patch({'server': {'storage_dir': self.childfs}}):
             importer.sync_repo(repo, conduit, configuration)

--- a/server/pulp/plugins/conduits/repo_sync.py
+++ b/server/pulp/plugins/conduits/repo_sync.py
@@ -53,9 +53,13 @@ class RepoSyncConduit(RepoScratchPadMixin, ImporterScratchPadMixin, AddUnitMixin
     allowed to do whatever threading makes sense to optimize its sync process.
     Calls into this instance do not have to be coordinated for thread safety,
     the instance will take care of it itself.
+
+    :ivar importer_object_id: The ObjectId of the importer for the given repo_id
+                              and importer_id.
+    :type importer_object_id: bson.objectid.ObjectId
     """
 
-    def __init__(self, repo_id, importer_id):
+    def __init__(self, repo_id, importer_id, importer_object_id):
         RepoScratchPadMixin.__init__(self, repo_id, ImporterConduitException)
         ImporterScratchPadMixin.__init__(self, repo_id, importer_id)
         AddUnitMixin.__init__(self, repo_id, importer_id)
@@ -63,6 +67,7 @@ class RepoSyncConduit(RepoScratchPadMixin, ImporterScratchPadMixin, AddUnitMixin
         StatusMixin.__init__(self, importer_id, ImporterConduitException)
         SearchUnitsMixin.__init__(self, ImporterConduitException)
 
+        self.importer_object_id = importer_object_id
         self._association_manager = manager_factory.repo_unit_association_manager()
         self._content_query_manager = manager_factory.content_query_manager()
 

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -665,8 +665,8 @@ def queue_sync_with_auto_publish(repo_id, overrides=None, scheduled_call_id=None
 @celery.task(base=Task, name='pulp.server.managers.repo.sync.sync')
 def sync(repo_id, sync_config_override=None, scheduled_call_id=None):
     """
-    Performs a synchronize operation on the given repository and triggers publishs for distributors
-    with autopublish enabled.
+    Performs a synchronize operation on the given repository and triggers publishes for
+    distributors with auto-publish enabled.
 
     The given repo must have an importer configured. This method is intentionally limited to
     synchronizing a single repo. Performing multiple repository syncs concurrently will require a
@@ -698,7 +698,7 @@ def sync(repo_id, sync_config_override=None, scheduled_call_id=None):
 
     call_config = PluginCallConfiguration(imp_config, repo_importer.config, sync_config_override)
     transfer_repo.working_dir = common_utils.get_working_directory()
-    conduit = RepoSyncConduit(repo_id, repo_importer.importer_type_id)
+    conduit = RepoSyncConduit(repo_id, repo_importer.importer_type_id, repo_importer.id)
     sync_result_collection = RepoSyncResult.get_collection()
 
     # Fire an events around the call

--- a/server/test/unit/plugins/conduits/test_repo_sync.py
+++ b/server/test/unit/plugins/conduits/test_repo_sync.py
@@ -43,7 +43,7 @@ class RepoSyncConduitTests(base.PulpServerTests):
         self.query_manager = query_manager.ContentQueryManager()
 
         importer_controller.set_importer(mock.MagicMock(repo_id='repo-1'), 'mock-importer', {})
-        self.conduit = RepoSyncConduit('repo-1', 'test-importer')
+        self.conduit = RepoSyncConduit('repo-1', 'test-importer', 'abc123')
 
     def tearDown(self):
         super(RepoSyncConduitTests, self).tearDown()

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -912,6 +912,7 @@ class TestSync(unittest.TestCase):
                                                                   safe=True)
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
         self.assertTrue(actual_result is mock_task_result.return_value)
+        self.assertEqual(mock_imp_inst.id, mock_conduit.call_args_list[0][0][2])
 
     @mock.patch('pulp.server.controllers.repository.TaskResult')
     def test_sync_failed(self, mock_task_result, mock_model, mock_plugin_api, mock_plug_conf,


### PR DESCRIPTION
Conduits are going away someday, but in the mean time the importer
ObjectId is needed during sync so the lazy catalog can be built and this
seems the best place to stash it.