### PR TITLE
Reorder config attr overrides to prevent explosions

### DIFF
--- a/devel/test/unit/server/test_base.py
+++ b/devel/test/unit/server/test_base.py
@@ -39,10 +39,10 @@ class LoadTestConfigTestCase(unittest.TestCase):
     """
     This class contains tests for the _load_test_config() function.
     """
-    @mock.patch('pulp.devel.unit.server.base.config.config.set')
+    @mock.patch('pulp.devel.unit.server.base.override_config_attrs')
     @mock.patch('pulp.devel.unit.server.base.stop_logging')
     @mock.patch('pulp.devel.unit.server.base.start_logging')
-    def test_load_test_config(self, start_logging, stop_logging, config_set):
+    def test_load_test_config(self, start_logging, stop_logging, override):
         """
         Assert correct operation of the function.
         """
@@ -53,14 +53,52 @@ class LoadTestConfigTestCase(unittest.TestCase):
         stop_logging.assert_called_once_with()
 
         # Ensure that the correct settings have been put into place
-        self.assertEqual(
-            [c[1] for c in config_set.mock_calls],
-            [('database', 'name', 'pulp_unittest'), ('server', 'storage_dir', '/tmp/pulp')])
+        self.assertEqual(config.config.get('database', 'name'), 'pulp_unittest')
+        self.assertEqual(config.config.get('server', 'storage_dir'), '/tmp/pulp')
 
-        # Ensure that the config doesn't allow tampering
-        self.assertTrue(config.config.set is base._enforce_config)
+        # Ensure that the config tampering prevention was triggered
+        override.assert_called_once_with()
+
+
+class ConfigAttrOverride(unittest.TestCase):
+    def tearDown(self):
+        # config altering overrides must be replaced after running these tests
+        base.override_config_attrs()
+
+    def test_override_restore(self):
+        # override and restore works as expected
+        base.override_config_attrs()
         self.assertTrue(config.load_configuration is base._enforce_config)
         self.assertTrue(config.__setattr__ is base._enforce_config)
+        self.assertTrue(config.config.set is base._enforce_config)
+        self.assertTrue(hasattr(config, '_overridden_attrs'))
+
+        base.restore_config_attrs()
+        self.assertTrue(
+            config.load_configuration is config._overridden_attrs['load_configuration'])
+        self.assertTrue(config.__setattr__ is config._overridden_attrs['__setattr__'])
+        self.assertTrue(config.config.set is config._overridden_attrs['config.set'])
+
+    def test_override_reentrant(self):
+        # the override/restore interaction is reentrant: override can be called again before
+        # restore is called and no further changes will be made, preventing base._enfore_config
+        # from being saved as the overridden attrs
+        base.override_config_attrs()
+        base.override_config_attrs()
+
+        for attr in config._overridden_attrs.values():
+            self.assertTrue(attr is not base._enforce_config)
+
+    def test_load_test_config_after_override(self):
+        """
+        _load_test_config works even when config modifications are disallowed beforehand
+        """
+        # _load_test_config is able to modify the config even after override is called...
+        base.override_config_attrs()
+        # If something was wrong, this would raise Exception
+        base._load_test_config()
+        # but attempts to alter the config afterwatd are still blocked
+        self.assertRaises(Exception, config.config.set, 'section', 'key', 'value')
 
 
 class StartDatabaseConnectionTestCase(unittest.TestCase):


### PR DESCRIPTION
start_logging() is called in _load_test_config, which triggers conf load,
but fails, because loading the config sets defaults, which is blocked by
overridden config attrs.

https://i.imgur.com/KJyc4gz.gifv

restoring the config setters for the duration of _load_test_config
safely prevents that explosion. I also added more/better tests to
confirm expectations of the config override/restore mechanism

fixes #1409

https://pulp.plan.io/issues/1409
