### PR TITLE
Add missing BooleanField import.

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -7,7 +7,7 @@ import uuid
 from collections import namedtuple
 from hmac import HMAC
 
-from mongoengine import (DictField, Document, DynamicField, IntField,
+from mongoengine import (BooleanField, DictField, Document, DynamicField, IntField,
                          ListField, StringField, UUIDField, ValidationError,
                          QuerySetNoCache)
 from mongoengine import signals


### PR DESCRIPTION
I somehow messed up this morning when I merged master into lazy-content. I thought I kept BooleanField in the import list, but apparently I did not.