### PR TITLE
Unit storage path based on sha256 of unit key instead of using UUID.

### DIFF
--- a/server/pulp/server/content/storage.py
+++ b/server/pulp/server/content/storage.py
@@ -84,6 +84,9 @@ class FileStorage(ContentStorage):
     def get_path(unit):
         """
         Get the appropriate storage path for the specified unit.
+        The path is derived by hashing a string representation of the unit
+        key and combining it with the storage directory and unit type as follows:
+        <storage_dir>/content/units/<digest>[0:2]/<digest>[2:]/
 
         :param unit: A content unit.
         :type unit: pulp.server.db.model.FileContentUnit
@@ -94,11 +97,12 @@ class FileStorage(ContentStorage):
             config.get('server', 'storage_dir'),
             'content',
             'units')
+        digest = unit.unit_key_as_digest(sha256())
         return os.path.join(
             storage_dir,
             unit.type_id,
-            unit.id[0:4],
-            unit.id)
+            digest[0:2],
+            digest[2:])
 
     def put(self, unit, path, location=None):
         """

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -5,6 +5,7 @@ import os
 import random
 import uuid
 from collections import namedtuple
+from hashlib import sha256
 from hmac import HMAC
 
 from mongoengine import (BooleanField, DictField, Document, DynamicField, IntField,
@@ -631,7 +632,7 @@ class ContentUnit(AutoRetryDocument):
         """
         The unit key represented as a string ordered by unit key fields alphabetically
         """
-        return str(sorted([getattr(self, key) for key in self.unit_key_fields]))
+        return self.unit_key_as_digest()
 
     @property
     def unit_key_as_named_tuple(self):
@@ -667,12 +668,30 @@ class ContentUnit(AutoRetryDocument):
         """
         return self._content_type_id
 
+    def unit_key_as_digest(self, algorithm=None):
+        """
+        The digest (hash) of the unit key.
+
+        :param algorithm: A hashing algorithm object. Uses SHA256 when not specified.
+        :type algorithm: hashlib.algorithm
+        :return: The hex digest of the unit key.
+        :rtype: str
+        """
+        _hash = algorithm or sha256()
+        for key, value in sorted(self.unit_key.items()):
+            _hash.update(key)
+            if not isinstance(value, basestring):
+                _hash.update(str(value))
+            else:
+                _hash.update(value)
+        return _hash.hexdigest()
+
     def __hash__(self):
         """
         This should provide a consistent and unique hash where units of the same
         type and the same unit key will get the same hash value.
         """
-        return hash(self._content_type_id + self.unit_key_str)
+        return hash(self.type_id + self.unit_key_as_digest())
 
 
 class FileContentUnit(ContentUnit):


### PR DESCRIPTION
https://pulp.plan.io/issues/1600

Changed `ContentUnit.unit_key_str()` because it did not produce unique results based on unit key.  The problem is that it created a string representation of - a list of sorted *values* that are not associated with their keys.

For example:
```
key_a = {
    'a':1,
    'b':2,
    'c':3,
    'd':3,
    'e':4
}

key_b = {
    'a':3,
    'b':2,
    'c':1,
    'd':4,
    'e':3
}
```

**both** *key_a* and *key_b*  produced the same string '[1, 2, 3, 3, 4]'
