### PR TITLE
Update Pulp to work with the pymongo 3.0.0 API.

### DIFF
--- a/docs/user-guide/release-notes/master.rst
+++ b/docs/user-guide/release-notes/master.rst
@@ -23,11 +23,12 @@ New Features
 Deprecation
 -----------
 
-Supported Platforms Changes
+Dependency/Platform Changes
 ---------------------------
 
 * If run on CentOS or Red Hat Enterprise Linux, the Pulp server now requires either
   version 7.1+ or 6.7+.
+* pymongo >= 3.0.0 is now required.
 
 Client Changes
 --------------

--- a/pulp.spec
+++ b/pulp.spec
@@ -350,8 +350,8 @@ Requires: python-%{name}-repoauth = %{pulp_version}
 Requires: python-blinker
 Requires: python-celery >= 3.1.0
 Requires: python-celery < 3.2.0
-Requires: python-pymongo >= 2.7.1
-Requires: python-mongoengine >= 0.9.0
+Requires: python-pymongo >= 3.0.0
+Requires: python-mongoengine >= 0.10.0
 Requires: python-setuptools
 Requires: python-oauth2 >= 1.5.211
 Requires: python-httplib2

--- a/server/pulp/plugins/types/database.py
+++ b/server/pulp/plugins/types/database.py
@@ -165,7 +165,7 @@ def all_type_ids():
     """
 
     collection = ContentType.get_collection()
-    type_id_son = list(collection.find(fields={'id': 1}))
+    type_id_son = list(collection.find(projection={'id': 1}))
     type_ids = [t['id'] for t in type_id_son]
 
     return type_ids
@@ -178,7 +178,7 @@ def all_type_collection_names():
     """
 
     collection = ContentType.get_collection()
-    type_ids = list(collection.find(fields={'id': 1}))
+    type_ids = list(collection.find(projection={'id': 1}))
 
     type_collection_names = []
     for id in type_ids:
@@ -266,7 +266,7 @@ def _create_or_update_type(type_def):
         type_def.id, type_def.display_name, type_def.description, type_def.unit_key,
         type_def.search_indexes, type_def.referenced_types)
     # no longer rely on _id = id
-    existing_type = content_type_collection.find_one({'id': type_def.id}, fields=[])
+    existing_type = content_type_collection.find_one({'id': type_def.id}, projection=[])
     if existing_type is not None:
         content_type._id = existing_type['_id']
     # XXX this still causes a potential race condition when 2 users are updating the same type

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -514,9 +514,9 @@ def delete(repo_id):
         # to keep the database clean.
         model.Distributor.objects(repo_id=repo_id).delete()
         model.Importer.objects(repo_id=repo_id).delete()
-        RepoSyncResult.get_collection().remove({'repo_id': repo_id}, safe=True)
-        RepoPublishResult.get_collection().remove({'repo_id': repo_id}, safe=True)
-        RepoContentUnit.get_collection().remove({'repo_id': repo_id}, safe=True)
+        RepoSyncResult.get_collection().remove({'repo_id': repo_id})
+        RepoPublishResult.get_collection().remove({'repo_id': repo_id})
+        RepoContentUnit.get_collection().remove({'repo_id': repo_id})
     except Exception, e:
         msg = _('Error updating one or more database collections while removing repo [%(r)s]')
         msg = msg % {'r': repo_id}
@@ -780,7 +780,7 @@ def sync(repo_id, sync_config_override=None, scheduled_call_id=None):
         # Do an update instead of a save in case the importer has changed the scratchpad
         model.Importer.objects(repo_id=repo_obj.repo_id).update(set__last_sync=sync_end_timestamp)
         # Add a sync history entry for this run
-        sync_result_collection.save(sync_result, safe=True)
+        sync_result_collection.save(sync_result)
         # Ensure counts are updated
         rebuild_content_unit_counts(repo_obj)
 
@@ -973,7 +973,7 @@ def _do_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_confi
         result = RepoPublishResult.error_result(
             repo_obj.repo_id, dist.distributor_id, dist.distributor_type_id,
             publish_start_timestamp, exception_timestamp, e, sys.exc_info()[2])
