### PR TITLE
Remove the `enabled` setting for lazy.

### DIFF
--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -356,17 +356,18 @@
 #
 # Settings for lazy content loading.
 #
-# enabled:
-#   This controls whether redirect is enabled
-#
 # redirect_host:
-#   The host FQDN or IP to which requests are redirected.
+#   The host FQDN or IP to which requests are redirected. Defaults to
+#   the local host's fully qualified domain name.
 #
 # redirect_port:
-#   The TCP port to which requests are redirected
+#   The TCP port to which requests are redirected. By default no port
+#   is stated explicitly so an HTTP redirect will use port 80 and an
+#   HTTPS redirect will use port 443. The protocol used will match the
+#   protocol the client used for the initial request.
 #
 # redirect_path:
-#   The base path to which requests are redirected
+#   The base path to which requests are redirected. Defaults to /streamer/
 #
 # https_retrieval:
 #   boolean; controls whether Pulp uses HTTPS or HTTP to
@@ -387,7 +388,6 @@
 #   downloading content from the Squid cache.
 
 [lazy]
-# enabled: false
 # redirect_host:
 # redirect_port:
 # redirect_path:

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -129,7 +129,6 @@ _default_values = {
         'login_method': '',
     },
     'lazy': {
-        'enabled': 'false',
         'redirect_host': socket.getfqdn(),
         'redirect_port': '',
         'redirect_path': '/streamer/',

--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -5,7 +5,6 @@ from django.http import \
     HttpResponse, HttpResponseRedirect, HttpResponseNotFound, HttpResponseForbidden
 from django.views.generic import View
 
-from pulp.common.config import parse_bool
 from pulp.repoauth.wsgi import allow_access
 from pulp.server.lazy import URL, Key
 from pulp.server.config import config as pulp_conf
@@ -131,7 +130,6 @@ class ContentView(View):
         """
         host = request.get_host()
         path = os.path.realpath(request.path_info)
-        lazy_enabled = parse_bool(pulp_conf.get('lazy', 'enabled'))
 
         # Authorization
         if not allow_access(request.environ, host):
@@ -146,9 +144,4 @@ class ContentView(View):
         if os.path.exists(path):
             return self.x_send(path)
 
-        # Redirect if lazy is on
-        if lazy_enabled:
-            return self.redirect(request, self.key)
-
-        # NotFound
-        return HttpResponseNotFound(request.path_info)
+        return self.redirect(request, self.key)

--- a/server/test/unit/server/content/web/test_views.py
+++ b/server/test/unit/server/content/web/test_views.py
@@ -171,52 +171,13 @@ class TestContentView(TestCase):
         redirect.assert_called_once_with(request, view.key)
         self.assertEqual(reply, redirect.return_value)
 
-    @patch('os.path.lexists', Mock(return_value=True))
-    @patch('os.path.realpath')
-    @patch('os.path.exists')
-    @patch(MODULE + '.pulp_conf')
-    @patch(MODULE + '.allow_access')
-    @patch(MODULE + '.HttpResponseNotFound')
-    @patch(MODULE + '.Key.load', Mock())
-    def test_get_not_found(self, not_found, allow_access, pulp_conf, exists, realpath):
-        allow_access.return_value = True
-        exists.return_value = False
-        realpath.side_effect = lambda p: p.upper()
-
-        host = 'localhost'
-        path = '/pulp/content'
-
-        conf = {
-            'authentication': {
-                'rsa_key': '/tmp/key'
-            },
-            'lazy': {
-                'enabled': 'false',
-            }
-        }
-        pulp_conf.get.side_effect = lambda s, p: conf.get(s).get(p)
-
-        request = Mock(path_info=path)
-        request.get_host.return_value = host
-
-        # test
-        view = ContentView()
-        reply = view.get(request)
-
-        # validation
-        allow_access.assert_called_once_with(request.environ, host)
-        realpath.assert_called_once_with(path)
-        exists.assert_called_once_with(path.upper())
-        not_found.assert_called_once_with(path)
-        self.assertEqual(reply, not_found.return_value)
-
     @patch('os.path.lexists', Mock(return_value=False))
     @patch('os.path.realpath', Mock())
     @patch(MODULE + '.allow_access', Mock(return_value=True))
     @patch(MODULE + '.Key.load', Mock())
     @patch(MODULE + '.pulp_conf')
     @patch(MODULE + '.HttpResponseNotFound')
-    def test_get_not_found_no_link(self, not_found, pulp_conf):
+    def test_get_not_found(self, not_found, pulp_conf):
         host = 'localhost'
         path = '/pulp/content'
         request = Mock(path_info=path)


### PR DESCRIPTION
This setting didn't do anything beyond stopping the content WSGI
application from redirecting the client. If the lazy services haven't
been setup, the client will receive a HTTP 503 or HTTP 404.

closes #1649