### PR TITLE
Rewrite script for rolling back to Pulp 2.7

### DIFF
--- a/playpen/all_27.sh
+++ b/playpen/all_27.sh
@@ -1,22 +1,64 @@
 #!/bin/bash
+# Downgrade a Pulp system from master to 2.7.
+#
+# WARNING: This script enabled and disables system-wide yum/dnf repositories and
+# performs other system-wide actions. Execute with care.
+set -euo pipefail
 
-#  When using this script, you will need to fix your database accordingly. If moving backward, you
-#  will need to drop the database, and you will always need to run the migrations.
+# This associative array is incomplete. Patches welcome.
+declare -rA repos_branches=(
+    [pulp]=2.7-dev
+    [pulp_ostree]=1.0-dev
+    [pulp_puppet]=2.7-dev
+    [pulp_python]=1.0-dev
+    [pulp_rpm]=2.7-dev
+)
 
+# Reinstall plugins we know how to handle, and uninstall all others.
+pushd ~/devel
+for repo in pulp*; do
+    # Defend against e.g. a file named "pulp_log.txt".
+    if [ ! -d "$repo" ]; then
+        continue
+    fi
 
-# pulp_docker, pulp_python, pulp_ostree excluded because they are versioned differently
-for repo in pulp pulp_puppet pulp_rpm
-do
-    pushd /home/vagrant/devel/$repo
-    git checkout 2.7-dev
-    find ~/devel -name "*.py[c0]" -delete
-    sudo ./pulp-dev.py --install
+    pushd "$repo"
+    if [ -n "${repos_branches[$repo]:-}" ]; then
+        git checkout "${repos_branches[$repo]}"
+        find . -name '*.py[c0]' -delete
+        sudo ./pulp-dev.py --install
+    else
+        sudo ./pulp-dev.py --uninstall
+    fi
     popd
 done
+popd
 
-for repo in pulp_docker pulp_python
-do
-    pushd /home/vagrant/devel/$repo
-    sudo ./pulp-dev.py --uninstall
-    popd
-done
+set -x
+
+# These aren't used by Pulp 2.7.
+sudo rm /etc/httpd/conf.d/pulp_content.conf
+sudo rm /etc/httpd/conf.d/pulp_streamer.conf
+
+# Pulp 2.7 is incompatible with python-mongoengine >= 3 and python-pymongo >=
+# 0.10.
+sudo dnf  -y remove python-{mongoengine,pymongo}
+sudo dnf config-manager --disablerepo pulp-nightlies
+sudo dnf config-manager --enablerepo pulp-2.7-beta
+sudo dnf -y install python-mongoengine-0.8.8 python-pymongo-2.5.2
+
+fmt <<EOF
+This script does not touch the Pulp database or change the state of Pulp
+services. If downgrading from Pulp master, you may wish to execute the
+following:
+EOF
+cat <<EOF
+
+    mongo pulp_database --eval 'db.dropDatabase()'
+    sudo -u apache pulp-manage-db
+    prestart
+
+EOF
+fmt <<EOF
+If upgrading from Pulp 2.6, you may wish to do something similar.
+EOF


### PR DESCRIPTION
Rewrite `playpen/all_27.sh`:

* Make the script behave more safely by adding `set -euo pipefail`.
* Make the script iterate through all directories named `pulp*` in the `~/devel` directory and either install the correct version of that plugin (if we know what that version is), or uninstall the plugin otherwise.
* Make the script disable the pulp-nightlies repo, enable the pulp-2.7-beta repo, and downgrade the python-{mongoengine,pymongo} packages as appropriate.
* Make the script delete the `/etc/httpd/conf.d/pulp_{content,streamer}` symlinks. These links are broken, and if left in place, they prevent httpd from starting.
* Make the script advise the user on how to drop and recreate the mongo database, and how to restart the Pulp services.