### PR TITLE
Use model serializers when searching mongoengine content units

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -108,6 +108,21 @@ def get_unit_model_querysets(repo_id, model_class, repo_content_unit_q=None):
         yield model_class.objects(id__in=chunk)
 
 
+def get_repo_unit_type_ids(repo_id):
+    """
+    Retrieve all the content unit type ids associated with a given repository.
+
+    :param repo_id: ID of the repo whose unit models should be retrieved.
+    :type  repo_id: str
+
+    :return: A list of content unit type ids
+    :rtype:  list of str
+    """
+    unit_type_ids = model.RepositoryContentUnit.objects(
+        repo_id=repo_id).distinct('unit_type_id')
+    return unit_type_ids
+
+
 def get_repo_unit_models(repo_id):
     """
     Retrieve all the MongoEngine models for units in a given repository. If a unit
@@ -120,8 +135,7 @@ def get_repo_unit_models(repo_id):
     :return: A list of sub-classes of ContentUnit that define a unit model.
     :rtype:  list of pulp.server.db.model.ContentUnit
     """
-    unit_types = model.RepositoryContentUnit.objects(
-        repo_id=repo_id).distinct('unit_type_id')
+    unit_types = get_repo_unit_type_ids(repo_id)
     unit_models = [plugin_api.get_unit_model_by_id(type_id) for type_id in unit_types]
     # Filter any non-MongoEngine content types.
     return filter(None, unit_models)

--- a/server/pulp/server/controllers/units.py
+++ b/server/pulp/server/controllers/units.py
@@ -66,3 +66,32 @@ def get_unit_key_fields_for_type(type_id):
         return tuple(type_def['unit_key'])
 
     raise ValueError
+
+
+def get_model_serializer_for_type(type_id):
+    """
+    Get a ModelSerializer instance associated with a given unit type id
+
+    Serializers are only needed with mongoengine models.
+
+    This will return None for pymongo models or mongoengine models that do not have a serializer.
+
+    :param type_id: unique ID for a unit type
+    :type  type_id: str
+
+    :return:    model serializer instance, if available
+    :rtype:     pulp.server.webservices.views.serializers.ModelSerializer or None
+
+    :raises ValueError: if the type ID is not found
+    """
+    model_class = plugin_api.get_unit_model_by_id(type_id)
+    # mongoengine models have a SERIALIZER attr, which is exposed via the serializer
+    # property as an instance with the associated model
+    if model_class is not None and hasattr(model_class, 'SERIALIZER'):
+        serializer = model_class.SERIALIZER
+        # model serializer methods currently take the model class as an arg
+        # so stash the model class on the serializer for now, and this all
+        # gets made better with https://pulp.plan.io/issues/1555
+        serializer.model = model_class
+        # instantiate the serializer before returning
+        return serializer()

--- a/server/pulp/server/managers/repo/unit_association_query.py
+++ b/server/pulp/server/managers/repo/unit_association_query.py
@@ -5,8 +5,8 @@ import itertools
 
 import pymongo
 
-from pulp.plugins.loader.api import get_unit_model_by_id
 from pulp.plugins.types import database as types_db
+from pulp.server.controllers import units
 from pulp.server.db.model.criteria import UnitAssociationCriteria
 from pulp.server.db.model.repository import RepoContentUnit
 
@@ -350,17 +350,12 @@ class RepoUnitAssociationQueryManager(object):
         :type associated_unit_ids: list
         :rtype: pymongo.cursor.Cursor
         """
-        model = get_unit_model_by_id(unit_type_id)
-        if model and hasattr(model, 'SERIALIZER'):
-            serializer = model.SERIALIZER()
-        else:
-            serializer = None
-
         collection = types_db.type_units_collection(unit_type_id)
+        serializer = units.get_model_serializer_for_type(unit_type_id)
 
         spec = criteria.unit_filters.copy()
         if spec and serializer:
-                spec = serializer.translate_filters(model, spec)
+                spec = serializer.translate_filters(serializer.model, spec)
 
         spec['_id'] = {'$in': associated_unit_ids}
 
@@ -374,7 +369,7 @@ class RepoUnitAssociationQueryManager(object):
             # translate incoming fields (e.g. id -> foo_id)
             if serializer:
                 for index, field in enumerate(fields):
-                    fields[index] = serializer.translate_field(model, field)
+                    fields[index] = serializer.translate_field(serializer.model, field)
 
         cursor = collection.find(spec, fields=fields)
 
@@ -385,7 +380,7 @@ class RepoUnitAssociationQueryManager(object):
         elif serializer:
             sort = list(sort)
             for index, (field, direction) in enumerate(sort):
-                sort[index] = (serializer.translate_field(model, field), direction)
+                sort[index] = (serializer.translate_field(serializer.model, field), direction)
 
         cursor.sort(sort)
 

--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -171,11 +171,7 @@ class ModelSerializer(BaseSerializer):
         """
         document_dict = {}
         for field in instance._fields:
