### PR TITLE
Update Vagrant to use the nightly repository.

### DIFF
--- a/playpen/ansible/library/pulp_facts.py
+++ b/playpen/ansible/library/pulp_facts.py
@@ -8,17 +8,10 @@ import pwd
 import subprocess
 
 
-# Determine if the pulp-2.7-beta repository is enabled or not
-pipe = subprocess.Popen('/usr/bin/yum-config-manager pulp-2.7-beta', stdout=subprocess.PIPE,
+pipe = subprocess.Popen('/usr/bin/yum-config-manager pulp-nightlies', stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE, shell=True)
 stdout, stderr = pipe.communicate()
-pulp_27_beta_repo_enabled = 'enabled = True' in stdout
-
-# Determine if the fedora-23 repo is available yet
-proc = subprocess.Popen(
-    '/usr/bin/curl -s -f https://repos.fedorapeople.org/repos/pulp/pulp/beta/2.7/fedora-23/',
-    stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-pulp_27_beta_f23_repo_available = (proc.wait() == 0)
+pulp_nightly_repo_enabled = 'enabled = True' in stdout
 
 # Determine if selinux is Enforcing or not
 pipe = subprocess.Popen('/usr/sbin/getenforce', stdout=subprocess.PIPE,
@@ -60,8 +53,7 @@ rpm_dependency_list = list(set(rpm_dependency_list))
 # Build the facts for Ansible
 facts = {
     'ansible_facts': {
-        'pulp_27_beta_repo_enabled': pulp_27_beta_repo_enabled,
-        'pulp_27_beta_f23_repo_available': pulp_27_beta_f23_repo_available,
+        'pulp_nightly_repo_enabled': pulp_nightly_repo_enabled,
         'selinux_enabled': selinux_enabled,
         'pulp_rpm_dependencies': rpm_dependency_list,
     }

--- a/playpen/ansible/roles/dev/tasks/main.yml
+++ b/playpen/ansible/roles/dev/tasks/main.yml
@@ -16,19 +16,9 @@
       url: https://repos.fedorapeople.org/repos/pulp/pulp/fedora-pulp.repo
       dest: /etc/yum.repos.d/fedora-pulp.repo
 
-- name: Enable Pulp 2.7 beta repository
-  command: dnf config-manager --set-enabled pulp-2.7-beta
-  when: pulp_27_beta_repo_enabled == false
-
-# This and its related fact should go away when we do have an f23 build, since it'll be a noop at that point
-- name: Rejigger the repo file if fedora 23 builds aren't available
-  replace:
-      dest: /etc/yum.repos.d/fedora-pulp.repo
-      regexp: 'fedora-\$releasever'
-      replace: fedora-22
-  when: not pulp_27_beta_f23_repo_available and
-        ansible_distribution == 'Fedora' and
-        ansible_distribution_version == '23'
+- name: Enable Pulp Nightly repository
+  command: dnf config-manager --set-enabled pulp-nightlies
+  when: pulp_nightly_repo_enabled == false
 
 # These can go away when https://fedorahosted.org/spin-kickstarts/ticket/59 is fixed
 - stat:


### PR DESCRIPTION
Each night Jenkies re-builds Pulp and the dependencies we carry. Our
vagrant environment should pull from these (rather than a beta repo)
when on master.