### PR TITLE
Add pdebug to the Vagrant bashrc.

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -122,6 +122,9 @@ pprocs() {
 
     printf "\nPulp WSGI processes:\n"
     ps ax | grep "wsgi:pulp" | grep -v grep | awk '{ print $1 }'
+
+pdebug() {
+    telnet 127.0.0.1 4444
 }
 
 export DJANGO_SETTINGS_MODULE=pulp.server.webservices.settings

--- a/playpen/ansible/roles/dev/files/motd
+++ b/playpen/ansible/roles/dev/files/motd
@@ -27,6 +27,7 @@ Here are some tips:
     preset:    Reset Pulp to a clean install state
     ppopulate: Populate Pulp with test repositories of several types
     pprocs:    List all Pulp-related process IDs
+    pdebug:    Start a remote PDB session on localhost
 
 * You can ssh into your vagrant environment with vagrant ssh, but presumably
   you already know this since you are reading this message :)


### PR DESCRIPTION
This currently just uses telnet to connect to localhost port 4444. When
rpdb is updated, it could be used to send a SIGTRAP to a specified
process and attach to it.