### PR TITLE
Allow restriction of fields on Mongoengine documents

### DIFF
--- a/bindings/test/unit/test_search.py
+++ b/bindings/test/unit/test_search.py
@@ -1,8 +1,7 @@
-import unittest
-
 import mock
 
 from pulp.bindings.search import SearchAPI, Operator, IntOperator, CSVOperator
+from pulp.common.compat import unittest
 
 
 class TestSearchAPI(unittest.TestCase):

--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -247,10 +247,15 @@ class RepoSearch(search.SearchView):
         :return: processed results of the query
         :rtype:  list
         """
+        only = query.get('fields', [])
         results = list(search_method(query))
-        return _process_repos(results, options.get('details', False),
-                              options.get('importers', False),
-                              options.get('distributors', False))
+        results = _process_repos(results, options.get('details', False),
+                                 options.get('importers', False),
+                                 options.get('distributors', False))
+        if only:
+            only.extend(['importers', 'distributors'])
+            search._trim_results(cls.model, results, only)
+        return results
 
 
 class RepoUnitSearch(search.SearchView):

--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -245,11 +245,16 @@ class ModelSerializer(BaseSerializer):
         :return: the key that mongoengine uses to store this field in the database
         :rtype:  basestring
         """
-        for internal, external in self._remapped_fields.iteritems():
-            if external == field:
-                return getattr(model, internal).db_field
-        else:
-            return getattr(model, field).db_field
+        try:
+            for internal, external in self._remapped_fields.iteritems():
+                if external == field:
+                    return getattr(model, internal).db_field
+            else:
+                return getattr(model, field).db_field
+        except AttributeError:
+            raise exceptions.InvalidValue(
+                "Field: <{0}> does not exist on objects in the <{1}> collection".format(
+                    field, model._meta['collection']))
 
     def translate_criteria(self, model, crit):
         """


### PR DESCRIPTION
Remove unspecified, nonrequired key value pairs from serialized results
when searching by a criteria object that specifies `fields`.

Working on https://pulp.plan.io/issues/1332 I noticed 500s when specifying invalid fields. Fixing https://pulp.plan.io/issues/1417 made 1332 simpler to fix.