### PR TITLE
Better support updated units with associated files.

### DIFF
--- a/nodes/child/pulp_node/importers/strategies.py
+++ b/nodes/child/pulp_node/importers/strategies.py
@@ -285,9 +285,28 @@ class ImporterStrategy(object):
         :param unit_inventory: The inventory of both parent and child content units.
         :type unit_inventory: UnitInventory
         """
-        for unit, ref in unit_inventory.updated_units():
-            unit = ref.fetch()
-            self.add_unit(request, unit)
+        download_list = []
+        units = unit_inventory.updated_units()
+        listener = ContentDownloadListener(self, request)
+        for unit, unit_ref in units:
+            storage_path = unit[constants.STORAGE_PATH]
+            if storage_path:
+                self._reset_storage_path(unit)
+                unit_url, destination = self._url_and_destination(unit_inventory.base_URL, unit)
+                _request = listener.create_request(unit_url, destination, unit, unit_ref)
+                download_list.append(_request)
+            else:
+                unit = unit_ref.fetch()
+                self.add_unit(request, unit)
+        if not download_list:
+            return
+        container = ContentContainer()
+        request.summary.sources = container.download(
+                request.cancel_event,
+                request.downloader,
+                download_list,
+                listener)
+        request.summary.errors.extend(listener.error_list)
 
     def _url_and_destination(self, base_url, unit):
         """

--- a/nodes/test/unit/test_plugins.py
+++ b/nodes/test/unit/test_plugins.py
@@ -952,10 +952,17 @@ class ImporterTest(PluginTestBase):
         dist.publish_repo(repo, conduit, cfg)
         # make the published unit have a newer _last_updated.
         collection = connection.get_collection(unit_db.unit_collection_name(self.UNIT_TYPE_ID))
+        # N=0 (no file)
         unit = collection.find_one({'N': 0})
-        unit['age'] = 84
+        unit['age'] = 84  # this will be updated back to 42.
         unit['_last_updated'] -= 1
+        unit['_storage_path'] = None
         collection.update({'N': 0}, unit, safe=True)
+        # N=1
+        unit = collection.find_one({'N': 1})
+        unit['age'] = 85   # this will be updated back to 42.
+        unit['_last_updated'] -= 1
+        collection.update({'N': 1}, unit, safe=True)
         # Test
         importer = NodesHttpImporter()
         publisher = dist.publisher(repo, cfg)
@@ -977,4 +984,6 @@ class ImporterTest(PluginTestBase):
             importer.sync_repo(repo, conduit, configuration)
         # Verify
         unit = collection.find_one({'N': 0})
+        self.assertEqual(unit['age'], 42)
+        unit = collection.find_one({'N': 1})
         self.assertEqual(unit['age'], 42)

--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -66,11 +66,14 @@ if sys.version_info >= (2, 6):
         '/usr/lib/pulp/plugins/types',
         '/var/lib/pulp/celery',
         '/var/lib/pulp/nodes/published',
+        '/var/lib/pulp/nodes/published/http',
+        '/var/lib/pulp/nodes/published/https',
         '/var/lib/pulp/published',
         '/var/lib/pulp/static',
         '/var/lib/pulp/uploads',
         '/var/log/pulp',
         '/var/www/pulp',
+        '/var/www/pulp/nodes',
         '/var/www/.python-eggs',  # needed for older versions of mod_wsgi
     ])
 
@@ -96,8 +99,9 @@ if sys.version_info >= (2, 6):
         ('server/srv/pulp/webservices.wsgi', '/srv/pulp/webservices.wsgi'),
 
         # Pulp Nodes
-        ('/var/lib/pulp/content', '/var/www/pulp/nodes'),
-        ('/var/lib/pulp/nodes/published', '/var/www/pulp/nodes'),
+        ('/var/lib/pulp/content', '/var/www/pulp/nodes/content'),
+        ('/var/lib/pulp/nodes/published/http', '/var/www/pulp/nodes/http'),
+        ('/var/lib/pulp/nodes/published/https', '/var/www/pulp/nodes/https'),
         ('nodes/parent/etc/httpd/conf.d/pulp_nodes.conf', '/etc/httpd/conf.d/pulp_nodes.conf'),
         ('nodes/child/etc/pulp/server/plugins.conf.d/nodes/importer/http.conf',
          '/etc/pulp/server/plugins.conf.d/nodes/importer/http.conf'),


### PR DESCRIPTION
https://pulp.plan.io/issues/1463

Basically the logic needed to be updated to detect that an updated unit has an associated file that needs to be downloaded.  When this is detected, we need to use the same approach as a newly added unit.  The conduit logic does the right thing depending on whether it's a new unit or an updated one.

I also noticed during testing that pulp-dev needed to be fixed to properly deal with changes introduced as part of: https://github.com/pulp/pulp/pull/2239.

The unit tests (white box) for nodes were stripped down a while back because they were broken as part of a platform change and never fixed/replaced.  This functionality (change) is covered by the remaining (black box) tests.