### PR TITLE
Rework the vagrant-setup.sh script to only install once.

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -64,16 +64,7 @@ preset() {
     popd
 
     sudo -u apache pulp-manage-db;
-    # If Crane is present, let's set up the publishing symlinks so that the app files can be used
-    if [ -d $HOME/devel/crane ]; then
-        pushd $HOME/devel/crane
-        mkdir -p metadata/v1 metadata/v2
-        setfacl -m u:apache:rwx metadata/*
-        sudo -u apache mkdir -p /var/lib/pulp/published/docker/v1 /var/lib/pulp/published/docker/v2
-        sudo -u apache ln -s $HOME/devel/crane/metadata/v1 /var/lib/pulp/published/docker/v1/app
-        sudo -u apache ln -s $HOME/devel/crane/metadata/v2 /var/lib/pulp/published/docker/v2/app
-        popd
-    fi
+    setup_crane_links;
     pstart;
     ppopulate;
 }
@@ -151,6 +142,19 @@ pprocs() {
 
 pdebug() {
     telnet 127.0.0.1 4444
+}
+
+setup_crane_links() {
+    # If Crane is present, let's set up the publishing symlinks so that the app files can be used
+    if [ -d $HOME/devel/crane ]; then
+        pushd $HOME/devel/crane
+        mkdir -p metadata/v1 metadata/v2
+        setfacl -m u:apache:rwx metadata/*
+        sudo -u apache mkdir -p /var/lib/pulp/published/docker/v1 /var/lib/pulp/published/docker/v2
+        sudo -u apache ln -s $HOME/devel/crane/metadata/v1 /var/lib/pulp/published/docker/v1/app
+        sudo -u apache ln -s $HOME/devel/crane/metadata/v2 /var/lib/pulp/published/docker/v2/app
+        popd
+    fi
 }
 
 export DJANGO_SETTINGS_MODULE=pulp.server.webservices.settings

--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -88,7 +88,10 @@ done
 echo "Disabling SSL verification on dev setup"
 sudo sed -i 's/# verify_ssl: True/verify_ssl: False/' /etc/pulp/admin/admin.conf
 
-preset
+sudo -u apache pulp-manage-db;
+setup_crane_links;
+pstart;
+ppopulate;
 
 # Give the user some use instructions
 if [ $USER = "vagrant" ]; then


### PR DESCRIPTION
The vagrant-setup.sh script had been installing, uninstalling,
and reinstalling the plugins which took a long time. This was done
for the DRY principle so that some code could be shared with preset
and vagrant-setup.sh, but it cost a few more minutes on each
vagrant up. This commit reworks preset() so that the more complex
operations are split into a common function that vagrant-setup.sh
can still use, which allows it not to call preset.