### PR TITLE
remove importer objects from tasks

### DIFF
--- a/server/pulp/server/controllers/distributor.py
+++ b/server/pulp/server/controllers/distributor.py
@@ -130,7 +130,7 @@ def delete(repo_id, dist_id):
 
     call_config = PluginCallConfiguration(plugin_config, distributor.config)
     repo = model.Repository.objects.get_repo_or_missing_resource(repo_id)
-    dist_instance.distributor_removed(repo.to_transfer_repo(), call_config)
+    dist_instance.distributor_removed(repo, call_config)
     distributor.delete()
 
     unbind_errors = []

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -272,7 +272,7 @@ def create_repo(repo_id, display_name=None, description=None, notes=None, import
     # Add the importer. Delete the repository if this fails.
     if importer_type_id is not None:
         try:
-            importer_controller.set_importer(repo, importer_type_id, importer_repo_plugin_config)
+            importer_controller.set_importer(repo_id, importer_type_id, importer_repo_plugin_config)
         except Exception:
             _logger.exception(
                 'Exception adding importer to repo [%s]; the repo will be deleted' % repo_id)
@@ -352,7 +352,7 @@ def delete(repo_id):
     # Inform all distributors
     for distributor in model.Distributor.objects(repo_id=repo_id):
         try:
-            dist_controller.delete(distributor)
+            dist_controller.delete(distributor.repo_id, distributor.distributor_id)
         except Exception, e:
             _logger.exception('Error received removing distributor [%s] from repo [%s]' % (
                 distributor.id, repo_id))

--- a/server/test/unit/plugins/conduits/test_repo_sync.py
+++ b/server/test/unit/plugins/conduits/test_repo_sync.py
@@ -42,7 +42,7 @@ class RepoSyncConduitTests(base.PulpServerTests):
         self.content_manager = content_manager.ContentManager()
         self.query_manager = query_manager.ContentQueryManager()
 
-        importer_controller.set_importer(mock.MagicMock(repo_id='repo-1'), 'mock-importer', {})
+        importer_controller.set_importer('repo-1', 'mock-importer', {})
         self.conduit = RepoSyncConduit('repo-1', 'test-importer')
 
     def tearDown(self):

--- a/server/test/unit/server/controllers/test_distributor.py
+++ b/server/test/unit/server/controllers/test_distributor.py
@@ -202,7 +202,7 @@ class TestDelete(unittest.TestCase):
 
         m_repo_pub_sched_man.delete_by_distributor_id.assert_called_once_with('rid', 'did')
         m_dist_inst.distributor_removed.assert_called_once_with(
-            m_repo_obj.to_transfer_repo.return_value, m_plug_call_conf.return_value)
+            m_repo_obj, m_plug_call_conf.return_value)
         m_dist_qs.get_or_404.return_value.delete.assert_called_once_with()
         m_task.assert_called_once_with(error=None, spawned_tasks=[])
         self.assertTrue(result is m_task.return_value)

--- a/server/test/unit/server/controllers/test_importer.py
+++ b/server/test/unit/server/controllers/test_importer.py
@@ -62,10 +62,10 @@ class TestSetImporter(unittest.TestCase):
         mock_plugin_config = mock.MagicMock()
         m_plug_api.get_importer_by_id.return_value = (mock_imp_inst, mock_plugin_config)
 
-        result = importer.set_importer(mock_repo, 'mtype', 'm_conf')
+        result = importer.set_importer('mrepo', 'mtype', 'm_conf')
         m_clean.assert_called_once_with('m_conf')
         mock_plug_call_config.assert_called_once_with(mock_plugin_config, m_clean.return_value)
-        mock_remove.assert_called_once_with(mock_repo.repo_id)
+        mock_remove.assert_called_once_with('mrepo')
         mock_imp_inst.importer_added.assert_called_once_with(mock_repo.to_transfer_repo(),
                                                              mock_call_config)
         mock_importer.save.assert_called_once_with()