-        publish_result_coll.save(result, safe=True)
+        publish_result_coll.save(result)
 
         _logger.exception(
             _('Exception caught from plugin during publish for repo [%(r)s]'
@@ -996,7 +996,7 @@ def _do_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_confi
     result = RepoPublishResult.expected_result(
         repo_obj.repo_id, dist.distributor_id, dist.distributor_type_id,
         publish_start_timestamp, publish_end_timestamp, summary, details, result_code)
-    publish_result_coll.save(result, safe=True)
+    publish_result_coll.save(result)
     return result
 
 

--- a/server/pulp/server/db/migrations/0007_scheduled_task_conversion.py
+++ b/server/pulp/server/db/migrations/0007_scheduled_task_conversion.py
@@ -32,7 +32,7 @@ def move_scheduled_syncs(importer_collection, schedule_collection):
     """
 
     # iterate over all importers looking for those with scheduled syncs
-    for importer in importer_collection.find(fields=['scheduled_syncs', 'id', 'repo_id']):
+    for importer in importer_collection.find(projection=['scheduled_syncs', 'id', 'repo_id']):
         scheduled_syncs = importer.get('scheduled_syncs')
         if scheduled_syncs is None:
             continue
@@ -60,7 +60,8 @@ def move_scheduled_publishes(distributor_collection, schedule_collection):
     """
 
     # iterate over all distributors looking for those with scheduled publishes
-    for distributor in distributor_collection.find(fields=['scheduled_publishes', 'id', 'repo_id']):
+    for distributor in distributor_collection.find(
+            projection=['scheduled_publishes', 'id', 'repo_id']):
         scheduled_publishes = distributor.get('scheduled_publishes')
         if scheduled_publishes is None:
             continue

--- a/server/pulp/server/db/migrations/lib/managers.py
+++ b/server/pulp/server/db/migrations/lib/managers.py
@@ -51,7 +51,7 @@ class RepoManager(object):
 
         # default to all repos if none were specified
         if not repo_ids:
-            repo_ids = [repo['id'] for repo in repo_collection.find(fields=['id'])]
+            repo_ids = [repo['id'] for repo in repo_collection.find(projection=['id'])]
 
         _logger.info('regenerating content unit counts for %d repositories' % len(repo_ids))
 
@@ -64,8 +64,7 @@ class RepoManager(object):
             for type_id in type_ids:
                 spec = {'repo_id': repo_id, 'unit_type_id': type_id}
                 counts[type_id] = association_collection.find(spec).count()
-            repo_collection.update({'id': repo_id}, {'$set': {'content_unit_counts': counts}},
-                                   safe=True)
+            repo_collection.update({'id': repo_id}, {'$set': {'content_unit_counts': counts}})
 
     @staticmethod
     def find_with_importer_type(importer_type_id):

--- a/server/pulp/server/managers/consumer/applicability.py
+++ b/server/pulp/server/managers/consumer/applicability.py
@@ -149,7 +149,7 @@ class ApplicabilityRegenerationManager(object):
             existing_applicability = RepoProfileApplicability(**dict(existing_applicability))
             profile_hash = existing_applicability['profile_hash']
             unit_profile = UnitProfile.get_collection().find_one({'profile_hash': profile_hash},
-                                                                 fields=['id', 'content_type'])
+                                                                 projection=['id', 'content_type'])
             if unit_profile is None:
                 # Unit profiles change whenever packages are installed or removed on consumers,
                 # and it is possible that existing_applicability references a UnitProfile
@@ -206,7 +206,7 @@ class ApplicabilityRegenerationManager(object):
                 profile = existing_applicability.profile
             else:
                 unit_profile = UnitProfile.get_collection().find_one({'id': profile_id},
-                                                                     fields=['profile'])
+                                                                     projection=['profile'])
                 profile = unit_profile['profile']
             call_config = PluginCallConfiguration(plugin_config=profiler_cfg,
                                                   repo_plugin_config=None)
@@ -266,7 +266,7 @@ class ApplicabilityRegenerationManager(object):
         :type:               boolean
         """
         query_params = {'repo_id': repo_id, 'profile_hash': profile_hash}
-        if RepoProfileApplicability.get_collection().find_one(query_params, fields=['_id']):
+        if RepoProfileApplicability.get_collection().find_one(query_params, projection=['_id']):
             return True
         return False
 
@@ -517,7 +517,7 @@ def _add_profiles_to_consumer_map_and_get_hashes(consumer_ids, consumer_map):
     """
     profiles = UnitProfile.get_collection().find(
         {'consumer_id': {'$in': consumer_ids}},
-        fields=['consumer_id', 'profile_hash'])
+        projection=['consumer_id', 'profile_hash'])
     profile_hashes = set()
     for p in profiles:
         consumer_map[p['consumer_id']]['profiles'].append(p)
