### PR TITLE
Label the streamer to run under the celery SELinux policy.

### DIFF
--- a/server/selinux/server/pulp-celery.fc
+++ b/server/selinux/server/pulp-celery.fc
@@ -3,3 +3,8 @@
 # Pulp celery workers need to manage temporary files in /var/cache/pulp
 /var/cache/pulp(/.*)? gen_context(system_u:object_r:pulp_var_cache_t,s0)
 /var/run/pulp(/.*)? gen_context(system_u:object_r:pulp_var_run_t,s0)
+
+# Label the Pulp streamer with the celery context. Eventually a policy should
+# be written for the streamer as needs fewer permissions than the celery policy
+# provides, but this allows it to run confined.
+/usr/bin/pulp_streamer -- gen_context(system_u:object_r:celery_exec_t,s0)


### PR DESCRIPTION
This is only the first step towards a "good" SELinux policy. The Celery
profile provides more permissions than the streamer needs to operate, so
it should eventually get its own policy.

closes #1459