### PR TITLE
Set Apache to allow unlimited requests per TCP connection.

### DIFF
--- a/server/etc/httpd/conf.d/pulp_apache_22.conf
+++ b/server/etc/httpd/conf.d/pulp_apache_22.conf
@@ -61,6 +61,21 @@ Alias /pulp/static /var/lib/pulp/static
 </Location>
 
 
+# Change the maximum number of times a TCP connection can be reused for HTTP
+# requests from 100 (the default) to 10,000 when HTTP Keep-Alive is enabled.
+# Note that when Keep-Alive requests are made, only the first request (the 
+# one that opened the connection) counts when calculating the 
+# MaxRequestsPerChild value. See Apache's documentation for more information.
+#
+# This configuration does mean it is cheaper for clients to make many
+# requests, so it does increase the server's susceptibility to denial of
+# service attacks. If this is a concern, consider lowering the value.
+#
+# If, on the other hand, DoS attacks are not a concern, consider setting this
+# to 0 (unlimited re-use) and potentially tweaking `KeepAliveTimeout`.
+MaxKeepAliveRequests 10000
+
+
 # Authentication
 #
 # If you want to authenticate against an external source, the best approach is

--- a/server/etc/httpd/conf.d/pulp_apache_24.conf
+++ b/server/etc/httpd/conf.d/pulp_apache_24.conf
@@ -64,6 +64,21 @@ Alias /pulp/static /var/lib/pulp/static
 </Location>
 
 
+# Change the maximum number of times a TCP connection can be reused for HTTP
+# requests from 100 (the default) to 10,000 when HTTP Keep-Alive is enabled.
+# Note that when Keep-Alive requests are made, only the first request (the 
+# one that opened the connection) counts when calculating the 
+# MaxRequestsPerChild value. See Apache's documentation for more information.
+#
+# This configuration does mean it is cheaper for clients to make many
+# requests, so it does increase the server's susceptibility to denial of
+# service attacks. If this is a concern, consider lowering the value.
+#
+# If, on the other hand, DoS attacks are not a concern, consider setting this
+# to 0 (unlimited re-use) and potentially tweaking `KeepAliveTimeout`.
+MaxKeepAliveRequests 10000
+
+
 # Authentication
 #
 # If you want to authenticate against an external source, the best approach is


### PR DESCRIPTION
By default, Apache allows 100 HTTP requests per TCP connection before
resetting it. Since it is not uncommon for Pulp to serve thousands or
tens of thousands of requests from a single client, it makes sense to
not use the default. This is especially noticeable when performing
Pulp-to-Pulp syncs.

This is related to issue #1629.