### PR TITLE
Don't forward requests for files that don't exist to the streamer.

### DIFF
--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -131,11 +131,15 @@ class ContentView(View):
             # Not Authorized
             return HttpResponseForbidden()
 
+        # Immediately 404 if the symbolic link doesn't even exist
+        if not os.path.lexists(request.path_info):
+            return HttpResponseNotFound(request.path_info)
+
         # Already downloaded
         if os.path.exists(path):
             return self.x_send(path)
 
-        # Redirect
+        # Redirect if lazy is on
         if lazy_enabled:
             return self.redirect(request, self.key)
 


### PR DESCRIPTION
Requests for directories or files that don't exist in the repository
should not be forwared to the streamer. This PR updates the view for the
content WSGI app to check for the link in the published repository
before forwarding a request.

closes #1551