### PR TITLE
Return gracefully when DownloadStep.cancel() is called before init.

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -1153,7 +1153,10 @@ class DownloadStep(PluginStep, listener.DownloadEventListener):
         Cancel the current step
         """
         super(DownloadStep, self).cancel()
-        self.downloader.cancel()
+        # If this step gets canceled before initialize() completes, the downloader may not exist
+        # yet.
+        if hasattr(self, 'downloader') and self.downloader:
+            self.downloader.cancel()
 
 
 class SaveUnitsStep(PluginStep):

--- a/server/test/unit/plugins/util/test_publish_step.py
+++ b/server/test/unit/plugins/util/test_publish_step.py
@@ -1036,6 +1036,20 @@ class DownloadStepTests(unittest.TestCase):
 
         self.assertTrue(dlstep.downloader.is_canceled)
 
+    def test_cancel_before_intitialize(self):
+        """
+        There was a bug wherein cancel() did not guard against self.downloader not being defined,
+        which meant that any cancel() called before initialize() would cause a traceback. This test
+        asserts that cancel() doesn't raise any exception when downloader is not yet defined.
+
+        https://pulp.plan.io/issues/1645
+        """
+        dlstep = publish_step.DownloadStep('fake-step')
+        dlstep.parent = MagicMock()
+
+        # This should not raise an Exception.
+        dlstep.cancel()
+
 
 @patch('pulp.plugins.util.publish_step.repo_controller.associate_single_unit')
 @patch('pulp.plugins.util.publish_step.units_controller.find_units')


### PR DESCRIPTION
DownloadStep.cancel() had unconditionally called
self.downloader.cancel(), which caused an AttributeError if
cancel() was called before intialize(). This would happen, for
example, if a pulp-docker sync were canceled during metadata
fetching.

https://pulp.plan.io/issues/1645

fixes #1645