### PR TITLE
Do not rm py[co]'s during prestart.

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -26,7 +26,6 @@ pstop() {
 }
 
 prestart() {
-    find ~/devel/pulp* -name '*.py[co]' -delete;
     _paction restart
 }
 


### PR DESCRIPTION
Removing the py[co] files causes the next Pulp startup to take a long time. The preset command also removes
the py[co] files, and is already an otherwise destructive command. Since this removal makes prestart take a
long time and prestart is a heavily used command during development, it was decided that dropping the
behavior from prestart and leaving it only in preset was favorable.