-            if field in self._remapped_fields:
-                document_dict[self._remapped_fields[field]] = getattr(instance, field)
-            else:
-                document_dict[field] = getattr(instance, field)
-
+            document_dict[self.translate_field_reverse(field)] = getattr(instance, field)
         return document_dict
 
     def _translate_filters(self, model, filters):
@@ -250,6 +246,20 @@ class ModelSerializer(BaseSerializer):
                 return getattr(model, internal).db_field
         else:
             return getattr(model, field).db_field
+
+    def translate_field_reverse(self, field):
+        """
+        Converts an internal db field name to the external representation of a field
+
+        :param field: field name (internal name)
+        :type  field: basestring
+
+        :return: the remapped field name to use in external representations
+        :rtype:  basestring
+        """
+        # If the field name is in the remapped_fields dict, return its value
+        # Otherwise, return the field name as-is
+        return self._remapped_fields.get(field, field)
 
     def translate_criteria(self, model, crit):
         """

--- a/server/test/unit/server/webservices/views/serializers/test_content.py
+++ b/server/test/unit/server/webservices/views/serializers/test_content.py
@@ -41,6 +41,7 @@ class TestRemapFieldsFromSerializer(TestCase):
             _ns = StringField(default='dummy_content_name')
             _content_type_id = StringField(required=True, default='content_type')
             unit_key_fields = ()
+            type_specific_id = StringField()
             SERIALIZER = ContentUnitHelperSerializer
         self.content_unit_model = ContentUnitHelper
 
@@ -54,5 +55,7 @@ class TestRemapFieldsFromSerializer(TestCase):
     def test_remap_fields(self, mock_get_model):
         mock_get_model.return_value = self.content_unit_model
         content.remap_fields_with_serializer(self.content_unit)
+        self.assertTrue('type_specific_id' not in self.content_unit,
+                        'type-specific ID field not remapped')
+        self.assertTrue('id' in self.content_unit)
         self.assertEqual(self.content_unit['id'], 'foo')
-        self.assertTrue('type_specific_id' not in self.content_unit)

--- a/server/test/unit/server/webservices/views/serializers/test_serializers.py
+++ b/server/test/unit/server/webservices/views/serializers/test_serializers.py
@@ -411,6 +411,22 @@ class TestModelSerializer(unittest.TestCase):
         result = test_serializer._translate(mock_model, 'external')
         self.assertEqual(result, 'internal_db')
 
+    def test_translate_field_reverse(self):
+        """
+        Test that individual strings are translated correctly from external to internal repr.
+        """
+
+        class FakeSerializer(serializers.ModelSerializer):
+
+            class Meta:
+                remapped_fields = {'internal': 'external'}
+
+        mock_model = mock.MagicMock()
+        mock_model.internal.db_field = 'internal_db'
+        test_serializer = FakeSerializer()
+        result = test_serializer.translate_field_reverse('internal')
+        self.assertEqual(result, 'external')
+
     @mock.patch('pulp.server.db.model.criteria.Criteria.from_dict')
     @mock.patch('pulp.server.webservices.views.serializers.ModelSerializer._translate')
     @mock.patch('pulp.server.webservices.views.serializers.ModelSerializer._translate_filters')


### PR DESCRIPTION
When breaking a criteria down into its raw mongo queries, use the
model serializers for a given content type to adjust the unit search
spec as-needed for each content type in the criteria.

https://pulp.plan.io/issues/1479
fixes #1479

https://pulp.plan.io/issues/1533
fixes #1533

https://pulp.plan.io/issues/1535
fixes #1535

https://pulp.plan.io/issues/1563
fixes #1563