### PR TITLE
Load `_storage_path` when reloading the content unit.

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1380,7 +1380,11 @@ class LazyUnitDownloadStep(DownloadEventListener):
         # Reload the content unit
         unit_model = plugin_api.get_unit_model_by_id(report.data[TYPE_ID])
         unit_qs = unit_model.objects.filter(id=report.data[UNIT_ID])
-        content_unit = unit_qs.only('_content_type_id', 'id', '_last_updated').get()
+        content_unit = unit_qs.only(
+            '_content_type_id',
+            'id', '_last_updated',
+            '_storage_path',
+        ).get()
         path_entry = report.data[UNIT_FILES][report.destination]
 
         # Validate the file and update the progress.


### PR DESCRIPTION
`_storage_path` is required when saving the unit. The reason this
already worked with single file units is that `set_storage_path` is
called on them and regenerates the _storage_path. This is required for
multi-file units.

closes #1545