@@ -543,7 +543,7 @@ def _add_repo_ids_to_consumer_map(consumer_ids, consumer_map):
     """
     bindings = Bind.get_collection().find(
         {'consumer_id': {'$in': consumer_ids}},
-        fields=['consumer_id', 'repo_id'])
+        projection=['consumer_id', 'repo_id'])
     for b in bindings:
         consumer_map[b['consumer_id']]['repo_ids'].append(b['repo_id'])
 
@@ -595,7 +595,7 @@ def _get_applicability_map(profile_hashes, content_types):
     """
     applicabilities = RepoProfileApplicability.get_collection().find(
         {'profile_hash': {'$in': profile_hashes}},
-        fields=['profile_hash', 'repo_id', 'applicability'])
+        projection=['profile_hash', 'repo_id', 'applicability'])
     return_value = {}
     for a in applicabilities:
         if content_types is not None:

--- a/server/pulp/server/managers/consumer/cud.py
+++ b/server/pulp/server/managers/consumer/cud.py
@@ -198,7 +198,7 @@ class ConsumerManager(object):
         :raises MissingResource: if a consumer with given id does not exist
         """
         consumer_coll = Consumer.get_collection()
-        consumer = consumer_coll.find_one({'id': id}, fields=fields)
+        consumer = consumer_coll.find_one({'id': id}, projection=fields)
         if not consumer:
             raise MissingResource(consumer=id)
         return consumer

--- a/server/pulp/server/managers/consumer/profile.py
+++ b/server/pulp/server/managers/consumer/profile.py
@@ -91,7 +91,7 @@ class ProfileManager(object):
         """
         collection = UnitProfile.get_collection()
         for p in self.get_profiles(id):
-            collection.remove(p, sefe=True)
+            collection.remove(p)
 
     @staticmethod
     def get_profile(consumer_id, content_type):

--- a/server/pulp/server/managers/content/orphan.py
+++ b/server/pulp/server/managers/content/orphan.py
@@ -103,7 +103,7 @@ class OrphanManager(object):
         content_units_collection = content_types_db.type_units_collection(content_type_id)
         repo_content_units_collection = RepoContentUnit.get_collection()
 
-        for content_unit in content_units_collection.find({}, fields=fields):
+        for content_unit in content_units_collection.find({}, projection=fields):
 
             repo_content_units_cursor = repo_content_units_collection.find(
                 {'unit_id': content_unit['_id']})
@@ -225,7 +225,7 @@ class OrphanManager(object):
                 unit_id=content_unit['_id'],
                 unit_type_id=content_type_id
             ).delete()
-            content_units_collection.remove(content_unit['_id'], safe=False)
+            content_units_collection.remove(content_unit['_id'])
 
             storage_path = content_unit.get('_storage_path', None)
             if storage_path is not None:

--- a/server/pulp/server/managers/content/query.py
+++ b/server/pulp/server/managers/content/query.py
@@ -71,7 +71,7 @@ class ContentQueryManager(object):
         collection = content_types_db.type_units_collection(content_type)
         if db_spec is None:
             db_spec = {}
-        cursor = collection.find(db_spec, fields=model_fields)
+        cursor = collection.find(db_spec, projection=model_fields)
         if start > 0:
             cursor.skip(start)
         if limit is not None:
@@ -165,7 +165,7 @@ class ContentQueryManager(object):
         collection = content_types_db.type_units_collection(content_type)
         for segment in paginate(unit_keys_dicts, page_size=50):
             spec = _build_multi_keys_spec(content_type, segment)
-            cursor = collection.find(spec, fields=model_fields)
+            cursor = collection.find(spec, projection=model_fields)
             for unit_dict in cursor:
                 yield unit_dict
 
