### PR TITLE
Create a proxy worker that pools TCP connections.

### DIFF
--- a/streamer/etc/httpd/conf.d/pulp_streamer.conf
+++ b/streamer/etc/httpd/conf.d/pulp_streamer.conf
@@ -36,3 +36,7 @@ Alias /streamer /var/www/streamer
     # Proxy all requests on to the Squid server.
     RewriteRule (.*) http://127.0.0.1:3128/$1 [P]
 </Directory>
+
+<Proxy http://127.0.0.1:3128>
+  ProxySet connectiontimeout=60
+</Proxy>


### PR DESCRIPTION
In Apache's default proxy configuration, workers do not use HTTP Keep-Alive or connection pooling. The TCP connections to the origin server will instead be opened and closed for each request[0]. This is *very* inefficient, especially since we know that we're always connection to localhost:3128. This configures a worker (which does use pooling) and sets a connection timeout of one minute.

[0] https://httpd.apache.org/docs/2.2/mod/mod_proxy.html#workers