### PR TITLE
unit association query uses model serializers

### DIFF
--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -282,6 +282,11 @@ class ModelSerializer(BaseSerializer):
             crit_dict['fields'] = [self._translate(model, field) for field in crit.fields]
         return Criteria.from_dict(crit_dict)
 
+    # expose these "private" methods as public, pending a more in-depth refactor
+    # https://pulp.plan.io/issues/1555
+    translate_field = _translate
+    translate_filters = _translate_filters
+
 
 class Repository(ModelSerializer):
     """


### PR DESCRIPTION
When building mongo queries, UnitAssociationQuery wasn't translating the
incoming fields to their proper mongo fields via the model serializer.

To start, this change makes "public" the serializer translate methods that
provide useful functionality when incoming criteria get broken down into
their actual mongo queries.

Then, those public methods are used by UnitAssociationQuery to translate
model fields before building queries to mongo.

https://pulp.plan.io/issues/1527
fixes #1527