### PR TITLE
Fix orphan purge to not fail when content not downloaded.

### DIFF
--- a/server/pulp/server/managers/content/orphan.py
+++ b/server/pulp/server/managers/content/orphan.py
@@ -287,6 +287,10 @@ class OrphanManager(object):
         @param path: absolute path to the file to delete
         @type  path: str
         """
+        if not os.path.lexists(path):
+            _logger.debug(_('Path: {p} does not exist').format(p=path))
+            return
+
         _logger.debug(_('Deleting orphaned file: %(p)s') % {'p': path})
 
         if not os.path.isabs(path):


### PR DESCRIPTION
https://pulp.plan.io/issues/1586

Skip file deletion when unit storage path does not exist.