### PR TITLE
Update the HTTP callback event publish to use requests.

### DIFF
--- a/server/pulp/server/event/http.py
+++ b/server/pulp/server/event/http.py
@@ -8,13 +8,12 @@ url
 
 Eventually this should be enhanced to support authentication credentials as well.
 """
-
-import base64
-import httplib
+from gettext import gettext as _
 import logging
 import threading
 
-from pulp.server.compat import json, json_util
+from requests import post
+from requests.auth import HTTPBasicAuth
 
 
 TYPE_ID = 'http'
@@ -25,56 +24,36 @@ _logger = logging.getLogger(__name__)
 def handle_event(notifier_config, event):
     # fire the actual http push function off in a separate thread to keep
     # pulp from blocking or deadlocking due to the tasking subsystem
-
     data = event.data()
-
     _logger.info(data)
-
-    body = json.dumps(data, default=json_util.default)
-
-    thread = threading.Thread(target=_send_post, args=[notifier_config, body])
+    thread = threading.Thread(target=_send_post, args=[notifier_config, data])
     thread.setDaemon(True)
     thread.start()
 
 
-def _send_post(notifier_config, body):
+def _send_post(notifier_config, data):
+    """
+    Sends a POST request with the given data to the configured notifier url.
 
-    # Basic headers
-    headers = {'Accept': 'application/json',
-               'Content-Type': 'application/json'}
-
-    # Parse the URL for the pieces we need
+    :param notifier_config: The configuration for the HTTP notifier. This should
+                            contain the 'url' key, and optional 'username' and
+                            'password' keys.
+    :type notifier_config:  dict
+    :param data:            The POST data as a Python dictionary.
+    :param data:            dict
+    """
     if 'url' not in notifier_config or not notifier_config['url']:
-        _logger.warn('HTTP notifier configured without a URL; cannot fire event')
+        _logger.error(_('HTTP notifier configured without a URL; cannot fire event'))
         return
-
     url = notifier_config['url']
-
-    try:
-        scheme, empty, server, path = url.split('/', 3)
-    except ValueError:
-        _logger.warn('Improperly configured post_sync_url: %(u)s' % {'u': url})
-        return
-
-    connection = _create_connection(scheme, server)
 
     # Process authentication
     if 'username' in notifier_config and 'password' in notifier_config:
-        raw = ':'.join((notifier_config['username'], notifier_config['password']))
-        encoded = base64.encodestring(raw)[:-1]
-        headers['Authorization'] = 'Basic ' + encoded
-
-    connection.request('POST', '/' + path, body=body, headers=headers)
-    response = connection.getresponse()
-    if response.status != httplib.OK:
-        error_msg = response.read()
-        _logger.warn('Error response from HTTP notifier: %(e)s' % {'e': error_msg})
-    connection.close()
-
-
-def _create_connection(scheme, server):
-    if scheme.startswith('https'):
-        connection = httplib.HTTPSConnection(server)
+        auth = HTTPBasicAuth(notifier_config['username'], notifier_config['password'])
     else:
-        connection = httplib.HTTPConnection(server)
-    return connection
+        auth = None
+
+    response = post(url, data=data, auth=auth)
+    if response.status_code != 200:
+        _logger.error(_('Received HTTP {code} from HTTP notifier to {url}.').format(
+            code=response.status_code, url=url))


### PR DESCRIPTION
This addresses two problems: firstly, the listener would
not validate the signature on the server's x509 certificate. Secondly,
it was willing to perform SSLv2 and SSLv3. python-requests validates
certificates by default. On EL6+ and Fedora, it uses the system trust
store to perform this validation.

The protocols supported by requests is determined by urllib3. As of
Fedora 23, SSLv2 and SSLv3 is not supported.

closes #581