### PR TITLE
create_symlink now allows the creation of broken symlinks.

### DIFF
--- a/server/pulp/plugins/util/misc.py
+++ b/server/pulp/plugins/util/misc.py
@@ -80,20 +80,16 @@ def create_symlink(source_path, link_path, directory_permissions=0770):
 
     If we are overriding a current symlink with a new target - a debug message will be logged.
 
-    If a file already exists at the location specified by link_path an exception will be raised.
-
-    :param source_path: path of the source to link to
-    :type  source_path: str
-    :param link_path: path of the link
-    :type  link_path: str
+    :param source_path:           path of the source to link to
+    :type  source_path:           str
+    :param link_path:             path of the link
+    :type  link_path:             str
     :param directory_permissions: The permissions used to create any missing directories.
-           This defaults to 0770
-    :type directory_permissions: int
-    """
+                                  This defaults to 0770
+    :type  directory_permissions: int
 
-    if not os.path.exists(source_path):
-        msg = _('Will not create a symlink to a non-existent source [%(s)s]')
-        raise RuntimeError(msg % {'s': source_path})
+    :raise RuntimeError: If the link path exists and is not already a symbolic link
+    """
 
     if link_path.endswith('/'):
         link_path = link_path[:-1]

--- a/server/test/unit/plugins/util/test_misc.py
+++ b/server/test/unit/plugins/util/test_misc.py
@@ -171,17 +171,22 @@ class TestCreateSymlink(unittest.TestCase):
     def test_create_symlink(self):
         source_path = os.path.join(self.working_dir, 'source')
         link_path = os.path.join(self.published_dir, 'link')
-
         touch(source_path)
-        self.assertFalse(os.path.exists(link_path))
 
+        self.assertFalse(os.path.exists(link_path))
         misc.create_symlink(source_path, link_path)
+        self.assertTrue(os.path.exists(link_path))
 
     def test_create_symlink_no_source(self):
+        """Assert links are created, even if the source doesn't exist."""
         source_path = os.path.join(self.working_dir, 'source')
         link_path = os.path.join(self.published_dir, 'link')
 
-        self.assertRaises(RuntimeError, misc.create_symlink, source_path, link_path)
+        self.assertFalse(os.path.exists(source_path))
+        self.assertFalse(os.path.exists(link_path))
+        misc.create_symlink(source_path, link_path)
+        self.assertTrue(os.path.lexists(link_path))
+        self.assertFalse(os.path.exists(source_path))
 
     @patch('pulp.plugins.util.misc.os.symlink')
     @patch('pulp.plugins.util.misc.os.makedirs')


### PR DESCRIPTION
Previously, pulp.plugins.util.misc.create_symlink would not allow
creating a symlink to a file that did not exist. This is now possible.
This change was introduced because the lazy workflow creates symlinks
that are initially broken.

closes #1421