### PR TITLE
Fixing a reference to the lazy sync section

### DIFF
--- a/docs/user-guide/deferred-download.rst
+++ b/docs/user-guide/deferred-download.rst
@@ -59,8 +59,7 @@ Configuration
 
 In addition to configuring the services listed above, alternate download policies must be
 enabled in the Pulp server configuration. This is located by default in ``/etc/pulp/server.conf``
-and is documented inline. All relevant settings are contained in the ``deferred_downloads``
-section.
+and is documented inline. All relevant settings are contained in the ``lazy`` section.
 
 Once the Pulp server is configured, the Apache reverse proxy, Squid, and the Pulp streamer
 require configuration. A default configuration for Apache is provided by the


### PR DESCRIPTION
Looking at the server.conf file, it seems like this should be lazy and not
deferred_downloads.

https://github.com/pulp/pulp/blob/1360d5d5c8f9b4f2d959970ca920990f33277022/server/etc/pulp/server.conf#L389