### PR TITLE
Update the spec file and init scripts so logs aren't 755.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -388,10 +388,11 @@ Pulp provides replication, access, and accounting for software repositories.
 %{_var}/lib/%{name}/published
 %{_var}/lib/%{name}/static
 %{_var}/lib/%{name}/uploads
-%dir %{_var}/log/%{name}
 %{_var}/www/pub
 %{_var}/cache/%{name}/
 %{_var}/run/%{name}/
+%defattr(640,apache,apache,750)
+%dir %{_var}/log/%{name}
 # Install the docs
 %defattr(-,root,root,-)
 %doc README LICENSE COPYRIGHT

--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -123,8 +123,8 @@ create_default_dir() {
         echo "- Creating default directory: '$1'"
         mkdir -p "$1"
         maybe_die "Couldn't create directory $1"
-        echo "- Changing permissions of '$1' to 02755"
-        chmod 02755 "$1"
+        echo "- Changing permissions of '$1' to 02750"
+        chmod 02750 "$1"
         maybe_die "Couldn't change permissions for $1"
         if [ -n "$CELERYBEAT_USER" ]; then
             echo "- Changing owner of '$1' to '$CELERYBEAT_USER'"
@@ -226,6 +226,7 @@ start_beat () {
 # this function implements the fix for bz #1145723
 write_log_message () {
   touch $CELERYBEAT_LOG_FILE && chown $CELERYD_USER $CELERYBEAT_LOG_FILE
+  chmod 640 $CELERYBEAT_LOG_FILE
   echo -n `date "+%Y-%m-%d %T"` >> $CELERYBEAT_LOG_FILE
   echo " $1" >> $CELERYBEAT_LOG_FILE
 }

--- a/server/etc/rc.d/init.d/pulp_workers
+++ b/server/etc/rc.d/init.d/pulp_workers
@@ -125,8 +125,8 @@ create_default_dir() {
         echo "- Creating default directory: '$1'"
         mkdir -p "$1"
         maybe_die "Couldn't create directory $1"
-        echo "- Changing permissions of '$1' to 02755"
-        chmod 02755 "$1"
+        echo "- Changing permissions of '$1' to 02750"
+        chmod 02750 "$1"
         maybe_die "Couldn't change permissions for $1"
         if [ -n "$CELERYD_USER" ]; then
             echo "- Changing owner of '$1' to '$CELERYD_USER'"
@@ -197,12 +197,14 @@ write_log_message () {
     do
       local log_file="`dirname $CELERYD_LOG_FILE`/${i}.log"
       touch $log_file && chown $CELERYD_USER $log_file
+      chmod 640 $log_file
       echo -n `date "+%Y-%m-%d %T"` >> $log_file
       echo " $1" >> $log_file
     done
   else
     local log_file="`dirname $CELERYD_LOG_FILE`/${CELERYD_NODES}.log"
     touch $log_file && chown $CELERYD_USER $log_file
+    chmod 640 $log_file
     echo -n `date "+%Y-%m-%d %T"` >> $log_file
     echo " $1" >> $log_file
   fi


### PR DESCRIPTION
Pulp logs to /var/log/pulp/ until logging is set up on systems using the
init scripts. This ensures the directory and the files within are not
world readable.

https://pulp.plan.io/issues/252