### PR TITLE
Add support for the Docker plugin to all_27.sh

### DIFF
--- a/playpen/all_27.sh
+++ b/playpen/all_27.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # This associative array is incomplete. Patches welcome.
 declare -rA repos_branches=(
     [pulp]=2.7-dev
+    [pulp_docker]=1.0-dev
     [pulp_ostree]=1.0-dev
     [pulp_puppet]=2.7-dev
     [pulp_python]=1.0-dev


### PR DESCRIPTION
Make the script install Docker from the 1.0-dev branch. Why this branch? I
followed the following procedure for choosing it:

1. Go to https://repos.fedorapeople.org/repos/pulp/pulp/fedora-pulp.repo, follow
   the link to the "Version 2.7 Beta Builds" directory, and note the plugin's
   version number there. In this case, `pulp-docker-*-1.0.2-1.fc22.noarch.rpm`
   packages are listed, which means that the plugin's version number as used in
   the last 2.7 beta build is 1.0.2.
2. Find the plugin source code repository, and view that plugin's branches.
3. Choose the branch whose name best matches the beta build version number.

For further context on this process, see https://pulp.plan.io/issues/1351#note-5
and the following discussion.