### PR TITLE
Sends back a group call report for summary of task group with 0 tasks

### DIFF
--- a/server/pulp/server/webservices/views/task_groups.py
+++ b/server/pulp/server/webservices/views/task_groups.py
@@ -50,13 +50,9 @@ class TaskGroupSummaryView(View):
 
         :return: Response containing a serialized dict of the task group summary
         :rtype : django.http.HttpResponse
-        :raises MissingResource: if group id is not found
         """
         tasks = TaskStatus.objects(group_id=group_id)
         task_group_total = tasks.count()
-
-        if task_group_total == 0:
-            raise MissingResource(group_id)
 
         summary = {'total': task_group_total}
         for state in CALL_STATES:

--- a/server/test/unit/server/webservices/views/test_task_groups.py
+++ b/server/test/unit/server/webservices/views/test_task_groups.py
@@ -6,27 +6,51 @@ import mock
 from .base import assert_auth_READ
 from pulp.common.compat import unittest
 
-from pulp.server.exceptions import MissingResource
 from pulp.server.webservices.views.task_groups import TaskGroupSummaryView
+
+
+class MockQuerySet(object):
+
+    def __init__(self, list_of_objects):
+        self.items = list_of_objects
+        self.i = 0
+        self.n = len(self.items)
+
+    def count(self):
+        return len(self.items)
+
+    def filter(self, state=None):
+        filtered_list = []
+        for item in self.items:
+            if item['state'] == state:
+                filtered_list.append(item)
+        return MockQuerySet(filtered_list)
 
 
 class TestTaskGroupSummary(unittest.TestCase):
     """
     Tests for TaskGroupSummaryView
     """
-
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
                 new=assert_auth_READ())
     @mock.patch('pulp.server.webservices.views.task_groups.TaskStatus.objects')
-    def test_get_task_group_summary_nonexistant(self, mock_objects):
+    @mock.patch(
+        'pulp.server.webservices.views.task_groups.generate_json_response_with_pulp_encoder')
+    def test_get_task_group_summary_nonexistant(self, mock_resp, mock_objects):
         """
         Test get task_group_summary with no tasks
         """
 
         mock_request = mock.MagicMock()
-        mock_objects.return_value.count.return_value = 0
+        mock_objects.return_value = MockQuerySet([])
+
         task_group_summary = TaskGroupSummaryView()
-        self.assertRaises(MissingResource, task_group_summary.get, mock_request, 'mock_task')
+        response = task_group_summary.get(mock_request, 'mock_task')
+
+        expected_content = {'accepted': 0, 'finished': 0, 'running': 0, 'canceled': 0,
+                            'waiting': 0, 'skipped': 0, 'suspended': 0, 'error': 0, 'total': 0}
+        mock_resp.assert_called_with(expected_content)
+        self.assertTrue(response is mock_resp.return_value)
 
     @mock.patch('pulp.server.webservices.views.decorators._verify_auth',
                 new=assert_auth_READ())
@@ -37,23 +61,6 @@ class TestTaskGroupSummary(unittest.TestCase):
         """
         Test get task_group_summary with multiple tasks
         """
-        class MockQuerySet(object):
-
-            def __init__(self, list_of_objects):
-                self.items = list_of_objects
-                self.i = 0
-                self.n = len(self.items)
-
-            def count(self):
-                return len(self.items)
-
-            def filter(self, state=None):
-                filtered_list = []
-                for item in self.items:
-                    if item['state'] == state:
-                        filtered_list.append(item)
-                return MockQuerySet(filtered_list)
-
         mock_request = mock.MagicMock()
         mock_objects.return_value = MockQuerySet([{'id': 'mock_task', 'worker_name': 'mock',
                                                    'state': 'running'},


### PR DESCRIPTION
Originally we wanted to return  a 404 when querying for a task group that has no tasks
associated with it. However, we always return a task group id when kicking off the
applicability regeneration task. User should be able to see that 0 tasks were dispatched
as part of that task group.

https://pulp.plan.io/issues/1582
closes #1582