### PR TITLE
fixing name of NAMED_TUPLE attribute to match what gets used on subclasses

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -472,7 +472,7 @@ class ContentUnit(AutoRetryDocument):
         'abstract': True,
     }
 
-    _NAMED_TUPLE = None
+    NAMED_TUPLE = None
 
     @classmethod
     def attach_signals(cls):


### PR DESCRIPTION
This attribute gets overridden on every subclass automatically based on the
unit key field names. It only exists on this base class to make IDEs happy and
accurately show the expected data model to humans. As such, I'm not sure it's
worth adding a test for.

The attribute is set on subclasses here, which is just a few lines below the change in this PR: https://github.com/pulp/pulp/blob/7d4af21ea08d1e718b039b1b0aba62cd0d1cfd5d/server/pulp/server/db/model/__init__.py#L488