### PR TITLE
Add a function to the Vagrant bashrc to print Pulp PIDs.

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -107,5 +107,19 @@ ppopulate() {
     fi
 }
 
+pprocs() {
+    printf "Pulp Worker processes:\n"
+    ps ax | grep "pulp.server.async.app -c 1" | grep -v grep | awk '{ print $1 }'
+
+    printf "\nPulp Resource Manager processes:\n"
+    ps ax | grep "pulp.server.async.app -n resource_manager" | grep -v grep | awk '{ print $1 }'
+
+    printf "\nPulp Celerybeat processes:\n"
+    ps ax | grep "pulp.server.async.celery_instance.celery" | grep -v grep | awk '{ print $1 }'
+
+    printf "\nPulp WSGI processes:\n"
+    ps ax | grep "wsgi:pulp" | grep -v grep | awk '{ print $1 }'
+}
+
 export DJANGO_SETTINGS_MODULE=pulp.server.webservices.settings
 export CRANE_CONFIG_PATH=$HOME/devel/crane/crane.conf

--- a/playpen/ansible/roles/dev/files/motd
+++ b/playpen/ansible/roles/dev/files/motd
@@ -26,6 +26,7 @@ Here are some tips:
     psmash:    Run Pulp Smash!
     preset:    Reset Pulp to a clean install state
     ppopulate: Populate Pulp with test repositories of several types
+    pprocs:    List all Pulp-related process IDs
 
 * You can ssh into your vagrant environment with vagrant ssh, but presumably
   you already know this since you are reading this message :)


### PR DESCRIPTION
I can see this being useful if, for example, you could provide a PID to pdebug and immediately begin debugging that process via SIGTRAP. Maybe it's not the best implementation, though.