### PR TITLE
the associate function failed to limit by unit type ID

### DIFF
--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -139,7 +139,30 @@ class RepoUnitAssociationManager(object):
         return unique_count
 
     @staticmethod
-    def associate_from_repo(source_repo_id, dest_repo_id, criteria=None,
+    def _units_from_criteria(source_repo, criteria):
+        """
+        Given a criteria, return an iterator of units
+
+        :param source_repo: repository to look for units in
+        :type  source_repo: pulp.server.db.model.Repository
+        :param criteria:    criteria object to use for the search parameters
+        :type  criteria:    pulp.server.db.model.criteria.UnitAssociationCriteria
+
+        :return:    generator of pulp.server.db.model.ContentUnit instances
+        :rtype:     generator
+        """
+        association_q = mongoengine.Q(__raw__=criteria.association_spec)
+        if criteria.type_ids:
+            association_q &= mongoengine.Q(unit_type_id__in=criteria.type_ids)
+        unit_q = mongoengine.Q(__raw__=criteria.unit_spec)
+        return repo_controller.find_repo_content_units(
+            repository=source_repo,
+            repo_content_unit_q=association_q,
+            units_q=unit_q,
+            yield_content_unit=True)
+
+    @classmethod
+    def associate_from_repo(cls, source_repo_id, dest_repo_id, criteria=None,
                             import_config_override=None):
         """
         Creates associations in a repository based on the contents of a source
@@ -200,13 +223,7 @@ class RepoUnitAssociationManager(object):
         if criteria is not None:
             # if all source types have been converted to mongo - search via new style
             if source_repo_unit_types.issubset(set(plugin_api.list_unit_models())):
-                association_q = mongoengine.Q(__raw__=criteria.association_spec)
-                unit_q = mongoengine.Q(__raw__=criteria.unit_spec)
-                transfer_units = repo_controller.find_repo_content_units(
-                    repository=source_repo,
-                    repo_content_unit_q=association_q,
-                    units_q=unit_q,
-                    yield_content_unit=True)
+                transfer_units = cls._units_from_criteria(source_repo, criteria)
             else:
                 # else, search via old style
                 associate_us = load_associated_units(source_repo_id, criteria)

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -1,6 +1,7 @@
 import mock
 
 from .... import base
+from pulp.common.compat import unittest
 from pulp.devel import mock_plugins
 from pulp.plugins.conduits.unit_import import ImportUnitConduit
 from pulp.plugins.config import PluginCallConfiguration
@@ -24,6 +25,30 @@ TYPE_2_DEF = model.TypeDefinition('type-2', 'Type 2', 'Test Definition Two',
 
 MOCK_TYPE_DEF = model.TypeDefinition('mock-type', 'Mock Type', 'Used by the mock importer',
                                      ['key-1'], [], [])
+
+
+@mock.patch('pulp.server.controllers.repository.find_repo_content_units', spec_set=True)
+class TestUnitsFromCriteria(unittest.TestCase):
+    def setUp(self):
+        super(TestUnitsFromCriteria, self).setUp()
+        self.manager = association_manager.RepoUnitAssociationManager()
+        self.repo = me_model.Repository(repo_id='repo1')
+
+    def test_limits_by_type(self, mock_find):
+        criteria = UnitAssociationCriteria(type_ids=['foo'])
+
+        self.manager._units_from_criteria(self.repo, criteria)
+
+        # This is the combination of a Q with a raw query, plus a normal Q. The original Q
+        # objects are preserved on the "children" attribute, since they cannot be directly
+        # combined like normal Q objects.
+        association_q_combination = mock_find.call_args[1]['repo_content_unit_q']
+        found = False
+        for association_q in association_q_combination.children:
+            if association_q.query.get('unit_type_id__in') == ['foo']:
+                found = True
+                break
+        self.assertTrue(found)
 
 
 @mock.patch('pulp.server.managers.repo.unit_association.model.Repository')


### PR DESCRIPTION
This bug would not have been noticed for plugins with only one unit type.

This fixes the bug and also pulls the criteria-to-units logic out to a separate
function, so it can more easily be reasoned about and tested.