### PR TITLE
Use the hostname in crane.conf

### DIFF
--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -39,7 +39,7 @@ if [ -d crane ]; then
 [general]
 data_dir: $HOME/devel/crane/metadata
 debug: true
-endpoint: pulp-devel:5001
+endpoint: $(hostname):5001
 EOF
 
     deactivate


### PR DESCRIPTION
Quite hypocritically I hardcoded a hostname into our development environment. This is a commit of shame.