### PR TITLE
Adds patch to have Qpid transport ack all processed messages

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -31,7 +31,7 @@
     },
     {
         "name": "python-kombu",
-        "version": "3.0.24-10.pulp",
+        "version": "3.0.24-11.pulp",
         "platform": [ "el6", "el7", "fc22", "fc23"]
     },
     {

--- a/deps/python-kombu/1564.patch
+++ b/deps/python-kombu/1564.patch
@@ -1,0 +1,38 @@
+--- /kombu/transport/qpid.py	2016-01-22 11:55:33.670000000 +0000
++++ /kombu/transport/qpid.py	2016-01-22 12:01:10.283000000 +0000
+@@ -89,6 +89,7 @@
+ import sys
+ import threading
+ import time
++import uuid
+ 
+ from itertools import count
+ from gettext import gettext as _
+@@ -1136,7 +1137,7 @@
+         props = message['properties']
+         props.update(
+             body_encoding=body_encoding,
+-            delivery_tag=next(self._delivery_tags),
++            delivery_tag=uuid.uuid4(),
+         )
+         props['delivery_info'].update(
+             exchange=exchange,
+--- /kombu/tests/transport/test_qpid.py	2016-01-22 11:55:33.669000000 +0000
++++ /kombu/tests/transport/test_qpid.py	2016-01-22 12:05:42.468000000 +0000
+@@ -6,6 +6,7 @@
+ import sys
+ import threading
+ import time
++import uuid
+ 
+ from collections import Callable
+ from itertools import count
+@@ -1364,7 +1365,7 @@
+             mock_message['properties']['body_encoding'], mock_body_encoding,
+         )
+         self.assertIsInstance(
+-            mock_message['properties']['delivery_tag'], int,
++            mock_message['properties']['delivery_tag'], uuid.UUID,
+         )
+         self.assertIs(
+             mock_message['properties']['delivery_info']['exchange'],

--- a/deps/python-kombu/python-kombu.spec
+++ b/deps/python-kombu/python-kombu.spec
@@ -11,7 +11,7 @@ Name:           python-%{srcname}
 # The Fedora package is using epoch 1, so we need to also do that to make sure ours gets installed
 Epoch:          1
 Version:        3.0.24
-Release:        10.pulp%{?dist}
+Release:        11.pulp%{?dist}
 Summary:        AMQP Messaging Framework for Python
 
 Group:          Development/Languages
@@ -23,6 +23,7 @@ Patch0:         1212200.patch
 Patch1:         qpid_fixes.patch
 Patch2:         1168.patch
 Patch3:         1245.patch
+Patch4:         1564.patch
 BuildArch:      noarch
 
 BuildRequires:  python2-devel
@@ -122,6 +123,7 @@ This subpackage is for python3
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 
 # manage requirements on rpm base
 sed -i 's/>=1.0.13,<1.1.0/>=1.3.0/' requirements/default.txt
@@ -178,6 +180,24 @@ popd
 %endif # with_python3
 
 %changelog
+* Mon Jan 25 2016 Brian Bouterse <bbouters@redhat.com> 3.0.24-11.pulp
+- Upgrades kombu to 3.0.24-11 (bbouters@redhat.com)
+- Adds upstream equivalent patch for kombu/celery#563
+- Adds fc23 to dist_list.txt config and removes fc21. (dkliban@redhat.com)
+- Upgrades kombu to 3.0.24-10 (bbouters@redhat.com)
+- Patches downstream Kombu with login_method support (bbouters@redhat.com)
+- Adjusts Qpid broker string and includes Kombu SASL fixes.
+  (bbouters@redhat.com)
+- Remove FC20 from dist_lists.txt (dkliban@redhat.com)
+- Added fc22 to dist_list.txt for pulp and dependencies (dkliban@redhat.com)
+- Removed F22 from dist_list (dkliban@redhat.com)
+- Fixes 917 and 1006 by stopping an thread that should have exited
+  (bbouters@redhat.com)
+- Added Fedora 22 to the dist list (dkliban@redhat.com)
+- Fixes a file descriptor leak in python-kombu (bbouters@redhat.com)
+- Kombu SASL connection, connection closing, and python dep fixes
+  (bbouters@redhat.com)
+
 * Tue Feb 03 2015 Brian Bouterse 3.0.24-5.pulp
 - 1174361 - Revert patch introduced with b0f2319. It is not needed.
   (bbouters@redhat.com)

--- a/rel-eng/packages/python-kombu
+++ b/rel-eng/packages/python-kombu
@@ -1,1 +1,1 @@
-3.0.24-5.pulp deps/python-kombu/
+3.0.24-11.pulp deps/python-kombu/


### PR DESCRIPTION
Adds a patch to python-kombu which uses UUIDs for delivery_tag instead of integers generated by `count()`. This fixes the acks_late issue in python-kombu.

This has been built on EL6, F22, and F23. The EL7 build is blocked, but will get unblocked and built later today. I propose we merge this asap, so downstream can be unblocked.