### PR TITLE
Disables all other celery serializers except JSON

### DIFF
--- a/server/pulp/server/async/celery_instance.py
+++ b/server/pulp/server/async/celery_instance.py
@@ -45,6 +45,7 @@ celery.conf.update(CELERYBEAT_SCHEDULE=CELERYBEAT_SCHEDULE)
 celery.conf.update(CELERYBEAT_SCHEDULER='pulp.server.async.scheduler.Scheduler')
 celery.conf.update(CELERY_WORKER_DIRECT=True)
 celery.conf.update(CELERY_TASK_SERIALIZER='json')
+celery.conf.update(CELERY_ACCEPT_CONTENT=['json'])
 
 
 def configure_login_method():

--- a/server/test/unit/server/async/test_celery_instance.py
+++ b/server/test/unit/server/async/test_celery_instance.py
@@ -76,7 +76,15 @@ class TestCelerybeatSchedule(unittest.TestCase):
         """
         self.assertEqual(celery_instance.celery.conf['CELERYBEAT_SCHEDULE'],
                          celery_instance.CELERYBEAT_SCHEDULE)
+
+
+class TestCelerySerializerConfig(unittest.TestCase):
+
+    def test_json_serializer_is_used(self):
         self.assertEqual(celery_instance.celery.conf['CELERY_TASK_SERIALIZER'], 'json')
+
+    def test_json_serializer_is_the_only_one_allowed(self):
+        self.assertEqual(celery_instance.celery.conf['CELERY_ACCEPT_CONTENT'], ['json'])
 
 
 def fake_get(new_config, section, key):


### PR DESCRIPTION
This removes a scary, multiline warning from celery workers when
they start up

https://pulp.plan.io/issues/23
re #23