@@ -83,8 +83,8 @@ class TestSetImporter(unittest.TestCase):
         mock_plugin_config = mock.MagicMock()
         m_plug_api.get_importer_by_id.return_value = (mock_imp_inst, mock_plugin_config)
 
-        result = importer.set_importer(mock_repo, 'mtype', 'm_conf')
-        mock_remove.assert_called_once_with(mock_repo.repo_id)
+        result = importer.set_importer('mrepo', 'mtype', 'm_conf')
+        mock_remove.assert_called_once_with('mrepo')
         mock_imp_inst.importer_added.assert_called_once_with(mock_repo.to_transfer_repo(),
                                                              mock_call_config)
         m_clean.assert_called_once_with('m_conf')
@@ -105,9 +105,9 @@ class TestSetImporter(unittest.TestCase):
         mock_plugin_config = mock.MagicMock()
         m_plug_api.get_importer_by_id.return_value = (mock_imp_inst, mock_plugin_config)
 
-        self.assertRaises(exceptions.InvalidValue, importer.set_importer, mrepo, 'mtype', 'mconf')
+        self.assertRaises(exceptions.InvalidValue, importer.set_importer, 'mrepo', 'mtype', 'mconf')
         m_clean.assert_called_once_with('mconf')
-        mock_remove.assert_called_once_with(mrepo.repo_id)
+        mock_remove.assert_called_once_with('mrepo')
         mock_imp_inst.importer_added.assert_called_once_with(mrepo.to_transfer_repo(),
                                                              mock_call_config)
         mock_plug_call_config.assert_called_once_with(mock_plugin_config, m_clean.return_value)
