### PR TITLE
Add lazy to the ansible playbook

### DIFF
--- a/playpen/ansible/dev-playbook.yml
+++ b/playpen/ansible/dev-playbook.yml
@@ -7,3 +7,4 @@
     - db
     - qpidd
     - dev
+    - lazy

--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -67,7 +67,7 @@ ptests() {
 }
 
 _paction() {
-    sudo systemctl $1 goferd httpd pulp_workers pulp_celerybeat pulp_resource_manager
+    sudo systemctl $1 goferd httpd pulp_workers pulp_celerybeat pulp_resource_manager pulp_streamer
 }
 
 psmash() {

--- a/playpen/ansible/roles/lazy/files/squid.conf
+++ b/playpen/ansible/roles/lazy/files/squid.conf
@@ -1,0 +1,119 @@
+# Recommended minimum configuration. It is important to note that order
+# matters in Squid's configuration; the configuration is applied top to bottom.
+
+ # Listen on port 3128 in Accelerator (caching) mode.
+ http_port 3128 accel
+
+ # Only accept connections from the local host. If the Apache reverse proxy is
+ # running on a different host, adjust this accordingly.
+ http_access allow localhost
+
+ # Allow requests with a destination that matches the port squid listens on,
+ # and deny everything else. This is okay because we only handle requests from
+ # the Apache reverse proxy.
+ acl Safe_ports port 3128
+ http_access deny !Safe_ports
+
+ # Only allow cachemgr access from localhost.
+ http_access allow localhost manager
+ http_access deny manager
+
+ # We strongly recommend the following be uncommented to protect innocent web
+ # applications running on the proxy server who think the only one who can 
+ # access services on "localhost" is a local user.
+ http_access deny to_localhost
+
+ # And finally deny all other access to this proxy.
+ http_access deny all
+
+
+ # Forward requests to the Pulp Streamer. Note that the port configured here
+ # must match the port the Pulp Streamer is listening on. The format for
+ # entries is: cache_peer hostname type http-port icp-port [options]
+ #
+ # The following options are set:
+ #  * no-digest: Disable request of cache digests, as the Pulp Streamer does
+ #               not provide one.
+ #
+ #  * no-query: Disable ICP queries to the Pulp Streamer.
+ #
+ #  * originserver: Causes the Pulp Streamer to be contacted as the origin 
+ #                  server. 
+ #
+ #  * name: Unique name for the peer. Used to reference the peer in other directives.
+ cache_peer localhost parent 8751 0 no-digest no-query originserver name=PulpStreamer
+
+ # Allow all queries to be forwarded to the Pulp Streamer.
+ cache_peer_access PulpStreamer allow all
+
+ # Ensure all requests are allowed to be cached.
+ cache allow all
+
+ # Set the debugging level. The format is 'section,level'. Valid levels are 1
+ # to 9, with 9 being the most verbose.
+ debug_options ALL,1
+
+
+ # Set the minimum object size to 0 kB so all content is cached.
+ minimum_object_size 0 kB
+
+ # Set the maximum object size that can be cached. Default is to support 
+ # DVD-sized objects so that ISOs are cached.
+ maximum_object_size 5 GB
+
+ # Objects larger than this size will not be kept in the memory cache. This
+ # should be set low enough to avoid large objects taking up all the memory
+ # cache, but high enough to avoid repeatedly reading hot objects from disk.
+ maximum_object_size_in_memory 100 MB
+
+ # Set the location and size of the disk cache.
+ # Format is: cache_dir type Directory-Name Fs-specific-data [options]
+ #
+ # * type specifies the type of storage system to use.
+ #
+ # * Directory-Name is the top-level directory where cache swap files will be
+ #   stored. Squid will not create this directory so it must exist and be 
+ #   writable by the Squid process.
+ #
+ # * Fs-specific-config varies by storage system type. For 'aufs' and 'ufs' 
+ #   the data is in the format: Mbytes L1 L2.
+ #     - Mbytes is the number of megabytes to use in this cache directory. Note that
+ #       that this should never exceed 80% of the storage space in that directory. 
+ #     - L1 is the number of first-level subdirectories which are created under
+ #       the root cache directory (Directory-Name).
+ #     - L2 is the number of second-level subdirectories which will be created under
+ #       each L1 subdirectory.
+ #
+ # Be aware that this directive must NOT precede the 'workers' configuration option,
+ # if you choose to use it, and should use configuration macros or conditionals to
+ # give each squid worker that requires a disk cache a dedicated cache directory.
+ #
+ # 'aufs' uses layered directories to store files, utilizing POSIX-threads to 
+ #  avoid blocking the main Squid process on disk-I/O. This was formerly known in
+ #  Squid as async-io.
+ #
+ # 'ufs' is simple to set up and available in all recent version of Squid, but
+ # should not be used in a production environment. 'ufs' does not make use of
+ # threads for I/O, so it blocks when reading from or writing to the cache.
+ #
+ # 'rock' uses a database-style storage. All cached entries are stored in a
+ # 'database' file, using fixed-size slots. A single entry occupies one or 
+ # more slots. 'rock' performs best with small files, whereas 'aufs' works best
+ # with larger files. A combination of the two can be used in advanced deployments.
+ cache_dir aufs /var/spool/squid 10000 16 256
+
+ # Leave coredumps in the first cache dir
+ coredump_dir /var/spool/squid
+
+ #
+ # Define how long objects without a explicit expiry time are considered fresh.
+ # All responses from the Pulp Streamer should enclude a max-age, but this is a
+ # way to ensure all objects become stale eventually.
+ #
+ # Add any of your own refresh_pattern entries above these.
+ #
+ refresh_pattern ^ftp: 1440 20% 10080
+ refresh_pattern ^gopher: 1440 0% 1440
+ refresh_pattern -i (/cgi-bin/|\?) 0 0% 0
+ refresh_pattern .  0 20% 4320
+

--- a/playpen/ansible/roles/lazy/tasks/main.yml
+++ b/playpen/ansible/roles/lazy/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Install lazy packages
+  dnf: name={{ item }} state=present
+  with_items:
+      - squid
+      - httpd
+
+- name: Install Squid proxy configuration
+  copy: src=squid.conf dest=/etc/squid/squid.conf
+
+- file: path=/var/spool/squid state=directory owner=squid group=squid mode=750
+
+- name: Start and enable Squid service
+  service: name=squid state=started enabled=yes

--- a/playpen/ansible/vagrant-playbook.yml
+++ b/playpen/ansible/vagrant-playbook.yml
@@ -12,3 +12,4 @@
     - db
     - qpidd
     - dev
+    - lazy


### PR DESCRIPTION
This doesn't enable or start the pulp streamer since that gets set up in the vagrant-setup.sh file which happens after the ansible run. When that changes, we can enable the streamer and start it in the lazy role.