### PR TITLE
Create a simple directory index for the content.wsgi app.

### DIFF
--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -59,6 +59,7 @@ if sys.version_info >= (2, 6):
         '/etc/pulp/server/plugins.conf.d/nodes/distributor',
         '/etc/pulp/vhosts80',
         '/usr/share/pulp',
+        '/usr/share/pulp/templates',
         '/usr/share/pulp/wsgi',
         '/usr/lib/pulp/admin',
         '/usr/lib/pulp/admin/extensions',
@@ -103,6 +104,10 @@ if sys.version_info >= (2, 6):
         ('server/usr/share/pulp/wsgi/content.wsgi', '/usr/share/pulp/wsgi/content.wsgi'),
         ('server/usr/share/pulp/wsgi/repo_auth.wsgi',
          '/usr/share/pulp/wsgi/repo_auth.wsgi'),
+        ('server/usr/share/pulp/templates/404.html', '/usr/share/pulp/templates/404.html'),
+        ('server/usr/share/pulp/templates/500.html', '/usr/share/pulp/templates/500.html'),
+        ('server/usr/share/pulp/templates/directory_index.html',
+         '/usr/share/pulp/templates/directory_index.html'),
 
         # Apache
         ('server/etc/httpd/conf.d/pulp_content.conf', '/etc/httpd/conf.d/pulp_content.conf'),

--- a/pulp.spec
+++ b/pulp.spec
@@ -307,6 +307,9 @@ ln -s %{_var}/lib/pulp/nodes/published/http %{buildroot}/%{_var}/www/pulp/nodes
 ln -s %{_var}/lib/pulp/nodes/published/https %{buildroot}/%{_var}/www/pulp/nodes
 # End Nodes Configuration
 
+# Templates for Django
+install -p -D -m 644 server/usr/share/pulp/templates/* -t %{buildroot}/%{_datadir}/pulp/templates
+
 %endif # End server installation block
 
 # Everything else installation
@@ -404,6 +407,7 @@ Pulp provides replication, access, and accounting for software repositories.
 %dir %{_sysconfdir}/%{name}/server/plugins.conf.d
 %dir %{_sysconfdir}/%{name}/vhosts80
 %dir %{_datadir}/%{name}/wsgi
+%{_datadir}/%{name}/templates
 %{_datadir}/%{name}/wsgi/webservices.wsgi
 %{_datadir}/%{name}/wsgi/content.wsgi
 %{_bindir}/pulp-manage-db

--- a/server/pulp/server/content/web/settings.py
+++ b/server/pulp/server/content/web/settings.py
@@ -34,3 +34,5 @@ USE_L10N = True
 USE_TZ = True
 
 STATIC_URL = '/static/'
+
+TEMPLATE_DIRS = ('/usr/share/pulp/templates/',)

--- a/server/setup.py
+++ b/server/setup.py
@@ -28,5 +28,5 @@ setup(
     install_requires=[
         'blinker', 'celery >=3.1.0, <3.2.0', DJANGO_REQUIRES, 'httplib2', 'iniparse',
         'isodate>=0.5.0', 'm2crypto', 'mongoengine>=0.10.0', 'oauth2>=1.5.211', 'pymongo>=3.0.0',
-        'semantic_version>=2.2.0', 'setuptools']
+        'semantic_version>=2.2.0', 'setuptools'],
 )

--- a/server/usr/share/pulp/templates/404.html
+++ b/server/usr/share/pulp/templates/404.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Not Found</title>
+</head>
+<body>
+    <h1>HTTP 404: Not found.</h1>
+    <p>The URL you requested was not found on this server.</p>
+</body>
+</html>

--- a/server/usr/share/pulp/templates/500.html
+++ b/server/usr/share/pulp/templates/500.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Internal Server Error</title>
+</head>
+<body>
+    <h1>HTTP 500: Internal server error.</h1>
+    <p>An unexpected error occurred while handling your request.</p>
+</body>
+</html>

--- a/server/usr/share/pulp/templates/directory_index.html
+++ b/server/usr/share/pulp/templates/directory_index.html
@@ -1,0 +1,21 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Pulp Repository Index</title>
+</head>
+<body>
+    <h1>Pulp Repository Content</h1>
+    <a href="../">Parent Directory</a>
+
+    <ul style='list-style: none outside none; font-family: monospace'>
+        {% for d in dirs %}
+            <li><a href="{{ d }}/">{{ d }}/</a></li>
+        {% endfor %}
+        {% for f in files %}
+            <li><a href="{{ f }}">{{ f }}</a></li>
+        {% endfor %}
+    </ul>
+</body>
+</html>


### PR DESCRIPTION
In the past we were able to use Apache's directory index feature.
However, for lazy content we pass the request through to the content
WSGI application and are unable to use this feature. This introduces a
simply template that lists the directories and files within a requested
directory, as well as clear HTTP 404 and HTTP 500 error pages.

closes #1512