### PR TITLE
adding a call to rebuild unit counts at the end of every associate_from_repo call

### DIFF
--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -240,6 +240,7 @@ class RepoUnitAssociationManager(object):
                 units=transfer_units)
 
             unit_ids = [u.to_id_dict() for u in copied_units]
+            repo_controller.rebuild_content_unit_counts(dest_repo)
             return {'units_successful': unit_ids}
         except Exception:
             msg = _('Exception from importer [%(i)s] while importing units into repository [%(r)s]')

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -142,9 +142,11 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         # Test - Make sure this does not raise an error
         self.manager.unassociate_unit_by_id(self.repo_id, 'type-1', 'unit-1')
 
+    @mock.patch('pulp.server.controllers.repository.rebuild_content_unit_counts', spec_set=True)
     @mock.patch('pulp.server.managers.repo.unit_association.plugin_api')
     @mock.patch('pulp.server.managers.repo.unit_association.model.Importer')
-    def test_associate_from_repo_no_criteria(self, mock_importer, mock_plugin, mock_repo):
+    def test_associate_from_repo_no_criteria(self, mock_importer, mock_plugin,
+                                             mock_rebuild_count, mock_repo):
         source_repo = mock.MagicMock(repo_id='source-repo')
         dest_repo = mock.MagicMock(repo_id='dest-repo')
         mock_imp_inst = mock.MagicMock()
@@ -189,6 +191,9 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         conduit = args[2]
         self.assertTrue(isinstance(conduit, ImportUnitConduit))
 
+        # This test is too complex and fragile to try asserting the right argument was passed.
+        self.assertEqual(mock_rebuild_count.call_count, 1)
+
         # Clean Up
         manager_factory.principal_manager().set_principal(principal=None)
 
@@ -230,9 +235,11 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         # Cleanup
         mock_plugins.MOCK_IMPORTER.import_units.side_effect = None
 
+    @mock.patch('pulp.server.controllers.repository.rebuild_content_unit_counts', spec_set=True)
     @mock.patch('pulp.server.managers.repo.unit_association.plugin_api')
     @mock.patch('pulp.server.managers.repo.unit_association.model.Importer')
-    def test_associate_from_repo_no_matching_units(self, mock_importer, mock_plugin, mock_repo):
+    def test_associate_from_repo_no_matching_units(self, mock_importer, mock_plugin,
+                                                   mock_rebuild_count, mock_repo):
         mock_imp_inst = mock.MagicMock()
         mock_plugin.get_importer_by_id.return_value = (mock_imp_inst, mock.MagicMock())
         source_repo = mock.MagicMock(repo_id='source-repo')


### PR DESCRIPTION
There was a bug in at least one plugin (and probably more) that forgot to
account for the unit counts during mongoengine conversion. This appears to be a
relatively inexpensive call, and I think is a fine and robust approach instead
of the previous one, where pulp tracked unit count deltas for each operation.