### PR TITLE
Add python-dnf to the dev-setup.sh script.

### DIFF
--- a/playpen/dev-setup.sh
+++ b/playpen/dev-setup.sh
@@ -105,6 +105,9 @@ for r in $REPOS; do
   fi
 done
 
+# Install some of Ansible's dependencies
+$HOME/devel/pulp/playpen/bootstrap-ansible.sh
+
 pushd pulp
 if [ ! -f /tmp/ansible_inventory ]; then
     echo -e "localhost ansible_connection=local" >> /tmp/ansible_inventory


### PR DESCRIPTION
python-dnf is a prerequisite for Ansible's dnf module to work, and is not included in Fedora 23 by default.