### PR TITLE
Update Repository Units from platform

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -749,6 +749,8 @@ def sync(repo_id, sync_config_override=None, scheduled_call_id=None):
         model.Importer.objects(repo_id=repo_obj.repo_id).update(set__last_sync=sync_end_timestamp)
         # Add a sync history entry for this run
         sync_result_collection.save(sync_result, safe=True)
+        # Ensure counts are updated
+        rebuild_content_unit_counts(repo_obj)
 
     fire_manager.fire_repo_sync_finished(sync_result)
     if sync_result.result == RepoSyncResult.RESULT_FAILED:

--- a/server/pulp/server/managers/content/upload.py
+++ b/server/pulp/server/managers/content/upload.py
@@ -15,6 +15,7 @@ from pulp.server.async.tasks import Task
 from pulp.server.db import model
 from pulp.server.exceptions import (PulpDataException, MissingResource, PulpExecutionException,
                                     PulpException)
+from pulp.server.controllers import repository as repo_controller
 
 
 logger = logging.getLogger(__name__)
@@ -204,8 +205,11 @@ class ContentUploadManager(object):
 
         # Invoke the importer
         try:
-            return importer_instance.upload_unit(transfer_repo, unit_type_id, unit_key,
-                                                 unit_metadata, file_path, conduit, call_config)
+            result = importer_instance.upload_unit(transfer_repo, unit_type_id, unit_key,
+                                                   unit_metadata, file_path, conduit, call_config)
+            repo_controller.rebuild_content_unit_counts(repo_obj)
+            return result
+
         except PulpException:
             msg = _('Error from the importer while importing uploaded unit to repository [%(r)s]')
             msg = msg % {'r': repo_id}

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -784,6 +784,7 @@ class TestUpdateLastUnitRemoved(unittest.TestCase):
         m_repo.save.assert_called_once_with()
 
 
+@mock.patch('pulp.server.controllers.repository.rebuild_content_unit_counts')
 @mock.patch('pulp.server.controllers.repository.sys')
 @mock.patch('pulp.server.controllers.repository.register_sigterm_handler')
 @mock.patch('pulp.server.controllers.repository._now_timestamp')
@@ -808,7 +809,7 @@ class TestSync(unittest.TestCase):
 
     def test_sync_sigterm_error(self, m_model, mock_plugin_api,
                                 mock_plug_conf, mock_wd, mock_conduit, mock_result, m_factory,
-                                mock_now, mock_reg_sig, mock_sys):
+                                mock_now, mock_reg_sig, mock_sys, mock_rebuild):
         """
         An error_result should be built when there is an error with the sigterm handler.
         """
@@ -828,11 +829,14 @@ class TestSync(unittest.TestCase):
         sync_func.assert_called_once_with(m_repo.to_transfer_repo(), mock_conduit(),
                                           mock_plug_conf())
 
+        # It is now platform's responsiblity to update plugin content unit counts
+        self.assertTrue(mock_rebuild.called, "rebuild_content_unit_counts must be called")
+
     @mock.patch('pulp.server.controllers.repository._queue_auto_publish_tasks')
     @mock.patch('pulp.server.controllers.repository.TaskResult')
     def test_sync_canceled(self, m_task_result, mock_spawn_auto_pub, m_model,
                            mock_plugin_api, mock_plug_conf, mock_wd, mock_conduit, mock_result,
-                           m_factory, mock_now, mock_reg_sig, mock_sys):
+                           m_factory, mock_now, mock_reg_sig, mock_sys, mock_rebuild):
         """
         Test the behavior of sync when the task is canceled.
         """
@@ -865,12 +869,15 @@ class TestSync(unittest.TestCase):
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
         self.assertTrue(actual_result is m_task_result.return_value)
 
+        # It is now platform's responsiblity to update plugin content unit counts
+        self.assertTrue(mock_rebuild.called, "rebuild_content_unit_counts must be called")
+
     @mock.patch('pulp.server.controllers.repository._queue_auto_publish_tasks')
     @mock.patch('pulp.server.controllers.repository.TaskResult')
     def test_sync_success(self, m_task_result, mock_spawn_auto_pub, m_model,
                           mock_plugin_api, mock_plug_conf, mock_wd,
                           mock_conduit, mock_result, m_factory, mock_now, mock_reg_sig,
-                          mock_sys):
+                          mock_sys, mock_rebuild):
         """
         Test repository sync when everything works as expected.
         """
