### PR TITLE
Launch the streamer with its own script in /usr/bin/

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -661,6 +661,7 @@ The streamer component of the Pulp Lazy Sync feature.
 
 %files -n python-pulp-streamer
 %defattr(-,root,root,-)
+%{_bindir}/pulp_streamer
 %{python_sitelib}/%{name}/streamer/
 %{python_sitelib}/pulp_streamer*.egg-info
 %config(noreplace) %{_sysconfdir}/%{name}/streamer.conf

--- a/streamer/setup.py
+++ b/streamer/setup.py
@@ -13,5 +13,10 @@ setup(
         'nectar >= 1.4.0',
         'setuptools',
         'twisted',
-    ]
+    ],
+    entry_points={
+        'console_scripts': [
+            'pulp_streamer = twisted.scripts.twistd:run'
+        ]
+    }
 )

--- a/streamer/usr/lib/systemd/system/pulp_streamer.service
+++ b/streamer/usr/lib/systemd/system/pulp_streamer.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 User=apache
-ExecStart=/usr/bin/twistd --nodaemon --syslog --prefix=pulp_streamer --pidfile= --python /usr/share/pulp/wsgi/streamer.tac
+ExecStart=/usr/bin/pulp_streamer --nodaemon --syslog --prefix=pulp_streamer --pidfile= --python /usr/share/pulp/wsgi/streamer.tac
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is to pave the way for the SELinux work (issue #1459).