### PR TITLE
Adds validation to the UTCDateTimeField for mongoengine

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -994,7 +994,7 @@ def _do_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_confi
               % {'r': repo_obj.repo_id}))
         raise
 
-    publish_end_timestamp = _now_timestamp()
+    publish_end_timestamp = _now_timestamp(string=False)
 
     # Reload the distributor in case the scratchpad is set by the plugin
     dist = model.Distributor.objects.get_or_404(repo_id=repo_obj.repo_id, distributor_id=dist_id)
@@ -1046,7 +1046,7 @@ def publish_history(start_date, end_date, repo_id, distributor_id):
     return RepoPublishResult.get_collection().find(search_params)
 
 
-def _now_timestamp():
+def _now_timestamp(string=True):
     """
     Return a current timestamp in iso8601 format.
 
@@ -1054,8 +1054,10 @@ def _now_timestamp():
     :rtype:  str
     """
     now = dateutils.now_utc_datetime_with_tzinfo()
-    now_in_iso_format = dateutils.format_iso8601_datetime(now)
-    return now_in_iso_format
+    if string:
+        return dateutils.format_iso8601_datetime(now)
+    else:
+        return now
 
 
 def queue_download_deferred():

--- a/server/pulp/server/db/fields.py
+++ b/server/pulp/server/db/fields.py
@@ -5,8 +5,10 @@ Each field class is inherited from one or more mongoengine fields
 and it provides it's own validation code.
 """
 
+from datetime import datetime
 from isodate import ISO8601Error
 from mongoengine import StringField, DateTimeField
+from mongoengine.errors import ValidationError
 
 from pulp.common import dateutils
 
@@ -48,3 +50,18 @@ class UTCDateTimeField(DateTimeField):
         """
         ret = super(UTCDateTimeField, self).to_python(value)
         return dateutils.ensure_tz(ret)
+
+    def validate(self, value, **kwargs):
+        """
+        Ensures that the value is a datetime.datetime object.
+
+        :param value: The value to validate for this field
+        :type value: datetime.datetime
+
+        :raises: mongoengine.errors.ValidationError
+        """
+
+        if value and not isinstance(value, datetime):
+            raise ValidationError('Value must be a datetime object.', field_name=self.name)
+
+        super(UTCDateTimeField, self).validate(value)

--- a/server/test/unit/server/db/test_fields.py
+++ b/server/test/unit/server/db/test_fields.py
@@ -61,3 +61,8 @@ class TestUTCDateTimeField(unittest.TestCase):
         self.assertEqual(model.timestamp.hour, 18)
         self.assertEqual(model.timestamp.tzinfo.utcoffset(model.timestamp), timedelta(0))
         self.assertEqual(timestamp, model.timestamp)
+
+    def test_string_raises_error(self):
+        time_field = fields.UTCDateTimeField()
+        timestamp = "2016-01-24T20:46:25Z"
+        self.assertRaises(mongoengine.errors.ValidationError, time_field.validate, timestamp)


### PR DESCRIPTION
Due to a bug in datetime utils, we can't rely on mongonegine to
convert a string representation of a timestamp with timezone represented
as Z on end. As a result we now require the date to be supplied as
a datetime object with tzinfo set.

https://pulp.plan.io/issues/1565
closes #1565