### PR TITLE
Update the dependencies for the streamer for EL.

### DIFF
--- a/streamer/setup.py
+++ b/streamer/setup.py
@@ -1,4 +1,13 @@
+import platform
 from setuptools import setup, find_packages
+
+
+# In EL twisted is still has sub-packages.
+dist = platform.dist()
+if dist[0] == 'redhat' and int(float(dist[1])) <= 7:
+    twisted = ['twisted-core', 'twisted-web']
+else:
+    twisted = ['twisted']
 
 setup(
     name='pulp-streamer',
@@ -12,8 +21,7 @@ setup(
         'mongoengine >= 0.7.10',
         'nectar >= 1.4.0',
         'setuptools',
-        'twisted',
-    ],
+    ] + twisted,
     entry_points={
         'console_scripts': [
             'pulp_streamer = twisted.scripts.twistd:run'


### PR DESCRIPTION
Twisted's Python packages in EL6 and EL7 are named differently than in
Fedora and other newer distributions. This wasn't a large problem until
we started to use setuputils to make a binary entry, which checks the
installed Python packages.