### PR TITLE
Update save_revision to work with multi-file units.

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -898,7 +898,9 @@ class LazyCatalogEntry(AutoRetryDocument):
         query = dict(
             unit_id=self.unit_id,
             unit_type_id=self.unit_type_id,
-            importer_id=self.importer_id)
+            importer_id=self.importer_id,
+            path=self.path
+        )
         # Find revisions
         qs = LazyCatalogEntry.objects.filter(**query)
         for revision in qs.distinct('revision'):

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -1001,6 +1001,7 @@ class TestLazyCatalogEntry(unittest.TestCase):
         entry.unit_id = '123'
         entry.unit_type_id = 'test'
         entry.importer_id = '44'
+        entry.path = '/no/where'
 
         # test
         entry.save_revision()
@@ -1011,11 +1012,13 @@ class TestLazyCatalogEntry(unittest.TestCase):
             [
                 call(unit_id=entry.unit_id,
                      unit_type_id=entry.unit_type_id,
-                     importer_id=entry.importer_id),
+                     importer_id=entry.importer_id,
+                     path=entry.path),
                 call(revision__in=set([0, 1]),
                      unit_id=entry.unit_id,
                      unit_type_id=entry.unit_type_id,
-                     importer_id=entry.importer_id),
+                     importer_id=entry.importer_id,
+                     path=entry.path),
             ])
         self.assertEqual(entry.revision, 2)
         save.assert_called_once_with()


### PR DESCRIPTION
Previously, the query used to get catalog revisions would retrieve all
entries for all files in a multi-file content unit. This ensures that
only catalog entries for a single file are retrieved. In combination
with a pulp_rpm PR, this closes issue 1539.