### PR TITLE
content unit search views use content unit serializers

### DIFF
--- a/nodes/parent/pulp_node/distributors/http/distributor.py
+++ b/nodes/parent/pulp_node/distributors/http/distributor.py
@@ -253,7 +253,7 @@ class NodesHttpDistributor(Distributor):
         for dist in model.Distributor.objects(repo_id=repo_id):
             if dist.distributor_type_id in constants.ALL_DISTRIBUTORS:
                 continue
-            serialized = model.Distributor.serializer(dist).data
+            serialized = model.Distributor.SERIALIZER(dist).data
             serialized.pop('_href')
             distributors.append(serialized)
         payload['distributors'] = distributors

--- a/server/pulp/server/controllers/importer.py
+++ b/server/pulp/server/controllers/importer.py
@@ -258,7 +258,7 @@ def update_importer_config(repo_id, importer_config):
     except ValidationError, e:
         raise exceptions.InvalidValue(e.to_dict().keys())
 
-    serialized = model.Importer.serializer(repo_importer).data
+    serialized = model.Importer.SERIALIZER(repo_importer).data
     return serialized
 
 

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -126,7 +126,7 @@ class Repository(AutoRetryDocument):
             'allow_inheritance': False,
             'indexes': [{'fields': ['-repo_id'], 'unique': True}],
             'queryset_class': RepoQuerySet}
-    serializer = serializers.Repository
+    SERIALIZER = serializers.Repository
 
     def to_transfer_repo(self):
         """
@@ -231,7 +231,7 @@ class Importer(AutoRetryDocument):
 
     # For backward compatibility
     _ns = StringField(default='repo_importers')
-    serializer = serializers.ImporterSerializer
+    SERIALIZER = serializers.ImporterSerializer
 
     meta = {'collection': 'repo_importers',
             'allow_inheritance': False,
@@ -966,7 +966,7 @@ class User(AutoRetryDocument):
             'indexes': ['-roles', {'fields': ['-login', '-name'], 'unique': True}],
             'queryset_class': CriteriaQuerySet}
 
-    serializer = serializers.User
+    SERIALIZER = serializers.User
 
     def is_superuser(self):
         """
@@ -1069,7 +1069,7 @@ class Distributor(AutoRetryDocument):
     scratchpad = DictField()
 
     _ns = StringField(default='repo_distributors')
