### PR TITLE
Fix 'Unknown OpenSSL error' unit test failure on F23.

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -37,8 +37,8 @@ TESTS_ALL_PLATFORMS = [
 TESTS_NON_RHEL5 = [
     'client_admin/test/unit',
     'nodes/test/nodes_tests',
-    'server/test/unit',
     'streamer/test/unit',
+    'server/test/unit',
     'repoauth/test',
     'oid_validation/test',
     'devel/test/unit'


### PR DESCRIPTION
Unit tests for the streamer are failing because one or more unit tests
in `server` are making use of OpenSSL and failing to clean the error
stack. This is probably a bug in M2Crypto. This commit simply ensures
the streamer tests run before the server tests.