### PR TITLE
fix regex to remove content and empty directories on orphan cleanup

### DIFF
--- a/playpen/cleanup/remove_orphaned_dirs.py
+++ b/playpen/cleanup/remove_orphaned_dirs.py
@@ -1,0 +1,47 @@
+"""
+This script removes empty directory structure from the pulp content directory. This is intended
+to clean up incomplete orphan removal that was present in Pulp < 2.8.0. The script will need to be
+run as the `apache` user.
+"""
+import os
+import re
+
+from pulp.server import config as pulp_config
+
+
+storage_dir = pulp_config.config.get('server', 'storage_dir')
+content_dir = os.path.join(storage_dir, 'content')
+root_content_regex = re.compile(os.path.join(storage_dir, 'content', '[^/]+/?$'))
+
+
+def rm_dir_leaf(path):
+    """
+    Removes an empty directory (leaf). If this call produces a new leaf, it will also be removed.
+
+    Guarantees that path that is passed and all of its subpaths (down to one level up from the
+    content directory) are not leafs or removed.
+
+    :param path: a directory to be removed if it is a leaf
+    :type  path: basestring
+    :param basedir: directory that contains all content, should remain even if empty
+    :type  basedir: basestring
+    """
+    if root_content_regex.match(path):
+        return
+    contents = os.listdir(path)
+    if contents:
+        return
+    if not os.access(path, os.W_OK):
+        return
+    os.rmdir(path)
+
+    path = os.path.dirname(path)
+    print "Removed empty dir: {0}".format(path)
+    rm_dir_leaf(path)
+
+
+if __name__ == "__main__":
+
+    for path, subdirs, files in os.walk(content_dir, topdown=False):
+        if not (subdirs or files):
+            rm_dir_leaf(path)

--- a/server/pulp/server/managers/content/orphan.py
+++ b/server/pulp/server/managers/content/orphan.py
@@ -302,7 +302,7 @@ class OrphanManager(object):
         OrphanManager.delete(path)
 
         # delete parent directories on the path as long as they fall empty
-        root_content_regex = re.compile(os.path.join(storage_dir, 'content', '[^/]+/?'))
+        root_content_regex = re.compile(os.path.join(storage_dir, 'content', '[^/]+/?$'))
         while True:
             path = os.path.dirname(path)
             if root_content_regex.match(path):


### PR DESCRIPTION
https://pulp.plan.io/issues/1238

This also adds a script into playpen that can be run to manually clean up any remaining directories that were left behind by orphan cleanup in pulp < 2.8.0