### PR TITLE
Ensures setting an importer serializes into the task result

### DIFF
--- a/server/pulp/server/controllers/importer.py
+++ b/server/pulp/server/controllers/importer.py
@@ -62,8 +62,8 @@ def set_importer(repo_id, importer_type_id, repo_plugin_config):
     :param repo_plugin_config: configuration values for the importer; may be None
     :type  repo_plugin_config: dict or None
 
-    :return: created importer object
-    :rtype:  pulp.server.model.Importer
+    :return: key-value pairs describing the importer that was set
+    :rtype:  dict
 
     :raises PulpExecutionException: if something goes wrong in the plugin
     :raises exceptions.InvalidValue: if the values passed to create the importer are invalid
@@ -97,7 +97,8 @@ def set_importer(repo_id, importer_type_id, repo_plugin_config):
     except ValidationError, e:
         raise exceptions.InvalidValue(e.to_dict().keys())
 
-    return importer
+    serialized = model.Importer.SERIALIZER(importer).data
+    return serialized
 
 
 def queue_set_importer(repo, importer_type_id, config):

--- a/server/test/unit/server/controllers/test_importer.py
+++ b/server/test/unit/server/controllers/test_importer.py
@@ -69,7 +69,8 @@ class TestSetImporter(unittest.TestCase):
         mock_imp_inst.importer_added.assert_called_once_with(mock_repo.to_transfer_repo(),
                                                              mock_call_config)
         mock_importer.save.assert_called_once_with()
-        self.assertTrue(result is m_model.Importer.return_value)
+        m_model.Importer.SERIALIZER.assert_called_once_with(mock_importer)
+        self.assertTrue(result is m_model.Importer.SERIALIZER.return_value.data)
 
     def test_as_expected(self, m_validate_conf, m_model, m_plug_api, m_clean, mock_remove,
                          mock_plug_call_config, *_):
@@ -90,7 +91,8 @@ class TestSetImporter(unittest.TestCase):
         m_clean.assert_called_once_with('m_conf')
         mock_plug_call_config.assert_called_once_with(mock_plugin_config, m_clean.return_value)
         mock_importer.save.assert_called_once_with()
-        self.assertTrue(result is m_model.Importer.return_value)
+        m_model.Importer.SERIALIZER.assert_called_once_with(mock_importer)
+        self.assertTrue(result is m_model.Importer.SERIALIZER.return_value.data)
 
     def test_validation_error(self, m_validate_conf, m_model, m_plug_api, m_clean, mock_remove,
                               mock_plug_call_config, *_):


### PR DESCRIPTION
The importer conversion introduced a regression where when you
update an importer it saved a reference to the new importer
itself in the TaskStatus instead of a serializer verison of it.

When that TaskStatus was fetched, it could not be serialized
by the webservices layer and caused a 500 exception.

https://pulp.plan.io/issues/1483
closes #1483