### PR TITLE
Attempt to guess the MIME type of content served with xsendfile.

### DIFF
--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -1,3 +1,4 @@
+import mimetypes
 import os
 
 from django.http import \
@@ -68,7 +69,13 @@ class ContentView(View):
         :rtype: django.http.HttpResponse
         """
         if os.access(path, os.R_OK):
-            reply = HttpResponse()
+            content_type = mimetypes.guess_type(path)[0]
+            # If the content type can't be detected by mimetypes, send it as arbitrary
+            # binary data. See https://tools.ietf.org/html/rfc2046#section-4.5.1 for
+            # more information.
+            if content_type is None:
+                content_type = 'application/octet-stream'
+            reply = HttpResponse(content_type=content_type)
             reply['X-SENDFILE'] = path
         else:
             reply = HttpResponseForbidden()

--- a/server/test/unit/server/content/web/test_views.py
+++ b/server/test/unit/server/content/web/test_views.py
@@ -42,16 +42,22 @@ class TestContentView(TestCase):
         self.assertEqual(joined, 'http://redhat.com:123http://host/my/path/?age=10')
 
     @patch('os.access')
-    @patch(MODULE + '.HttpResponse')
-    def test_x_send(self, response, access):
+    def test_x_send(self, access):
         path = '/my/path'
-        response.return_value = {}
         access.return_value = True
         reply = ContentView.x_send(path)
         access.assert_called_once_with(path, os.R_OK)
-        response.assert_called_once_with()
-        self.assertEqual(response.return_value['X-SENDFILE'], path)
-        self.assertEqual(reply, response.return_value)
+        self.assertEqual(reply['X-SENDFILE'], path)
+        self.assertEqual(reply['Content-Type'], 'application/octet-stream')
+
+    @patch('os.access')
+    def test_x_send_mime_type(self, access):
+        path = '/my/path.rpm'
+        access.return_value = True
+        reply = ContentView.x_send(path)
+        access.assert_called_once_with(path, os.R_OK)
+        self.assertEqual(reply['X-SENDFILE'], path)
+        self.assertEqual(reply['Content-Type'], 'application/x-rpm')
 
     @patch('os.access')
     @patch(MODULE + '.HttpResponseForbidden')


### PR DESCRIPTION
This is mostly for the benefit of browsers, since the default MIME
type Django uses is text/html which causes the browser to attempt to
render RPMs and such instead of downloading them.

closes #1627