### PR TITLE
Change all QuerySet objects to be QuerySetNoCache objects.

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -630,7 +630,7 @@ class UnitModelPluginStep(PluginStep):
                 queries = repo_controller.get_unit_model_querysets(self.get_repo().id,
                                                                    model_class,
                                                                    self._repo_content_unit_q)
-                self._unit_querysets.extend(q.no_cache() for q in queries)
+                self._unit_querysets.extend(queries)
         return self._unit_querysets
 
     def get_total(self):

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -47,7 +47,7 @@ def get_associated_unit_ids(repo_id, unit_type, repo_content_unit_q=None):
     qs = model.RepositoryContentUnit.objects(q_obj=repo_content_unit_q,
                                              repo_id=repo_id,
                                              unit_type_id=unit_type)
-    for assoc in qs.no_cache().only('unit_id'):
+    for assoc in qs.only('unit_id'):
         yield assoc.unit_id
 
 

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -8,7 +8,8 @@ from collections import namedtuple
 from hmac import HMAC
 
 from mongoengine import (DictField, Document, DynamicField, IntField,
-                         ListField, StringField, UUIDField, ValidationError)
+                         ListField, StringField, UUIDField, ValidationError,
+                         QuerySetNoCache)
 from mongoengine import signals
 
 from pulp.common import constants, dateutils, error_codes
@@ -50,7 +51,12 @@ class AutoRetryDocument(Document):
         super(AutoRetryDocument, self).__init__(*args, **kwargs)
         UnsafeRetry.decorate_instance(instance=self, full_name=type(self))
 
