### PR TITLE
Quote the rm py[co] statements in the bashrc.

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -26,7 +26,7 @@ pstop() {
 }
 
 prestart() {
-    find ~/devel/pulp* -name *.py[co] -delete;
+    find ~/devel/pulp* -name '*.py[co]' -delete;
     _paction restart
 }
 
@@ -38,7 +38,7 @@ preset() {
     pstop;
     mongo pulp_database ~/drop_database.js;
     sudo rm -rf /var/lib/pulp/*;
-    find ~/devel/pulp* -name *.py[co] -delete;
+    find ~/devel/pulp* -name '*.py[co]' -delete;
     sudo -u apache pulp-manage-db;
     # If Crane is present, let's set up the publishing symlinks so that the app files can be used
     if [ -d $HOME/devel/crane ]; then


### PR DESCRIPTION
The quotes are needed because without them bash will attempt to expand the asterisk that precedes which can
cause trouble depending on which folder your cwd is.