-    serializer = serializers.Distributor
+    SERIALIZER = serializers.Distributor
 
     meta = {'collection': 'repo_distributors',
             'allow_inheritance': False,

--- a/server/pulp/server/db/model/dispatch.py
+++ b/server/pulp/server/db/model/dispatch.py
@@ -205,7 +205,7 @@ class ScheduledCall(Model):
         # If principal is a User object, serialize it. If it does not have a serializer, it is
         # a SystemUser which is already a dict.
         try:
-            serial_principal = self.principal.serializer(self.principal).data
+            serial_principal = self.principal.SERIALIZER(self.principal).data
         except AttributeError:
             serial_principal = self.principal
 

--- a/server/pulp/server/db/querysets.py
+++ b/server/pulp/server/db/querysets.py
@@ -53,8 +53,8 @@ class CriteriaQuerySet(QuerySetPreventCache):
         """
         query_set = self
         model = query_set._document
-        if hasattr(model, 'serializer'):
-            criteria = model.serializer().translate_criteria(model, criteria)
+        if hasattr(model, 'SERIALIZER'):
+            criteria = model.SERIALIZER().translate_criteria(model, criteria)
 
         if criteria.spec is not None:
             query_set = query_set.filter(__raw__=criteria.spec)

--- a/server/pulp/server/webservices/middleware/postponed.py
+++ b/server/pulp/server/webservices/middleware/postponed.py
@@ -31,8 +31,8 @@ class PostponedOperationMiddleware(object):
 
         # Use the object's serializer if it is a Mongoengine Document.
         result = serialized_call_report.get('result')
-        if hasattr(result, 'serializer'):
-            serialized_call_report['result'] = result.serializer(result).data
+        if hasattr(result, 'SERIALIZER'):
+            serialized_call_report['result'] = result.SERIALIZER(result).data
 
         return json.dumps(serialized_call_report, default=json_util.default)
 

--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -33,7 +33,7 @@ def _merge_related_objects(name, model, repos):
 
     :param name: name of the field, either 'importers' or 'distributors'.
     :type  name: basestring
-    :param model: mongoengine document, must specify its serializer
+    :param model: mongoengine document, must specify its serializer at the SERIALIZER attribute
     :type  model: mongoengine.Document
     :param repos: list of serialized repos that should have importers and distributors added.
     :type  repos: list of dicts
@@ -47,7 +47,7 @@ def _merge_related_objects(name, model, repos):
         repo[name] = []
 
     for item in model.objects(repo_id__in=repo_ids):
-        serialized = model.serializer(item).data
+        serialized = model.SERIALIZER(item).data
         repo_dict[item['repo_id']][name].append(serialized)
 
 
@@ -307,7 +307,7 @@ class RepoImportersView(View):
         """
 
         importers = model.Importer.objects(repo_id=repo_id)
-        serialized_importers = model.Importer.serializer(importers, multiple=True).data
+        serialized_importers = model.Importer.SERIALIZER(importers, multiple=True).data
         return generate_json_response_with_pulp_encoder(serialized_importers)
 
     @auth_required(authorization.CREATE)
@@ -359,7 +359,7 @@ class RepoImporterResourceView(View):
         :raises exceptions.MissingResource: if importer_id does not match importer for repo
         """
         importer = importer_controller.get_valid_importer(repo_id, importer_id)
-        serialized_importer = model.Importer.serializer(importer).data
+        serialized_importer = model.Importer.SERIALIZER(importer).data
         return generate_json_response_with_pulp_encoder(serialized_importer)
 
     @auth_required(authorization.DELETE)
@@ -591,7 +591,7 @@ class RepoDistributorsView(View):
         """
         model.Repository.objects.get_repo_or_missing_resource(repo_id)
         distributors = model.Distributor.objects(repo_id=repo_id)
-        serialized_dists = model.Distributor.serializer(distributors, multiple=True).data
+        serialized_dists = model.Distributor.SERIALIZER(distributors, multiple=True).data
         return generate_json_response_with_pulp_encoder(serialized_dists)
 
     @auth_required(authorization.CREATE)
@@ -618,7 +618,7 @@ class RepoDistributorsView(View):
 
         distributor = dist_controller.add_distributor(repo_id, distributor_type, distributor_config,
                                                       auto_publish, distributor_id)
-        serialized = model.Distributor.serializer(distributor).data
+        serialized = model.Distributor.SERIALIZER(distributor).data
         response = generate_json_response_with_pulp_encoder(serialized)
         return generate_redirect_response(response, serialized['_href'])
 
@@ -653,7 +653,7 @@ class RepoDistributorResourceView(View):
 
         model.Repository.objects.get_repo_or_missing_resource(repo_id)
         dist = model.Distributor.objects.get_or_404(repo_id=repo_id, distributor_id=distributor_id)
-        serialized = model.Distributor.serializer(dist).data
+        serialized = model.Distributor.SERIALIZER(dist).data
         return generate_json_response_with_pulp_encoder(serialized)
 
     @auth_required(authorization.DELETE)

--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -4,7 +4,6 @@ from bson.objectid import ObjectId
 from django.core.urlresolvers import reverse
 
 from pulp.server import exceptions
-from pulp.server.db.model import criteria
 
 
 class BaseSerializer(object):
@@ -271,6 +270,8 @@ class ModelSerializer(BaseSerializer):
         :return: translated Criteria object
         :rtype:  pulp.server.db.model.criteria.Criteria
         """
+        # Circular import avoidance, since criteria imports models which imports serializers
+        from pulp.server.db.model.criteria import Criteria
         crit_dict = crit.as_dict()
         if crit.filters:
             crit_dict['filters'] = self._translate_filters(model, crit.filters)
@@ -279,7 +280,7 @@ class ModelSerializer(BaseSerializer):
             crit_dict['sort'] = sort
         if crit.fields:
             crit_dict['fields'] = [self._translate(model, field) for field in crit.fields]
-        return criteria.Criteria.from_dict(crit_dict)
+        return Criteria.from_dict(crit_dict)
 
 
 class Repository(ModelSerializer):

--- a/server/pulp/server/webservices/views/serializers/content.py
+++ b/server/pulp/server/webservices/views/serializers/content.py
@@ -1,13 +1,55 @@
 """
 Module for content serialization.
 """
+import logging
 
 from pulp.common import dateutils
+from pulp.plugins.loader import api
 from pulp.server.webservices import http
 from pulp.server.webservices.views.serializers import db
 
-
+_logger = logging.getLogger(__name__)
 CONTENT_URI_PATH = http.API_V2_HREF + '/content'
+
+
+def remap_fields_with_serializer(content_unit):
+    """Remap fields in place in a pymongo object using a mongoengine serializer
+
+    :param content_unit: Content unit to modify
+    :type content_unit: dict
+    :param remove_remapped: If True, remove remapped keys from content unit when remapping.
+                            Remapped keys are left in place and copied by default
+    :type remove_remapped: bool
+
+    This is a small workaround to help in cases where REST views are returning the older objects
+    coming out of pymongo, but still need to have their fields remapped according to the rules of
+    the pymongo serializer. As a workaround, this is a "best effort" function, so serialization
+    failures will be written to the debug log and not raise exeptions.
+
+    Usage of pymongo objects is deprecated. Since this function is only concerned with serializing
+    pymongo objects, its usage is also deprecated. Furthermore, this function is only intended to
+    be used in the final serialization of objects before presentation in the REST API.
+
+    """
+    try:
+        content_type_id = content_unit['_content_type_id']
+    except KeyError:
+        # content unit didn't have a content type id, usually means we're testing...
+        _logger.debug('No _content_type_id found in content unit when remapping fields: '
+                      '{0!r}'.format(content_unit))
+        return
+
+    cu_document = api.get_unit_model_by_id(content_type_id)
+
+    if hasattr(cu_document, 'SERIALIZER'):
+        for original_field, remapped_field in cu_document.SERIALIZER()._remapped_fields.items():
+            try:
+                content_unit[remapped_field] = content_unit.pop(original_field)
+            except KeyError:
+                # If the original field doesn't exist, log and move on
+                _logger.debug('original field not found when attempting to remap: {0}'
+                              '{0}'.format(original_field))
+                continue
 
 
 def content_unit_obj(content_unit):
@@ -15,6 +57,7 @@ def content_unit_obj(content_unit):
     Serialize a content unit.
     """
     serial = db.scrub_mongo_fields(content_unit)
+    remap_fields_with_serializer(content_unit)
     last_updated = content_unit.get('_last_updated')
     if last_updated:
         content_unit['_last_updated'] = dateutils.format_iso8601_utc_timestamp(last_updated)

--- a/server/pulp/server/webservices/views/users.py
+++ b/server/pulp/server/webservices/views/users.py
@@ -42,7 +42,7 @@ class UsersView(View):
         :return: Response containing a list of users
         :rtype: django.http.HttpResponse
         """
-        users = model.User.serializer(model.User.objects(), multiple=True).data
+        users = model.User.SERIALIZER(model.User.objects(), multiple=True).data
         return generate_json_response_with_pulp_encoder(users)
 
     @auth_required(authorization.CREATE)
@@ -74,7 +74,7 @@ class UsersView(View):
             raise pulp_exceptions.InvalidValue(user_data.keys())
 
         new_user = user_controller.create_user(login, password=password, name=name)
-        serialized_user = model.User.serializer(new_user).data
+        serialized_user = model.User.SERIALIZER(new_user).data
 
         # For backwards compatability. See https://pulp.plan.io/issues/1125
         serialized_user['id'] = str(serialized_user['_id'])
@@ -106,7 +106,7 @@ class UserResourceView(View):
         :rtype: django.http.HttpResponse
         """
         user = model.User.objects.get_or_404(login=login)
-        serialized_user = model.User.serializer(user).data
+        serialized_user = model.User.SERIALIZER(user).data
         return generate_json_response_with_pulp_encoder(serialized_user)
 
     @auth_required(authorization.DELETE)
@@ -146,5 +146,5 @@ class UserResourceView(View):
         """
         delta = request.body_as_json.get('delta')
         updated_user = user_controller.update_user(login, delta)
-        serialized_user = model.User.serializer(updated_user).data
+        serialized_user = model.User.SERIALIZER(updated_user).data
         return generate_json_response_with_pulp_encoder(serialized_user)

--- a/server/test/unit/server/controllers/test_importer.py
+++ b/server/test/unit/server/controllers/test_importer.py
@@ -366,7 +366,7 @@ class TestUpdateImporterConfig(unittest.TestCase):
         mock_imp_inst = mock.MagicMock()
         mock_plugin_config = mock.MagicMock()
         mock_plugin_api.get_importer_by_id.return_value = (mock_imp_inst, mock_plugin_config)
-        mock_ser = mock_model.Importer.serializer
+        mock_ser = mock_model.Importer.SERIALIZER
         mock_validate_config.return_value = (True, 'message')
 
         result = importer.update_importer_config('mrepo', {'test': 'config'})
@@ -384,7 +384,7 @@ class TestUpdateImporterConfig(unittest.TestCase):
         mock_imp_inst = mock.MagicMock()
         mock_plugin_config = mock.MagicMock()
         mock_plugin_api.get_importer_by_id.return_value = (mock_imp_inst, mock_plugin_config)
-        mock_ser = mock_model.Importer.serializer
+        mock_ser = mock_model.Importer.SERIALIZER
         mock_validate_config.return_value = (True, 'message')
 
         result = importer.update_importer_config('mrepo', {'test': 'change', 'dont_keep': None})

--- a/server/test/unit/server/db/model/test_dispatch.py
+++ b/server/test/unit/server/db/model/test_dispatch.py
@@ -618,7 +618,7 @@ class TestScheduledCallAsDict(unittest.TestCase):
         call['principal'] = model.User('test_user')
 
         result = call.as_dict()
-        self.assertEqual(result['principal'], model.User.serializer(call['principal']).data)
+        self.assertEqual(result['principal'], model.User.SERIALIZER(call['principal']).data)
 
     def test_system_user_is_dict(self):
         """
@@ -640,7 +640,7 @@ class TestScheduledCallAsDict(unittest.TestCase):
         self.assertEqual(result['_id'], call.id)
         for k, v in SCHEDULE.items():
             if k == 'principal':
-                self.assertTrue(result[k] is SCHEDULE[k].serializer.return_value.data)
+                self.assertTrue(result[k] is SCHEDULE[k].SERIALIZER.return_value.data)
             else:
                 self.assertEqual(v, result[k])
         self.assertTrue('next_run' in result)

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -820,7 +820,7 @@ class TestImporter(unittest.TestCase):
         """
         Ensure that the serializer is set.
         """
-        self.assertEqual(model.Importer.serializer, serializers.ImporterSerializer)
+        self.assertEqual(model.Importer.SERIALIZER, serializers.ImporterSerializer)
 
     def test_meta_collection(self):
         """
@@ -889,7 +889,7 @@ class TestDistributor(unittest.TestCase):
         """
         Ensure that the serializer is set.
         """
-        self.assertEqual(model.Distributor.serializer, serializers.Distributor)
+        self.assertEqual(model.Distributor.SERIALIZER, serializers.Distributor)
 
     def test_meta_collection(self):
         """

--- a/server/test/unit/server/db/test_querysets.py
+++ b/server/test/unit/server/db/test_querysets.py
@@ -53,8 +53,8 @@ class TestCriteriaQuerySet(unittest.TestCase):
         class MockDocument(Document):
             """Fake Mongoengine document"""
             meta = {'queryset_class': querysets.CriteriaQuerySet}
-            serializer = mock.MagicMock()
-            mock_crit = serializer().translate_criteria.return_value
+            SERIALIZER = mock.MagicMock()
+            mock_crit = SERIALIZER().translate_criteria.return_value
             mock_crit.spec = 'spec'
             mock_crit.fields = ['field']
             mock_crit.sort = [('field', 1), ('other', 0)]

--- a/server/test/unit/server/webservices/middleware/test_postponed.py
+++ b/server/test/unit/server/webservices/middleware/test_postponed.py
@@ -68,7 +68,7 @@ class TestPostponedOperationMiddleware(unittest.TestCase):
         e.call_report.serialize.return_value = mock_serialized
         ret = postponed.PostponedOperationMiddleware._get_operation_postponed_body(e)
         e.call_report.serialize.assert_called_once_with()
-        mock_result.serializer.assert_called_once_with(mock_result)
+        mock_result.SERIALIZER.assert_called_once_with(mock_result)
         mjson.dumps.assert_called_once_with(mock_serialized, default=mjson_default)
-        mock_serialized['result'] = mock_result.serializer.return_value.data
+        mock_serialized['result'] = mock_result.SERIALIZER.return_value.data
         self.assertTrue(ret is mjson.dumps.return_value)

--- a/server/test/unit/server/webservices/views/serializers/test_serializers.py
+++ b/server/test/unit/server/webservices/views/serializers/test_serializers.py
@@ -2,12 +2,7 @@ from bson.objectid import ObjectId
 import mock
 
 from pulp.common.compat import unittest
-# The serializers module should not normally be an starting point for imports, so we need to import
-# the criteria module before serializers to prevent a circular import. This is only an issue when
-# running this test module by itself, and will be fixed when pulp.server.db.model becomes a true
-# module or moves to pulp.server.db.models. See https://pulp.plan.io/issues/1066
 from pulp.server import exceptions
-from pulp.server.db.model import criteria  # noqa
 from pulp.server.webservices.views import serializers
 
 
@@ -416,7 +411,7 @@ class TestModelSerializer(unittest.TestCase):
         result = test_serializer._translate(mock_model, 'external')
         self.assertEqual(result, 'internal_db')
 
-    @mock.patch('pulp.server.webservices.views.serializers.criteria.Criteria.from_dict')
+    @mock.patch('pulp.server.db.model.criteria.Criteria.from_dict')
     @mock.patch('pulp.server.webservices.views.serializers.ModelSerializer._translate')
     @mock.patch('pulp.server.webservices.views.serializers.ModelSerializer._translate_filters')
     def test_translate_criteria(self, mock_translate_filters, mock_translate, mock_new_crit):

--- a/server/test/unit/server/webservices/views/test_repositories.py
+++ b/server/test/unit/server/webservices/views/test_repositories.py
@@ -35,7 +35,7 @@ class TestMergeRelatedObjects(unittest.TestCase):
         Test that objects are included in the appropriate repositories.
         """
 
-        def mock_serialize(data):
+        def mock_serializer(data):
             """
             Imitate the serialzer by storing the data in .data.
             """
@@ -49,7 +49,7 @@ class TestMergeRelatedObjects(unittest.TestCase):
                           {'repo_id': 'mock2', 'id': 'mock_importer2'}]
 
         m_model.Importer.objects.return_value = mock_importers
-        m_model.Importer.serializer.side_effect = mock_serialize
+        m_model.Importer.SERIALIZER = mock_serializer
 
         # If this is available, it will be used. Removed after https://pulp.plan.io/issues/780
         del m_model.Importer.find_by_repo_list
@@ -92,7 +92,7 @@ class TestReposView(unittest.TestCase):
         'pulp.server.webservices.views.repositories.generate_json_response_with_pulp_encoder')
     @mock.patch('pulp.server.webservices.views.repositories._merge_related_objects')
     @mock.patch('pulp.server.webservices.views.repositories.serializers.Repository')
-    def test__process_repos_minimal(self, mock_serialize, mock_merge, mock_resp):
+    def test__process_repos_minimal(self, mock_serializer, mock_merge, mock_resp):
         """
         Test _process_repos without optional args, assert that processing was called for each repo.
         """
@@ -717,7 +717,7 @@ class TestRepoImportersView(unittest.TestCase):
                 new=assert_auth_READ())
     @mock.patch(
         'pulp.server.webservices.views.repositories.generate_json_response_with_pulp_encoder')
-    @mock.patch('pulp.server.webservices.views.repositories.model.Importer.serializer')
+    @mock.patch('pulp.server.webservices.views.repositories.model.Importer.SERIALIZER')
     @mock.patch('pulp.server.webservices.views.repositories.model.Importer.objects')
     def test_get_importers(self, mock_imp_qs, mock_imp_serializer, mock_resp):
         """
@@ -767,7 +767,7 @@ class TestRepoImporterResourceView(unittest.TestCase):
     @mock.patch(
         'pulp.server.webservices.views.repositories.generate_json_response_with_pulp_encoder')
     @mock.patch('pulp.server.webservices.views.repositories.importer_controller.get_valid_importer')
-    @mock.patch('pulp.server.webservices.views.repositories.model.Importer.serializer')
+    @mock.patch('pulp.server.webservices.views.repositories.model.Importer.SERIALIZER')
     def test_get_importer(self, mock_imp_serializer, mock_validate, mock_resp):
         """
         Get an importer for a repository.
@@ -1094,16 +1094,16 @@ class TestRepoDistributorsView(unittest.TestCase):
         repo_dist = RepoDistributorsView()
         response = repo_dist.get(mock.MagicMock(), 'mock_repo')
 
-        m_model.Distributor.serializer.assert_called_once_with(
+        m_model.Distributor.SERIALIZER.assert_called_once_with(
             m_model.Distributor.objects.return_value, multiple=True)
-        m_resp.assert_called_once_with(m_model.Distributor.serializer.return_value.data)
+        m_resp.assert_called_once_with(m_model.Distributor.SERIALIZER.return_value.data)
         self.assertTrue(response is m_resp.return_value)
 
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth', new=assert_auth_CREATE())
     @mock.patch('pulp.server.webservices.views.repositories.generate_redirect_response')
     @mock.patch(
         'pulp.server.webservices.views.repositories.generate_json_response_with_pulp_encoder')
-    @mock.patch('pulp.server.webservices.views.repositories.model.Distributor.serializer')
+    @mock.patch('pulp.server.webservices.views.repositories.model.Distributor.SERIALIZER')
     @mock.patch('pulp.server.webservices.views.repositories.dist_controller')
     def test_post_as_expected(self, m_dist_cont, m_serial, mock_resp, mock_redir):
         """
@@ -1168,9 +1168,9 @@ class TestRepoDistributorResourceView(unittest.TestCase):
         repo_dist = RepoDistributorResourceView()
         response = repo_dist.get(mock_request, 'mock_repo', 'mock_distributor')
 
-        m_model.Distributor.serializer.assert_called_once_with(
+        m_model.Distributor.SERIALIZER.assert_called_once_with(
             m_model.Distributor.objects.get_or_404.return_value)
-        m_resp.assert_called_once_with(m_model.Distributor.serializer.return_value.data)
+        m_resp.assert_called_once_with(m_model.Distributor.SERIALIZER.return_value.data)
         self.assertTrue(response is m_resp.return_value)
 
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth',

--- a/server/test/unit/server/webservices/views/test_search.py
+++ b/server/test/unit/server/webservices/views/test_search.py
@@ -25,7 +25,7 @@ class TestSearchView(unittest.TestCase):
         """
         class FakeSearchView(search.SearchView):
             model = mock.MagicMock()
-            del model.serializer
+            del model.SERIALIZER
 
         request = mock.MagicMock()
         request.GET = http.QueryDict('')
@@ -72,7 +72,7 @@ class TestSearchView(unittest.TestCase):
         """
         class FakeSearchView(search.SearchView):
             model = mock.MagicMock()
-            del model.serializer
+            del model.SERIALIZER
 
         request = mock.MagicMock()
         request.GET = http.QueryDict('filters={"name":"admin"}')
@@ -115,7 +115,7 @@ class TestSearchView(unittest.TestCase):
         request = mock.MagicMock()
         request.GET = http.QueryDict('field=name&field=id&filters={"name":"admin"}')
         view = FakeSearchView()
-        view.model.serializer.return_value.data = {'serialized': 'content'}
+        view.model.SERIALIZER.return_value.data = {'serialized': 'content'}
 
         with mock.patch.object(FakeSearchView, '_generate_response',
                                side_effect=FakeSearchView._generate_response) as _generate_response:
@@ -139,7 +139,7 @@ class TestSearchView(unittest.TestCase):
         """
         class FakeSearchView(search.SearchView):
             model = mock.MagicMock()
-            del model.serializer
+            del model.SERIALIZER
 
         request = mock.MagicMock()
         request.body = '{"criteria": {"filters": {"money": {"$gt": 1000000}}}}'
@@ -178,7 +178,7 @@ class TestSearchView(unittest.TestCase):
         """
         class FakeSearchView(search.SearchView):
             model = mock.MagicMock()
-            del model.serializer
+            del model.SERIALIZER
 
         query = {'filters': {'money': {'$gt': 1000000}}}
         FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
@@ -202,8 +202,8 @@ class TestSearchView(unittest.TestCase):
         class FakeSearchView(search.SearchView):
             response_builder = mock.MagicMock(return_value=42)
             model = mock.MagicMock()
-            # If the model hasattr serializer it will be used.
-            del model.serializer
+            # If the model hasattr SERIALIZER it will be used.
+            del model.SERIALIZER
 
         query = {'filters': {'money': {'$gt': 1000000}}}
         FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
@@ -247,7 +247,7 @@ class TestSearchView(unittest.TestCase):
         """
         class FakeSearchView(search.SearchView):
             model = mock.MagicMock()
-            del model.serializer
+            del model.SERIALIZER
 
         query = {'filters': {'money': {'$gt': 1000000}}, 'fields': ['cash', 'id']}
         FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
@@ -271,7 +271,7 @@ class TestSearchView(unittest.TestCase):
         """
         class FakeSearchView(search.SearchView):
             model = mock.MagicMock()
-            del model.serializer
+            del model.SERIALIZER
 
         query = {'filters': {'money': {'$gt': 1000000}}, 'fields': ['cash']}
         FakeSearchView.model.objects.find_by_criteria.return_value = ['big money', 'bigger money']
@@ -290,7 +290,7 @@ class TestSearchView(unittest.TestCase):
     def test__generate_response_with_serializer(self):
         """
         Test the _generate_response() method for the case where the SearchView is configured to
-        use a serializer.
+        use a serializer method instead of the model SERIALIZER
         """
         class FakeSearchView(search.SearchView):
             model = mock.MagicMock()

--- a/server/test/unit/server/webservices/views/test_users.py
+++ b/server/test/unit/server/webservices/views/test_users.py
@@ -24,7 +24,7 @@ class TestUserSearchView(unittest.TestCase):
         self.assertEqual(UserSearchView.response_builder,
                          util.generate_json_response_with_pulp_encoder)
         self.assertEqual(UserSearchView.model, model.User)
-        self.assertEqual(UserSearchView.model.serializer, serializers.User)
+        self.assertEqual(UserSearchView.model.SERIALIZER, serializers.User)
 
 
 class TestUsersView(unittest.TestCase):
@@ -43,9 +43,9 @@ class TestUsersView(unittest.TestCase):
         request = mock.MagicMock()
         view = UsersView()
         response = view.get(request)
-        mock_model.serializer.assert_called_once_with(mock_model.objects.return_value,
+        mock_model.SERIALIZER.assert_called_once_with(mock_model.objects.return_value,
                                                       multiple=True)
-        mock_resp.assert_called_once_with(mock_model.serializer.return_value.data)
+        mock_resp.assert_called_once_with(mock_model.SERIALIZER.return_value.data)
         self.assertTrue(response is mock_resp.return_value)
 
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
@@ -98,12 +98,12 @@ class TestUsersView(unittest.TestCase):
         """
         request = mock.MagicMock()
         request.body = json.dumps({'login': 'test-user', 'name': 'test-user', 'password': '111'})
-        mock_model.serializer.return_value.data = {'_id': 'copy to id', '_href': 'mock/path'}
+        mock_model.SERIALIZER.return_value.data = {'_id': 'copy to id', '_href': 'mock/path'}
         user = UsersView()
         response = user.post(request)
 
         mock_ctrl.create_user.assert_called_once_with('test-user', password='111', name='test-user')
-        mock_model.serializer.assert_called_once_with(mock_ctrl.create_user.return_value)
+        mock_model.SERIALIZER.assert_called_once_with(mock_ctrl.create_user.return_value)
         mock_auto_perm = mock_factory.permission_manager().grant_automatic_permissions_for_resource
         mock_auto_perm.assert_called_once_with('mock/path')
         mock_resp.assert_called_once_with({'id': 'copy to id', '_href': 'mock/path',
@@ -130,7 +130,7 @@ class TestUserResourceView(unittest.TestCase):
         response = user.get(request, 'test-user')
 
         mock_model.objects.get_or_404.assert_called_once_with(login='test-user')
-        mock_resp.assert_called_once_with(mock_model.serializer.return_value.data)
+        mock_resp.assert_called_once_with(mock_model.SERIALIZER.return_value.data)
         self.assertTrue(response is mock_resp.return_value)
 
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
@@ -168,6 +168,6 @@ class TestUserResourceView(unittest.TestCase):
         response = user.put(request, 'test-user')
 
         mock_ctrl.update_user.assert_called_once_with('test-user', {'name': 'some-user'})
-        mock_model.serializer.assert_called_once_with(mock_ctrl.update_user.return_value)
-        mock_resp.assert_called_once_with(mock_model.serializer.return_value.data)
+        mock_model.SERIALIZER.assert_called_once_with(mock_ctrl.update_user.return_value)
+        mock_resp.assert_called_once_with(mock_model.SERIALIZER.return_value.data)
         self.assertTrue(response is mock_resp.return_value)


### PR DESCRIPTION
Recent changes in the pymongo > mongoengine conversion have resulted in
different ways to represent mongo documents in the REST api views; the
correct way is to use the mongoengine Document serializers wherever
possible. When that isn't possible, remap_fields_with_serializer exists
to use the information in a mongoengine serializer to modify serialized
results properly.

Anything that is using the serialization functions in
pulp.server.webservices.views.serializers.content should automaticaly
benefit from this change, which implicitly fixes redmine #1490.

These changes can also be used to benefit views that don't call the
existing serialization functions by explicitly using the new
remap_fields_with_serializer function as-needed, such as RepoUnitSearch,
which will help (but not fix) redmine #1478.

fixes #1490
https://pulp.plan.io/issues/1490

re #1478
https://pulp.plan.io/issues/1478