@@ -905,10 +912,13 @@ class TestSync(unittest.TestCase):
         self.assertEqual(mock_imp_inst.id, mock_conduit.call_args_list[0][0][2])
         self.assertTrue(actual_result is m_task_result.return_value)
 
+        # It is now platform's responsiblity to update plugin content unit counts
+        self.assertTrue(mock_rebuild.called, "rebuild_content_unit_counts must be called")
+
     @mock.patch('pulp.server.controllers.repository.TaskResult')
     def test_sync_failed(self, m_task_result, m_model, mock_plugin_api, mock_plug_conf,
                          mock_wd, mock_conduit, mock_result, m_factory, mock_now, mock_reg_sig,
-                         mock_sys):
+                         mock_sys, mock_rebuild):
         """
         Test repository sync when the result is failure.
         """
@@ -941,6 +951,9 @@ class TestSync(unittest.TestCase):
                                                                   safe=True)
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
 
+        # It is now platform's responsiblity to update plugin content unit counts
+        self.assertTrue(mock_rebuild.called, "rebuild_content_unit_counts must be called")
+
     @mock.patch('pulp.server.controllers.repository._queue_auto_publish_tasks')
     @mock.patch('pulp.server.controllers.repository._')
     @mock.patch('pulp.server.controllers.repository._logger')
@@ -948,7 +961,7 @@ class TestSync(unittest.TestCase):
     def test_sync_invalid_sync_report(self, m_task_result, mock_logger, mock_gettext,
                                       mock_spawn_auto_pub, m_model, mock_plugin_api,
                                       mock_plug_conf, mock_wd, mock_conduit, mock_result,
-                                      m_factory, mock_now, mock_reg_sig, mock_sys):
+                                      m_factory, mock_now, mock_reg_sig, mock_sys, mock_rebuild):
         """
         Test repository sync when the sync report is not valid.
         """
@@ -973,6 +986,9 @@ class TestSync(unittest.TestCase):
                                                                   safe=True)
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
         self.assertTrue(result is m_task_result.return_value)
+
+        # It is now platform's responsiblity to update plugin content unit counts
+        self.assertTrue(mock_rebuild.called, "rebuild_content_unit_counts must be called")
 
 
 @mock.patch('pulp.server.controllers.repository.model.Distributor.objects')

--- a/server/test/unit/server/managers/content/test_upload.py
+++ b/server/test/unit/server/managers/content/test_upload.py
@@ -160,8 +160,9 @@ class ContentUploadManagerTests(base.PulpServerTests):
         self.assertRaises(PulpDataException, self.upload_manager.is_valid_upload, 'repo-u',
                           'fake-type')
 
+    @mock.patch('pulp.server.controllers.repository.rebuild_content_unit_counts')
     @mock.patch('pulp.server.controllers.importer.model.Repository.objects')
-    def test_import_uploaded_unit(self, mock_repo_qs):
+    def test_import_uploaded_unit(self, mock_repo_qs, mock_rebuild):
         importer_controller.set_importer('repo-u', 'mock-importer', {})
 
         key = {'key': 'value'}
@@ -193,6 +194,9 @@ class ContentUploadManagerTests(base.PulpServerTests):
         conduit = call_args[5]
         self.assertTrue(isinstance(conduit, UploadConduit))
         self.assertEqual(call_args[5].repo_id, 'repo-u')
+
+        # It is now platform's responsiblity to update plugin content unit counts
+        self.assertTrue(mock_rebuild.called, "rebuild_content_unit_counts must be called")
 
         # Clean up
         mock_plugins.MOCK_IMPORTER.upload_unit.return_value = None


### PR DESCRIPTION
Updating repository units from platform, due to them
not being reliably updated by plugins.  The code to do
this lives in platform, so we should be able to utilize it
from there

https://pulp.plan.io/issues/1467
re #[1467](https://pulp.plan.io/issues/1467)