### PR TITLE
Add a new REST API endpoint to download lazy repositories.

### DIFF
--- a/bindings/pulp/bindings/repository.py
+++ b/bindings/pulp/bindings/repository.py
@@ -367,15 +367,33 @@ class RepositoryActionsAPI(PulpAPI):
         return self.server.POST(path, data)
 
     def publish(self, repo_id, distributor_id, override_config):
-        path = self.base_path % repo_id + "/publish/"
+        path = self.base_path % repo_id + "publish/"
         data = {'id': distributor_id,
                 'override_config': override_config}
         return self.server.POST(path, data)
 
     def associate(self, repo_id, source_repo_id):
-        path = self.base_path % repo_id + "/associate/"
+        path = self.base_path % repo_id + "associate/"
         data = {'source_repo_id': source_repo_id}
         return self.server.POST(path, data)
+
+    def download(self, repo_id, verify_all_units=False):
+        """
+        Dispatch a task to download all ContentUnits for the given repository
+        that are not already downloaded. This is intended for repositories using
+        the ``background`` or ``on_demand`` download strategies.
+
+        :param repo_id:          the repository id to dispatch the task for.
+        :type  repo_id:          str
+        :param verify_all_units: verify all unit files in the repo if true. See
+                                 the API documentation for more information.
+        :type  verify_all_units: bool
+
+        :return: Response object
+        :rtype:  pulp.bindings.responses.Response
+        """
+        path = self.base_path % repo_id + 'download/'
+        return self.server.POST(path, {'verify_all_units': verify_all_units})
 
 
 class RepositoryUnitAPI(PulpAPI):

--- a/client_admin/pulp/client/admin/repo.py
+++ b/client_admin/pulp/client/admin/repo.py
@@ -3,6 +3,8 @@ from gettext import gettext as _
 from pulp.client.commands.repo import cudl as repo_commands
 from pulp.client.commands.repo import group as group_commands
 from pulp.client.commands.repo import history as history_commands
+from pulp.client.commands.repo.status import PublishStepStatusRenderer
+from pulp.client.commands.repo.sync_publish import DownloadRepositoryCommand
 from pulp.client.extensions.extensions import PulpCliSection
 
 
@@ -24,6 +26,7 @@ class RepoSection(PulpCliSection):
         self.prompt = context.prompt  # for easier access
 
         self.add_command(repo_commands.ListRepositoriesCommand(context, include_all_flag=False))
+        self.add_command(DownloadRepositoryCommand(context, PublishStepStatusRenderer(context)))
 
         # Subsections
         self.add_subsection(RepoGroupSection(context))

--- a/docs/dev-guide/integration/rest-api/repo/sync.rst
+++ b/docs/dev-guide/integration/rest-api/repo/sync.rst
@@ -33,6 +33,45 @@ The task created will have the following tags:
 ``"pulp:action:sync", "pulp:repository:<repo_id>"``
 
 
+Download a Repository
+---------------------
+
+Downloads content into a repository that was deferred at sync time. This is useful for
+repositories with importers that are configured with ``download_policy=(background | on_demand)``.
+Content that has already been downloaded will not be downloaded again.
+
+.. note::
+  This API requires that the :ref:`deferred downloading` features must be installed
+  and configured to work. If it has not been configured, the task dispatched by this
+  API does nothing.
+
+| :method:`post`
+| :path:`/v2/repositories/<repo_id>/actions/download/`
+| :permission:`execute`
+| :param_list:`post`
+
+* :param:`?verify_all_units,boolean,check all units in the repository for corrupted or
+  missing files and re-download files as necessary rather than just downloading files
+  that are known to be missing (defaults to false)`
+
+| :response_list:`_`
+
+* :response_code:`202,if the download is set to be executed`
+* :response_code:`404,if the repository does not exist`
+
+| :return:`a` :ref:`call_report`
+
+:sample_request:`_` ::
+
+ {
+   "verify_all_units": false
+ }
+
+**Tags:**
+The task created will have the following tags:
+``"pulp:action:download_repo", "pulp:repository:<repo_id>"``
+
+
 Scheduling a Sync
 -----------------
 A repository can be synced automatically using an :term:`iso8601 interval`.

--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -68,7 +68,8 @@ from pulp.server.webservices.views.repositories import(
     RepoDistributorsView, RepoAssociate, RepoImporterResourceView, RepoImportersView,
     RepoImportUpload, RepoPublish, RepoPublishHistory, RepoPublishScheduleResourceView,
     RepoPublishSchedulesView, RepoResourceView, RepoSearch, RepoSync, RepoSyncHistory,
-    RepoSyncSchedulesView, RepoSyncScheduleResourceView, RepoUnassociate, RepoUnitSearch, ReposView,
+    RepoSyncSchedulesView, RepoSyncScheduleResourceView, RepoUnassociate, RepoUnitSearch,
+    ReposView, RepoDownload
 )
 from pulp.server.webservices.views.roles import (RoleResourceView, RoleUserView, RoleUsersView,
                                                  RolesView)
@@ -232,6 +233,8 @@ urlpatterns = patterns(
         name='repo_sync'),
     url(r'^v2/repositories/(?P<repo_id>[^/]+)/actions/publish/$', RepoPublish.as_view(),
         name='repo_publish'),
+    url(r'^v2/repositories/(?P<repo_id>[^/]+)/actions/download/$', RepoDownload.as_view(),
+        name='repo_download'),
     url(r'^v2/repositories/(?P<dest_repo_id>[^/]+)/actions/associate/$', RepoAssociate.as_view(),
         name='repo_associate'),
     url(r'^v2/repositories/(?P<repo_id>[^/]+)/actions/unassociate/$', RepoUnassociate.as_view(),

--- a/server/test/unit/server/webservices/test_urls.py
+++ b/server/test/unit/server/webservices/test_urls.py
@@ -441,6 +441,14 @@ class TestDjangoRepositoriesUrls(unittest.TestCase):
         url_name = 'repo_sync'
         assert_url_match(url, url_name, repo_id='mock_repo')
 
+    def test_match_repo_download(self):
+        """
+        Test url matching for repo_download.
+        """
+        url = '/v2/repositories/mock_repo/actions/download/'
+        url_name = 'repo_download'
+        assert_url_match(url, url_name, repo_id='mock_repo')
+
     def test_match_repo_publish_history(self):
         """
         Test url matching for repo_publish_history.


### PR DESCRIPTION
This new API is located at ``v2/repositories/<repo-id>/actions/download/``.
This commit also adds support for this API in pulp-admin.

closes #1355