### PR TITLE
Update the lazy download tasks to correctly skip existing files.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -356,7 +356,7 @@ Requires: python-oauth2 >= 1.5.211
 Requires: python-httplib2
 Requires: python-isodate >= 0.5.0-1.pulp
 Requires: python-qpid
-Requires: python-nectar >= 1.1.6
+Requires: python-nectar >= 1.4.3
 Requires: python-semantic_version >= 2.2.0
 Requires: httpd
 Requires: mod_ssl


### PR DESCRIPTION
Prior to this commit, the ``download_started`` method attempted to raise
an exception to stop downloading a file that already existed on disk.

This assumes that https://github.com/pulp/nectar/pull/38 is part of the 1.4.3 release of Nectar.