@@ -167,7 +167,7 @@ class TestQueueSetImporter(unittest.TestCase):
         result = importer.queue_set_importer(repo, 'm_type', 'm_conf')
         m_task_tags = [m_tags.resource_tag.return_value, m_tags.action_tag.return_value]
         m_set.apply_async_with_reservation.assert_called_once_with(
-            m_tags.RESOURCE_REPOSITORY_TYPE, 'm_id', [repo, 'm_type'],
+            m_tags.RESOURCE_REPOSITORY_TYPE, 'm_id', ['m_id', 'm_type'],
             {'repo_plugin_config': 'm_conf'}, tags=m_task_tags)
         self.assertTrue(result is m_set.apply_async_with_reservation.return_value)
 

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -328,8 +328,7 @@ class TestCreateRepo(unittest.TestCase):
         """
         repo = repo_controller.create_repo('m_repo', importer_type_id='mock_type',
                                            importer_repo_plugin_config='mock_config')
-        m_imp_ctrl.set_importer.assert_called_once_with(m_repo_model.return_value, 'mock_type',
-                                                        'mock_config')
+        m_imp_ctrl.set_importer.assert_called_once_with('m_repo', 'mock_type', 'mock_config')
         self.assertTrue(repo is m_repo_model.return_value)
         self.assertEqual(repo.delete.call_count, 0)
 
@@ -338,12 +337,11 @@ class TestCreateRepo(unittest.TestCase):
         """
         Test creation of a repository when the importer configuration fails.
         """
-        repo_inst = m_repo_model.return_value
         m_imp_ctrl.set_importer.side_effect = MockException
         repo_inst = m_repo_model.return_value
         self.assertRaises(MockException, repo_controller.create_repo, 'm_repo',
                           importer_type_id='id', importer_repo_plugin_config='mock_config')
-        m_imp_ctrl.set_importer.assert_called_once_with(repo_inst, 'id', 'mock_config')
+        m_imp_ctrl.set_importer.assert_called_once_with('m_repo', 'id', 'mock_config')
         self.assertEqual(repo_inst.delete.call_count, 1)
 
     def test_create_with_distributor_list_not_list(self, m_repo_model, m_factory, m_imp_ctrl,
@@ -465,7 +463,7 @@ class TestDelete(unittest.TestCase):
         m_repo.delete.assert_called_once_with()
         pymongo_args = {'repo_id': 'foo-repo'}
         pymongo_kwargs = {'safe': True}
-        m_dist_ctrl.delete.assert_called_once_with(m_dist)
+        m_dist_ctrl.delete.assert_called_once_with(m_dist.repo_id, m_dist.distributor_id)
         m_model.Distributor.objects.return_value.delete.assert_called_once_with()
         m_model.Importer.objects.return_value.delete.assert_called_once_with()
         m_sync.get_collection().remove.assert_called_once_with(pymongo_args, **pymongo_kwargs)

--- a/server/test/unit/server/managers/content/test_upload.py
+++ b/server/test/unit/server/managers/content/test_upload.py
@@ -143,7 +143,7 @@ class ContentUploadManagerTests(base.PulpServerTests):
 
     @mock.patch('pulp.server.controllers.importer.model.Repository.objects')
     def test_is_valid_upload(self, mock_repo_qs):
-        importer_controller.set_importer(mock.MagicMock(repo_id='repo-u'), 'mock-importer', {})
+        importer_controller.set_importer('repo-u', 'mock-importer', {})
         valid = self.upload_manager.is_valid_upload('repo-u', 'mock-type')
         self.assertTrue(valid)
 
@@ -155,14 +155,14 @@ class ContentUploadManagerTests(base.PulpServerTests):
 
     @mock.patch('pulp.server.controllers.importer.model.Repository.objects')
     def test_is_valid_upload_unsupported_type(self, mock_repo_qs):
-        importer_controller.set_importer(mock.MagicMock(repo_id='repo-u'), 'mock-importer', {})
+        importer_controller.set_importer('repo-u', 'mock-importer', {})
         # Test
         self.assertRaises(PulpDataException, self.upload_manager.is_valid_upload, 'repo-u',
                           'fake-type')
 
     @mock.patch('pulp.server.controllers.importer.model.Repository.objects')
     def test_import_uploaded_unit(self, mock_repo_qs):
-        importer_controller.set_importer(mock.MagicMock(repo_id='repo-u'), 'mock-importer', {})
+        importer_controller.set_importer('repo-u', 'mock-importer', {})
 
         key = {'key': 'value'}
         metadata = {'k1': 'v1'}
@@ -205,7 +205,7 @@ class ContentUploadManagerTests(base.PulpServerTests):
 
     @mock.patch('pulp.server.controllers.importer.model.Repository.objects')
     def test_import_uploaded_unit_importer_error(self, mock_repo_qs):
-        importer_controller.set_importer(mock.MagicMock(repo_id='repo-u'), 'mock-importer', {})
+        importer_controller.set_importer('repo-u', 'mock-importer', {})
         mock_plugins.MOCK_IMPORTER.upload_unit.side_effect = Exception()
         upload_id = self.upload_manager.initialize_upload()
         self.assertRaises(PulpExecutionException, self.upload_manager.import_uploaded_unit,
@@ -213,7 +213,7 @@ class ContentUploadManagerTests(base.PulpServerTests):
 
     @mock.patch('pulp.server.controllers.importer.model.Repository.objects')
     def test_import_uploaded_unit_importer_error_reraise_pulp_exception(self, mock_repo_qs):
-        importer_controller.set_importer(mock.MagicMock(repo_id='repo-u'), 'mock-importer', {})
+        importer_controller.set_importer('repo-u', 'mock-importer', {})
         mock_plugins.MOCK_IMPORTER.upload_unit.side_effect = InvalidValue(['filename'])
         upload_id = self.upload_manager.initialize_upload()
         self.assertRaises(InvalidValue, self.upload_manager.import_uploaded_unit, 'repo-u',


### PR DESCRIPTION
Distributors/importers conversion mixed with recent serialization work caused some problems. This removes passing importer objects through the tasking system. Additionally, recent changes to the distributor controller mean that it should be passing a model.Repository object to the plugin instead of a repo transfer unit.