### PR TITLE
Update the recommended Squid configuration for Kickstart.

### DIFF
--- a/docs/user-guide/deferred-download.rst
+++ b/docs/user-guide/deferred-download.rst
@@ -126,6 +126,16 @@ inline documentation::
   # objects so that ISOs are cached.
   maximum_object_size 5 GB
 
+  # Sets an upper limit on how far (number of bytes) into the file
+  # a Range request may be to cause Squid to prefetch the whole file.
+  # If beyond this limit, Squid forwards the Range request as it is and
+  # the result is NOT cached.
+  #
+  # A value of 'none' causes Squid to always prefetch the entire file.
+  # This is desirable in all cases for Pulp and is required to Kickstart
+  # from repositories using deferred download policies.
+  range_offset_limit none
+
   # Objects larger than this size will not be kept in the memory cache. This should
   # be set low enough to avoid large objects taking up all the memory cache, but
   # high enough to avoid repeatedly reading hot objects from disk.

--- a/playpen/ansible/roles/lazy/files/squid.conf
+++ b/playpen/ansible/roles/lazy/files/squid.conf
@@ -61,6 +61,16 @@
  # DVD-sized objects so that ISOs are cached.
  maximum_object_size 5 GB
 
+ # Sets an upper limit on how far (number of bytes) into the file
+ # a Range request may be to cause Squid to prefetch the whole file.
+ # If beyond this limit, Squid forwards the Range request as it is and
+ # the result is NOT cached.
+ #
+ # A value of 'none' causes Squid to always prefetch the entire file.
+ # This is desirable in all cases for Pulp and is required to Kickstart
+ # from repositories using deferred download policies.
+ range_offset_limit none
+
  # Objects larger than this size will not be kept in the memory cache. This
  # should be set low enough to avoid large objects taking up all the memory
  # cache, but high enough to avoid repeatedly reading hot objects from disk.


### PR DESCRIPTION
Kickstart uses the Range header, which the streamer does not handle.
Furthermore, we will always want to fetch the entire file since Pulp is
going to download the cached file later.