-    meta = {'abstract': True}
+    # QuerySetNoCache is used as the default QuerySet to ensure that all sub-classes
+    # do not cache query results unless specifically requested by calling ``cache``.
+    meta = {
+        'abstract': True,
+        'queryset_class': QuerySetNoCache,
+    }
 
     def clean(self):
         """

--- a/server/test/unit/plugins/util/test_publish_step.py
+++ b/server/test/unit/plugins/util/test_publish_step.py
@@ -81,7 +81,7 @@ class TestUnitModelPluginStep(PluginBase):
 
         ret = self.step.unit_querysets
 
-        self.assertEqual(ret, [qs1.no_cache.return_value, qs2.no_cache.return_value])
+        self.assertEqual(ret, [qs1, qs2])
 
     @patch('pulp.server.controllers.repository.get_unit_model_querysets')
     def test_caches_querysets(self, mock_get_querysets):

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -604,7 +604,7 @@ class TestTaskApplyAsync(ResourceReservationTests):
         task.apply_async(*args, **kwargs)
 
         task_statuses = TaskStatus.objects()
-        self.assertEqual(len(task_statuses), 1)
+        self.assertEqual(task_statuses.count(), 1)
         new_task_status = task_statuses[0]
         self.assertEqual(new_task_status['task_id'], 'test_task_id')
         self.assertIsNone(new_task_status['group_id'])
@@ -631,7 +631,7 @@ class TestTaskApplyAsync(ResourceReservationTests):
         task.apply_async(*args, **kwargs)
 
         task_statuses = TaskStatus.objects()
-        self.assertEqual(len(task_statuses), 1)
+        self.assertEqual(task_statuses.count(), 1)
         new_task_status = task_statuses[0]
         self.assertEqual(new_task_status['task_id'], 'test_task_id')
         self.assertEqual(new_task_status['group_id'], group_id)
@@ -689,7 +689,7 @@ class TestTaskApplyAsync(ResourceReservationTests):
         task.apply_async(*args, **kwargs)
 
         task_statuses = TaskStatus.objects()
-        self.assertEqual(len(task_statuses), 1)
+        self.assertEqual(task_statuses.count(), 1)
         new_task_status = task_statuses[0]
         self.assertEqual(new_task_status['task_id'], 'test_task_id')
         self.assertEqual(new_task_status['worker_name'],
@@ -707,7 +707,7 @@ class TestTaskApplyAsync(ResourceReservationTests):
         task.apply_async(*args, **kwargs)
 
         task_statuses = TaskStatus.objects()
-        self.assertEqual(len(task_statuses), 1)
+        self.assertEqual(task_statuses.count(), 1)
         new_task_status = task_statuses[0]
         self.assertEqual(new_task_status['task_id'], 'test_task_id')
         self.assertEqual(new_task_status['worker_name'], 'othername')

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -33,14 +33,14 @@ class TestGetAssociatedUnitIDs(unittest.TestCase):
         ]
 
     def test_returns_ids(self, mock_objects):
-        mock_objects.return_value.no_cache.return_value.only.return_value = self.associations
+        mock_objects.return_value.only.return_value = self.associations
 
         ret = list(repo_controller.get_associated_unit_ids('repo1', 'demo_model'))
 
         self.assertEqual(ret, ['a', 'b'])
 
     def test_returns_generator(self, mock_objects):
-        mock_objects.return_value.no_cache.return_value.only.return_value = self.associations
+        mock_objects.return_value.only.return_value = self.associations
 
         ret = repo_controller.get_associated_unit_ids('repo1', 'demo_model')
 

--- a/server/test/unit/server/db/model/test_dispatch.py
+++ b/server/test/unit/server/db/model/test_dispatch.py
@@ -273,7 +273,7 @@ class TestTaskStatus(unittest.TestCase):
 
         ts = TaskStatus.objects()
         # There should only be one TaskStatus in the db
-        self.assertEqual(len(ts), 1)
+        self.assertEqual(ts.count(), 1)
         ts = ts[0]
         # Make sure all the attributes are correct
         self.assertEqual(ts['task_id'], task_id)
@@ -319,7 +319,7 @@ class TestTaskStatus(unittest.TestCase):
 
         ts = TaskStatus.objects()
         # There should only be one TaskStatus in the db
-        self.assertEqual(len(ts), 1)
+        self.assertEqual(ts.count(), 1)
         ts = ts[0]
         # Make sure all the attributes are correct
         self.assertEqual(ts['task_id'], task_id)
@@ -369,7 +369,7 @@ class TestTaskStatus(unittest.TestCase):
 
         ts = TaskStatus.objects()
         # There should only be one TaskStatus in the db
-        self.assertEqual(len(ts), 1)
+        self.assertEqual(ts.count(), 1)
         ts = ts[0]
         # Make sure all the attributes are correct
         self.assertEqual(ts['task_id'], task_id)
@@ -426,7 +426,7 @@ class TestTaskStatus(unittest.TestCase):
 
         ts = TaskStatus.objects()
         # There should only be one TaskStatus in the db
-        self.assertEqual(len(ts), 1)
+        self.assertEqual(ts.count(), 1)
         ts = ts[0]
         # Make sure all the attributes are correct
         self.assertEqual(ts['task_id'], task_id)
@@ -1000,7 +1000,7 @@ class TaskStatusTests(base.PulpServerTests):
         created = TaskStatus(task_id, worker_name, tags, state).save()
 
         task_statuses = TaskStatus.objects()
-        self.assertEqual(1, len(task_statuses))
+        self.assertEqual(1, task_statuses.count())
 
         task_status = task_statuses[0]
         self.assertEqual(task_id, task_status['task_id'])
@@ -1022,7 +1022,7 @@ class TaskStatusTests(base.PulpServerTests):
         TaskStatus(task_id).save()
 
         task_statuses = TaskStatus.objects()
-        self.assertEqual(1, len(task_statuses))
+        self.assertEqual(task_statuses.count(), 1)
         self.assertEqual(task_id, task_statuses[0]['task_id'])
         self.assertEqual(None, task_statuses[0]['worker_name'])
         self.assertEqual([], task_statuses[0]['tags'])
@@ -1172,7 +1172,7 @@ class TaskStatusTests(base.PulpServerTests):
         sort = (('task_id', DESCENDING), )
         criteria = Criteria(filters=filters, fields=fields, limit=limit, sort=sort)
         query_set = TaskStatus.objects.find_by_criteria(criteria)
-        self.assertEqual(len(query_set), 1)
+        self.assertEqual(query_set.count(), 1)
         self.assertEqual(query_set[0].task_id, '3')
         self.assertEqual(query_set[0].result, result)
         task_state_default = constants.CALL_WAITING_STATE

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -7,7 +7,7 @@ Tests for the pulp.server.db.model module.
 from mock import patch, Mock
 
 from mongoengine import (ValidationError, DateTimeField, DictField, Document, IntField, ListField,
-                         StringField)
+                         StringField, QuerySetNoCache)
 
 from pulp.common import error_codes, dateutils
 from pulp.common.compat import unittest
@@ -39,7 +39,12 @@ class TestAutoRetryDocument(unittest.TestCase):
         """
         Ensure that AutoRetryDocument is an abstract document.
         """
-        self.assertDictEqual(model.AutoRetryDocument._meta, {'abstract': True})
+        self.assertTrue(model.AutoRetryDocument._meta['abstract'])
+
+    def test_no_cache_query_set(self):
+        """Ensure the QuerySet class is the non-caching variety."""
+        self.assertTrue(issubclass(model.AutoRetryDocument._meta['queryset_class'],
+                                   QuerySetNoCache))
 
     def test_clean_raises_nothing_if_properly_defined(self):
         class MockDoc(model.AutoRetryDocument):
@@ -518,6 +523,7 @@ class TestWorkerModel(unittest.TestCase):
 
     def test_meta_queryset(self):
         self.assertEqual(model.Worker._meta['queryset_class'], CriteriaQuerySet)
+        self.assertTrue(issubclass(model.Worker.objects.__class__, QuerySetNoCache))
 
 
 class TestMigrationTracker(unittest.TestCase):
@@ -782,6 +788,11 @@ class TestUser(unittest.TestCase):
         sample_model = model.CeleryBeatLock()
         self.assertTrue(isinstance(sample_model, Document))
 
+    def test_no_cache_query_set(self):
+        """Ensure the QuerySet class is the non-caching variety."""
+        self.assertTrue(issubclass(model.User.objects.__class__,
+                                   QuerySetNoCache))
+
     def test_attributes(self):
         self.assertTrue(isinstance(model.User.login, StringField))
         self.assertTrue(model.User.login.required)
@@ -819,6 +830,7 @@ class TestUser(unittest.TestCase):
         Test that the model can search with criteria.
         """
         self.assertEqual(model.User._meta['queryset_class'], CriteriaQuerySet)
