### PR TITLE
distributors should be passed a transfer repo, not a repo_obj

### DIFF
--- a/server/pulp/server/controllers/distributor.py
+++ b/server/pulp/server/controllers/distributor.py
@@ -130,7 +130,7 @@ def delete(repo_id, dist_id):
 
     call_config = PluginCallConfiguration(plugin_config, distributor.config)
     repo = model.Repository.objects.get_repo_or_missing_resource(repo_id)
-    dist_instance.distributor_removed(repo, call_config)
+    dist_instance.distributor_removed(repo.to_transfer_repo(), call_config)
     distributor.delete()
 
     unbind_errors = []

--- a/server/test/unit/server/controllers/test_distributor.py
+++ b/server/test/unit/server/controllers/test_distributor.py
@@ -202,7 +202,7 @@ class TestDelete(unittest.TestCase):
 
         m_repo_pub_sched_man.delete_by_distributor_id.assert_called_once_with('rid', 'did')
         m_dist_inst.distributor_removed.assert_called_once_with(
-            m_repo_obj, m_plug_call_conf.return_value)
+            m_repo_obj.to_transfer_repo.return_value, m_plug_call_conf.return_value)
         m_dist_qs.get_or_404.return_value.delete.assert_called_once_with()
         m_task.assert_called_once_with(error=None, spawned_tasks=[])
         self.assertTrue(result is m_task.return_value)


### PR DESCRIPTION
I changed this line to fix a smash test yesterday. The iso distributor was expecting a repo object, not a transfer object. However, it turned out to be that the iso plugin was incorrect, not core.