### PR TITLE
Fix the crane permissions in the preset command.

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -43,11 +43,10 @@ preset() {
     if [ -d $HOME/devel/crane ]; then
         pushd $HOME/devel/crane
         mkdir -p metadata/v1 metadata/v2
-        sudo mkdir -p /var/lib/pulp/published/docker/v1 /var/lib/pulp/published/docker/v2
-        sudo chown apache:apache /var/lib/pulp/published/docker/v1
-        sudo chown apache:apache /var/lib/pulp/published/docker/v2
-        sudo ln -s $HOME/devel/crane/metadata/v1 /var/lib/pulp/published/docker/v1/app
-        sudo ln -s $HOME/devel/crane/metadata/v2 /var/lib/pulp/published/docker/v2/app
+        setfacl -m u:apache:rwx metadata/*
+        sudo -u apache mkdir -p /var/lib/pulp/published/docker/v1 /var/lib/pulp/published/docker/v2
+        sudo -u apache ln -s $HOME/devel/crane/metadata/v1 /var/lib/pulp/published/docker/v1/app
+        sudo -u apache ln -s $HOME/devel/crane/metadata/v2 /var/lib/pulp/published/docker/v2/app
         popd
     fi
     pstart;


### PR DESCRIPTION
The recent move of the Crane building from the vagrant-setup.sh to the development .bashrc file caused some
permissions in the resulting environment to disallow pulp_docker from publishing into Crane. This commit fixes that
issue.