### PR TITLE
Remove the requestor's IP address from the signature.

### DIFF
--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -91,7 +91,6 @@ class ContentView(View):
         host = request.environ['SERVER_NAME']
         port = request.environ['SERVER_PORT']
         query = request.environ['QUERY_STRING']
-        remote_ip = request.environ['REMOTE_ADDR']
 
         redirect_host = pulp_conf.get('lazy', 'redirect_host')
         redirect_port = pulp_conf.get('lazy', 'redirect_port')
@@ -106,7 +105,7 @@ class ContentView(View):
             query)
 
         url = URL(redirect)
-        signed = url.sign(key, remote_ip=remote_ip)
+        signed = url.sign(key)
         return HttpResponseRedirect(str(signed))
 
     def __init__(self, **kwargs):

--- a/server/test/unit/server/content/web/test_views.py
+++ b/server/test/unit/server/content/web/test_views.py
@@ -103,7 +103,7 @@ class TestContentView(TestCase):
         # validation
         url.assert_called_once_with(ContentView.urljoin(
             scheme, host, port, redirect_path, path, query))
-        url.return_value.sign.assert_called_once_with(key, remote_ip=remote_ip)
+        url.return_value.sign.assert_called_once_with(key)
         redirect.assert_called_once_with(str(url.return_value.sign.return_value))
         self.assertEqual(reply, redirect.return_value)
 

--- a/streamer/srv/pulp/streamer_auth.wsgi
+++ b/streamer/srv/pulp/streamer_auth.wsgi
@@ -31,12 +31,11 @@ def allow_access(environ, host):
     :rtype:  bool
     """
     url = SignedURL(environ['REQUEST_URI'])
-    remote_ip = environ['REMOTE_ADDR']
     try:
-        url.validate(key, remote_ip=remote_ip)
-        log.debug(_('Validated {ip} for {url}.').format(ip=remote_ip, url=url))
+        url.validate(key)
+        log.debug(_('Validated {ip} for {url}.').format(ip=environ['REMOTE_ADDR'], url=url))
         return True
     except NotValid, le:
         msg = _('Received invalid request from {ip} for {url}: {error}.')
-        log.debug(msg.format(ip=remote_ip, url=url, error=str(le)))
+        log.debug(msg.format(ip=environ['REMOTE_ADDR'], url=url, error=str(le)))
         return False


### PR DESCRIPTION
I encountered problems with this because one request was being made via
IPv6 and a second request was being made via IPv4.