### PR TITLE
Adding requests-toolbelt to el6, el7, fc23

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -57,6 +57,6 @@
     {
         "name": "python-requests-toolbelt",
         "version": "0.6.0-1",
-        "platform": [ "fc22" ]
+        "platform": [ "el6", "el7", "fc22", "fc23" ]
     }
 ]

--- a/deps/python-requests-toolbelt/dist_list.txt
+++ b/deps/python-requests-toolbelt/dist_list.txt
@@ -1,1 +1,1 @@
-fc22
+el6 el7 fc22 fc23


### PR DESCRIPTION
Since requests-toolbelt still needs to go through testing
repositories, it will be carried by us for those systems
as well until they make it into stable.