+        self.assertTrue(issubclass(model.Worker.objects.__class__, QuerySetNoCache))
 
 
 class TestUserAuth(unittest.TestCase):

--- a/server/test/unit/server/db/test_querysets.py
+++ b/server/test/unit/server/db/test_querysets.py
@@ -9,6 +9,7 @@ from pulp.server.db import querysets
 
 
 class MockDocument(Document):
+    """Fake Mongoengine document"""
     meta = {'queryset_class': querysets.CriteriaQuerySet}
 
 
@@ -17,14 +18,14 @@ class TestCriteriaQuerySet(unittest.TestCase):
     Tests for custom querysets that search with Criteria objects.
     """
 
+    def test_cache_not_implemented(self):
+        """Assert that calling `cache` results in an exception."""
+        self.assertRaises(NotImplementedError, MockDocument.objects.cache)
+
     def test_find_by_criteria_no_translate(self):
         """
         Test that various QuerySet methods are called.
         """
-
-        class MockDocument(Document):
-            """Fake Mongoengine document"""
-            meta = {'queryset_class': querysets.CriteriaQuerySet}
 
         mock_crit = mock.MagicMock()
         mock_crit.fields = ['field']
@@ -96,6 +97,11 @@ class TestReqoQuerySet(unittest.TestCase):
     """
     Tests for the repository custom query set.
     """
+
+    def test_cache_not_implemented(self):
+        """Assert that calling `cache` results in an exception."""
+        qs = querysets.RepoQuerySet(mock.MagicMock(), mock.MagicMock())
+        self.assertRaises(NotImplementedError, qs.cache)
 
     def test_get_repo(self):
         """


### PR DESCRIPTION
In order to not cache query results by default, all models must
use QuerySet objects that are subclasses of QuerySetNoCache. This
modifies all our models that don't have custom QuerySet objects to
use the QuerySetNoCache by default (by inheriting from
AutoRetryDocument) and introduces a superclass for all custom QuerySet
classes to use which derives from QuerySetNoCache.

closes #1395