### PR TITLE
Use Celery's local_received time for worker availability.

### DIFF
--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -235,9 +235,9 @@ class Scheduler(beat.Scheduler):
 
         # this is not an event that gets sent anywhere. We process it
         # immediately.
-        scheduler_event = {'timestamp': time.time(),
-                           'type': 'scheduler-event',
-                           'hostname': ("%s@%s" % (SCHEDULER_WORKER_NAME, platform.node()))}
+        scheduler_event = {
+            'timestamp': time.time(), 'local_received': time.time(), 'type': 'scheduler-event',
+            'hostname': ("%s@%s" % (SCHEDULER_WORKER_NAME, platform.node()))}
         worker_watcher.handle_worker_heartbeat(scheduler_event)
         return ret
 

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -106,13 +106,19 @@ class TestSchedulerTick(unittest.TestCase):
 
     @mock.patch('celery.beat.Scheduler.__init__', new=mock.Mock())
     @mock.patch('celery.beat.Scheduler.tick')
+    @mock.patch('pulp.server.async.scheduler.platform.node')
+    @mock.patch('pulp.server.async.scheduler.time')
     @mock.patch('pulp.server.async.scheduler.worker_watcher.handle_worker_heartbeat')
-    def test_calls_handle_heartbeat(self, mock_heartbeat, mock_tick):
+    def test_calls_handle_heartbeat(self, mock_heartbeat, time, node, mock_tick):
         sched_instance = scheduler.Scheduler()
+        time.time.return_value = 1449261335.275528
+        node.return_value = 'some_host'
 
         sched_instance.tick()
 
-        mock_heartbeat.assert_called_once()
+        expected_event = {'timestamp': 1449261335.275528, 'local_received': 1449261335.275528,
+                          'type': 'scheduler-event', 'hostname': 'scheduler@some_host'}
+        mock_heartbeat.assert_called_once_with(expected_event)
 
 
 class TestSchedulerSetupSchedule(unittest.TestCase):

--- a/server/test/unit/server/async/test_worker_watcher.py
+++ b/server/test/unit/server/async/test_worker_watcher.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 
 import mock
@@ -6,39 +7,29 @@ from pulp.server.async import worker_watcher
 
 
 class TestParseAndLogEvent(unittest.TestCase):
-    @mock.patch('pulp.server.async.worker_watcher.datetime')
-    @mock.patch('pulp.server.async.worker_watcher._log_event')
-    def test__parse_and_log_event(self, mock__log_event, mock_datetime):
-        event = {'timestamp': mock.Mock(), 'type': mock.Mock(), 'hostname': mock.Mock()}
+    def test__parse_and_log_event(self):
+        event = {'timestamp': 1449260644.097711, 'local_received': 1449260669.830475,
+                 'type': 'fake-type', 'hostname': 'fake-worker'}
 
         result = worker_watcher._parse_and_log_event(event)
 
-        # assert that the timestamp got converted using utcfromtimestamp()
-        mock_datetime.utcfromtimestamp.assert_called_once_with(event['timestamp'])
-
-        # assert that the resul dictionary has the right keys
-        self.assertTrue('timestamp' in result)
-        self.assertTrue('type' in result)
-        self.assertTrue('worker_name' in result)
-
-        # assert that the values in the resul dictionary are right
-        self.assertTrue(result['timestamp'] is mock_datetime.utcfromtimestamp.return_value)
+        # assert that the values in the result dictionary are right
+        self.assertEqual(result['timestamp'], datetime.datetime.utcfromtimestamp(1449260644.097711))
+        self.assertEqual(result['local_received'],
+                         datetime.datetime.utcfromtimestamp(1449260669.830475))
         self.assertTrue(result['type'] is event['type'])
         self.assertTrue(result['worker_name'] is event['hostname'])
 
-        # assert that the event info is passed to _log_event
-        mock__log_event.assert_called_once_with(result)
-
-
-class TestLogEvent(unittest.TestCase):
     @mock.patch('pulp.server.async.worker_watcher._logger')
     @mock.patch('pulp.server.async.worker_watcher._')
-    def test__log_event(self, mock_gettext, mock__logger):
-        event_info = {'timestamp': mock.Mock(), 'type': mock.Mock(), 'worker_name': mock.Mock()}
+    def test__log_event_logs_correctly(self, mock_gettext, mock__logger):
+        event_info = {'timestamp': 1449260644.097711, 'local_received': 1449260669.830475,
+                      'type': 'fake-type', 'hostname': 'fake-worker'}
 
-        worker_watcher._log_event(event_info)
+        worker_watcher._parse_and_log_event(event_info)
 
-        log_string = "received '%(type)s' from %(worker_name)s at time: %(timestamp)s"
+        log_string = ("'%(type)s' sent at time %(timestamp)s from %(worker_name)s, received at "
+                      "time: %(local_received)s")
         mock_gettext.assert_called_with(log_string)
         mock__logger.assert_called_once()
 
@@ -56,14 +47,14 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
 
         mock_event = mock.Mock()
         mock_worker.objects.return_value.first.return_value = None
-        mock__parse_and_log_event.return_value = {'worker_name': 'fake-worker',
-                                                  'timestamp': '2014-12-08T15:52:29Z',
-                                                  'type': 'fake-type'}
+        mock__parse_and_log_event.return_value = {
+            'worker_name': 'fake-worker', 'timestamp': '2014-12-08T15:52:29Z',
+            'local_received': '2014-12-08T15:52:36Z', 'type': 'fake-type'}
 
         worker_watcher.handle_worker_heartbeat(mock_event)
 
         mock_worker.objects.return_value.update_one.\
-            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:29Z', upsert=True)
+            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:36Z', upsert=True)
         mock_logger.info.assert_called_once_with('New worker \'fake-worker\' discovered')
 
     @mock.patch('pulp.server.async.worker_watcher._logger')
@@ -77,14 +68,14 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
 
         mock_event = mock.Mock()
         mock_worker.objects.return_value.first.return_value = mock.Mock()
-        mock__parse_and_log_event.return_value = {'worker_name': 'fake-worker',
-                                                  'timestamp': '2014-12-08T15:52:29Z',
-                                                  'type': 'fake-type'}
+        mock__parse_and_log_event.return_value = {
+            'worker_name': 'fake-worker', 'timestamp': '2014-12-08T15:52:29Z',
+            'local_received': '2014-12-08T15:52:48Z', 'type': 'fake-type'}
 
         worker_watcher.handle_worker_heartbeat(mock_event)
 
         mock_worker.objects.return_value.update_one.\
-            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:29Z', upsert=True)
+            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:48Z', upsert=True)
         self.assertEquals(mock_logger.info.called, False)
 
 


### PR DESCRIPTION
Pulp had been using the timestamp attribute of Celery's Events to determine when the workers were most
recently available. Due to a bug in Celery, this cause an off-by-one-hour bug for users who live in a locale
that does daylight savings time that is not currently observing daylight savings time (such as New York in
the winter):

https://github.com/celery/celery/issues/1802#issuecomment-161916587

This fixes the issue by using the local_received time which is computed in the receiver by Celery with
time.time() without any timezone shifting attempts.

https://pulp.plan.io/issues/1380

fixes #1380