### PR TITLE
Ensure the HTTP event notifier sends JSON-encoded bodies.

### DIFF
--- a/server/pulp/server/event/http.py
+++ b/server/pulp/server/event/http.py
@@ -39,7 +39,7 @@ def _send_post(notifier_config, data):
                             contain the 'url' key, and optional 'username' and
                             'password' keys.
     :type notifier_config:  dict
-    :param data:            The POST data as a Python dictionary.
+    :param data:            The POST data as a Python dictionary that is JSON serializable.
     :param data:            dict
     """
     if 'url' not in notifier_config or not notifier_config['url']:
@@ -53,7 +53,7 @@ def _send_post(notifier_config, data):
     else:
         auth = None
 
-    response = post(url, data=data, auth=auth)
+    response = post(url, json=data, auth=auth)
     if response.status_code != 200:
         _logger.error(_('Received HTTP {code} from HTTP notifier to {url}.').format(
             code=response.status_code, url=url))

--- a/server/test/unit/server/event/test_http.py
+++ b/server/test/unit/server/event/test_http.py
@@ -32,7 +32,7 @@ class TestHTTPNotifierTests(unittest.TestCase):
         http._send_post(notifier_config, data)
         mock_post.assert_called_once_with(
             'https://localhost/api/',
-            data=data, auth=None
+            json=data, auth=None
         )
 
     @mock.patch(MODULE_PATH + 'HTTPBasicAuth')
@@ -48,7 +48,7 @@ class TestHTTPNotifierTests(unittest.TestCase):
         http._send_post(notifier_config, data)
         mock_post.assert_called_once_with(
             'https://localhost/api/',
-            data=data,
+            json=data,
             auth=mock_basic_auth.return_value
         )
         mock_basic_auth.assert_called_once_with('jcline', 'hunter2')
@@ -80,7 +80,7 @@ class TestHTTPNotifierTests(unittest.TestCase):
         http._send_post(notifier_config, data)
         mock_post.assert_called_once_with(
             'https://localhost/api/',
-            data=data,
+            json=data,
             auth=mock_basic_auth.return_value
         )
         mock_log.error.assert_called_once_with(expected_log)


### PR DESCRIPTION
By default requests form-encodes post requests. However, there is
a json kwarg that will dump the provided dictionary to JSON and POST
it with the correct content type.

See http://docs.python-requests.org/en/latest/user/quickstart/#more-complicated-post-requests