### PR TITLE
Fix unit test failures on EL5/6 for lazy-content.

### DIFF
--- a/client_lib/pulp/client/commands/repo/importer_config.py
+++ b/client_lib/pulp/client/commands/repo/importer_config.py
@@ -98,10 +98,10 @@ class OptionsBundle(object):
             parse_func=parsers.pulp_parse_optional_nonnegative_int
         )
 
-        d = _('content downloading policy ({m})'.format(
-            m=' | '.join((constants.DOWNLOAD_IMMEDIATE,
-                          constants.DOWNLOAD_BACKGROUND,
-                          constants.DOWNLOAD_ON_DEMAND))))
+        methods = ' | '.join((constants.DOWNLOAD_IMMEDIATE,
+                              constants.DOWNLOAD_BACKGROUND,
+                              constants.DOWNLOAD_ON_DEMAND))
+        d = _('content downloading policy (%(method)s)' % {'method': methods})
         self.opt_download_policy = PulpCliOption(
             '--download-policy',
             d,

--- a/streamer/test/unit/streamer/test_config.py
+++ b/streamer/test/unit/streamer/test_config.py
@@ -1,11 +1,10 @@
-from unittest import TestCase
-
 from mock import Mock, patch, call
 
 from pulp.streamer.config import load_configuration, DEFAULT_VALUES
+from pulp.common.compat import unittest
 
 
-class TestConfig(TestCase):
+class TestConfig(unittest.TestCase):
 
     @patch('pulp.streamer.config.SafeConfigParser')
     def test_load_configuration(self, mock_parser_class):

--- a/streamer/test/unit/streamer/test_server.py
+++ b/streamer/test/unit/streamer/test_server.py
@@ -1,10 +1,10 @@
 from httplib import INTERNAL_SERVER_ERROR, NOT_FOUND
-from unittest import TestCase
 
 from mock import Mock, patch
 from mongoengine import NotUniqueError
 from twisted.web.server import Request
 
+from pulp.common.compat import unittest
 from pulp.plugins.loader.exceptions import PluginNotFound
 from pulp.server.constants import PULP_STREAM_REQUEST_HEADER
 from pulp.streamer import Responder, StreamerListener, Streamer
@@ -13,7 +13,7 @@ from pulp.streamer import Responder, StreamerListener, Streamer
 MODULE_PREFIX = 'pulp.streamer.server.'
 
 
-class TestStreamerListener(TestCase):
+class TestStreamerListener(unittest.TestCase):
 
     def test_download_headers(self):
         """
@@ -51,7 +51,7 @@ class TestStreamerListener(TestCase):
         listener.request.setResponseCode.assert_called_once_with('418')
 
 
-class TestStreamer(TestCase):
+class TestStreamer(unittest.TestCase):
 
     def setUp(self):
         self.config = Mock()
@@ -205,7 +205,7 @@ class TestStreamer(TestCase):
         self.assertEqual(0, mock_deferred_download.return_value.save.call_count)
 
 
-class TestResponder(TestCase):
+class TestResponder(unittest.TestCase):
 
     def test_enter(self):
         """


### PR DESCRIPTION
Several unit tests are failing on lazy-content due to features missing
from Python 2.4 or 2.6.