@@ -185,7 +185,7 @@ class ContentQueryManager(object):
         @rtype: (possibly empty) tuple of dict's
         """
         collection = content_types_db.type_units_collection(content_type)
-        cursor = collection.find({'_id': {'$in': unit_ids}}, fields=model_fields)
+        cursor = collection.find({'_id': {'$in': unit_ids}}, projection=model_fields)
         return tuple(cursor)
 
     def get_content_unit_keys(self, content_type, unit_ids):
@@ -207,7 +207,7 @@ class ContentQueryManager(object):
         all_fields = ['_id']
         _flatten_keys(all_fields, key_fields)
         collection = content_types_db.type_units_collection(content_type)
-        cursor = collection.find({'_id': {'$in': unit_ids}}, fields=all_fields)
+        cursor = collection.find({'_id': {'$in': unit_ids}}, projection=all_fields)
         dicts = tuple(dict(d) for d in cursor)
         ids = tuple(d.pop('_id') for d in dicts)
         return (ids, dicts)
@@ -231,7 +231,7 @@ class ContentQueryManager(object):
         for segment in paginate(unit_keys):
             spec = _build_multi_keys_spec(content_type, segment)
             fields = ['_id']
-            for item in collection.find(spec, fields=fields):
+            for item in collection.find(spec, projection=fields):
                 yield str(item['_id'])
 
     def get_root_content_dir(self, content_type):

--- a/server/pulp/server/managers/repo/unit_association_query.py
+++ b/server/pulp/server/managers/repo/unit_association_query.py
@@ -239,7 +239,7 @@ class RepoUnitAssociationQueryManager(object):
 
         collection = RepoContentUnit.get_collection()
 
-        cursor = collection.find({'repo_id': repo_id}, fields=['unit_type_id'])
+        cursor = collection.find({'repo_id': repo_id}, projection=['unit_type_id'])
 
         return [t for t in cursor.distinct('unit_type_id')]
 
@@ -264,7 +264,7 @@ class RepoUnitAssociationQueryManager(object):
 
         collection = RepoContentUnit.get_collection()
 
-        cursor = collection.find(spec, fields=criteria.association_fields)
+        cursor = collection.find(spec, projection=criteria.association_fields)
 
         if criteria.association_sort:
             cursor.sort(criteria.association_sort)
@@ -362,7 +362,7 @@ class RepoUnitAssociationQueryManager(object):
             fields = list(fields)
             fields.append('_content_type_id')
 
-        cursor = collection.find(spec, fields=fields)
+        cursor = collection.find(spec, projection=fields)
 
         sort = criteria.unit_sort
 

--- a/server/setup.py
+++ b/server/setup.py
@@ -27,6 +27,6 @@ setup(
     },
     install_requires=[
         'blinker', 'celery >=3.1.0, <3.2.0', DJANGO_REQUIRES, 'httplib2', 'iniparse',
-        'isodate>=0.5.0', 'm2crypto', 'mongoengine>=0.7.10', 'oauth2>=1.5.211', 'pymongo>=2.5.2',
+        'isodate>=0.5.0', 'm2crypto', 'mongoengine>=0.10.0', 'oauth2>=1.5.211', 'pymongo>=3.0.0',
         'semantic_version>=2.2.0', 'setuptools']
 )

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -524,7 +524,7 @@ class TestDelete(unittest.TestCase):
 
         m_repo.delete.assert_called_once_with()
         pymongo_args = {'repo_id': 'foo-repo'}
-        pymongo_kwargs = {'safe': True}
+        pymongo_kwargs = {}
         m_model.Distributor.objects.return_value.delete.assert_called_once_with()
         m_model.Importer.objects.return_value.delete.assert_called_once_with()
         m_sync.get_collection().remove.assert_called_once_with(pymongo_args, **pymongo_kwargs)
@@ -556,7 +556,7 @@ class TestDelete(unittest.TestCase):
 
         m_repo.delete.assert_called_once_with()
         pymongo_args = {'repo_id': 'foo-repo'}
-        pymongo_kwargs = {'safe': True}
+        pymongo_kwargs = {}
         m_dist_ctrl.delete.assert_called_once_with(m_dist.repo_id, m_dist.distributor_id)
         m_model.Distributor.objects.return_value.delete.assert_called_once_with()
         m_model.Importer.objects.return_value.delete.assert_called_once_with()
@@ -593,7 +593,7 @@ class TestDelete(unittest.TestCase):
 
         m_repo.delete.assert_called_once_with()
         pymongo_args = {'repo_id': 'foo-repo'}
-        pymongo_kwargs = {'safe': True}
+        pymongo_kwargs = {}
 
         m_dist_ctrl.remove_distributor.has_calls([
             mock.call('foo-repo', 'mock_d1'), mock.call('foo-repo', 'mock_d2')])
@@ -639,7 +639,7 @@ class TestDelete(unittest.TestCase):
 
         m_repo.delete.assert_called_once_with()
         pymongo_args = {'repo_id': 'foo-repo'}
-        pymongo_kwargs = {'safe': True}
+        pymongo_kwargs = {}
 
         m_model.Distributor.objects.return_value.delete.assert_called_once_with()
         m_model.Importer.objects.return_value.delete.assert_called_once_with()
@@ -678,7 +678,7 @@ class TestDelete(unittest.TestCase):
         result = repo_controller.delete('foo-repo')
         m_repo.delete.assert_called_once_with()
         pymongo_args = {'repo_id': 'foo-repo'}
-        pymongo_kwargs = {'safe': True}
+        pymongo_kwargs = {}
 
         m_model.Distributor.objects.return_value.delete.assert_called_once_with()
         m_model.Importer.objects.return_value.delete.assert_called_once_with()
@@ -883,8 +883,7 @@ class TestSync(unittest.TestCase):
             'canceled'
         )
         m_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
-        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
-                                                                  safe=True)
+        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result())
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
         self.assertTrue(actual_result is m_task_result.return_value)
 
@@ -925,8 +924,7 @@ class TestSync(unittest.TestCase):
             'success'
         )
         m_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
-        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
-                                                                  safe=True)
+        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result())
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
         self.assertEqual(mock_imp_inst.id, mock_conduit.call_args_list[0][0][2])
         self.assertTrue(actual_result is m_task_result.return_value)
@@ -966,8 +964,7 @@ class TestSync(unittest.TestCase):
             'failed'
         )
         m_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
-        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
-                                                                  safe=True)
+        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result())
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
 
         # It is now platform's responsiblity to update plugin content unit counts
@@ -1001,8 +998,7 @@ class TestSync(unittest.TestCase):
             'err'
         )
         m_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
-        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result(),
-                                                                  safe=True)
+        mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result())
         mock_fire_man.fire_repo_sync_finished.assert_called_once_with(mock_result.expected_result())
         self.assertTrue(result is m_task_result.return_value)
 
@@ -1103,7 +1099,7 @@ class TestDoPublish(unittest.TestCase):
             mock_now(), expected_e, mock_sys.exc_info()[2])
 
         m_repo_pub_result.get_collection().save.assert_called_once_with(
-            m_repo_pub_result.error_result(), safe=True)
+            m_repo_pub_result.error_result())
         mock_log.exception.assert_called_once_with(mock_text())
 
     def test_successful_publish(self, m_dist_qs, m_repo_pub_result, mock_now,
@@ -1126,7 +1122,7 @@ class TestDoPublish(unittest.TestCase):
             mock_now(), 'summary', 'details', m_repo_pub_result.RESULT_SUCCESS
         )
         m_repo_pub_result.get_collection().save.assert_called_once_with(
-            m_repo_pub_result.expected_result(), safe=True)
+            m_repo_pub_result.expected_result())
         self.assertTrue(result is m_repo_pub_result.expected_result.return_value)
 
     def test_failed_publish(self, m_dist_qs, m_repo_pub_result, mock_now,

--- a/server/test/unit/server/db/migrations/lib/test_managers.py
+++ b/server/test/unit/server/db/migrations/lib/test_managers.py
@@ -61,7 +61,6 @@ class RepoManagerTests(base.ResourceReservationTests):
         repo_col.update.assert_called_once_with(
             {'id': 'repo1'},
             {'$set': {'content_unit_counts': {'rpm': 6, 'srpm': 6}}},
-            safe=True
         )
 
     def test_rebuild_default_all_repos(self, mock_get_assoc_col, mock_get_repo_col):

--- a/server/test/unit/server/managers/content/test_query.py
+++ b/server/test/unit/server/managers/content/test_query.py
@@ -147,4 +147,4 @@ class TestGetContentUnitIDs(unittest.TestCase):
         # evaluate the generator so the code actually runs
         list(ret)
         expected_spec = {'$or': ({'a': 'foo'}, {'a': 'bar'})}
-        mock_find.assert_called_once_with(expected_spec, fields=['_id'])
+        mock_find.assert_called_once_with(expected_spec, projection=['_id'])


### PR DESCRIPTION
https://pulp.plan.io/issues/1528

fixes #1528 

This pull request does not include the effort needed to provide pymongo >= 3.0.0 in the Pulp RPM repository. That will be done in a separate effort. Until that is done, this pull request will not pass in Jenkies.

https://github.com/pulp/pulp_rpm/pull/775 must be merged before this is merged.