### PR TITLE
Remove database initialization from content.wsgi.

### DIFF
--- a/server/pulp/server/content/web/wsgi.py
+++ b/server/pulp/server/content/web/wsgi.py
@@ -2,10 +2,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from pulp.server.db import connection
-
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pulp.server.content.web.settings')
 
-connection.initialize()
 application = get_wsgi_application()


### PR DESCRIPTION
Firstly, the content application does not use the database, so it
shouldn't be initializing a connection to the database. Secondly, this
implementation breaks with pymongo-3.x because it was creating a
connection in a parent process (pre-WSGI forking, I believe) which is
not safe (see https://jira.mongodb.org/browse/PYTHON-961).

Without this, it is not possible to download content from Pulp.