### PR TITLE
Launch the streamer with its own script in /usr/bin/

### DIFF
--- a/streamer/etc/rc.d/init.d/pulp_streamer
+++ b/streamer/etc/rc.d/init.d/pulp_streamer
@@ -16,7 +16,7 @@
 # Short-Description: pulp's lazy content streamer service
 ### END INIT INFO
 
-TWISTD="/usr/bin/twistd"
+TWISTD="/usr/bin/pulp_streamer"
 TWISTD_USER="apache"
 TWISTD_GROUP="apache"
 TWISTD_PID_FILE="/var/run/pulp/pulp_streamer.pid"


### PR DESCRIPTION
This is very much related to #2373 only I forgot Upstart was a thing.

This is to pave the way for the SELinux work (issue #1459)