### PR TITLE
Rework deferred download guide to include Varnish.

### DIFF
--- a/streamer/etc/httpd/conf.d/pulp_streamer.conf
+++ b/streamer/etc/httpd/conf.d/pulp_streamer.conf
@@ -1,3 +1,5 @@
+# The first path in this `Alias` directive should match the `redirect_path` setting in
+# /etc/pulp/server.conf
 Alias /streamer /var/www/streamer
 
 <Location /streamer/>
@@ -10,9 +12,9 @@ Alias /streamer /var/www/streamer
 
     RewriteEngine on
 
-    # Remove the 'policy' and 'signature' query parameter if it is present in 
-    # the request. Without this Squid receives a different URL for each request
-    # and we aren't able to make use of Squid's caching.
+    # Remove the 'policy' and 'signature' query parameter if it is present in
+    # the request. Without this re-write, the caching proxy receives a different
+    # URL for each request and caching will be pointless.
     #
     # Each block checks for the existence of a key in the query string and, if
     # present, rewrites the URL to remove the key and its value. It begins by
@@ -33,10 +35,18 @@ Alias /streamer /var/www/streamer
     RewriteCond %1%2 (^|&|;)([^(&|;)].*|$)
     RewriteRule ^(.*)$ $1?%2 [DPI]
 
-    # Proxy all requests on to the Squid server.
+    # Proxy all requests on to the Squid server. If you are using a different caching
+    # proxy server, either modify the port it listens on, or change the port here.
+    # For example, Varnish listens on TCP port 6081 by default so this rewrite rule
+    # would change to: RewriteRule (.*) http://127.0.0.1:6081/$1 [P]
     RewriteRule (.*) http://127.0.0.1:3128/$1 [P]
 </Directory>
 
+# By default, Apache doesn't pool reverse proxy TCP connections unless you create a worker
+# using the `Proxy` directive. If you are not using Apache to reverse proxy, you probably
+# don't need any equivalent to this configuration. You will also need to change the port
+# number used here if you are not using Squid, or if Squid is not listening on its default
+# port.
 <Proxy http://127.0.0.1:3128>
   ProxySet connectiontimeout=60
 </Proxy>


### PR DESCRIPTION
We do not actually require Squid to be used as the caching proxy. Many
users may be interested in using a different caching proxy for numerous
reasons (performance, familiarity, ease of configuration etc). This just 
makes it clear that the services are interchangeable with other services.

As a side note, Varnish looks very nice. It'd be worth performance testing it side-by-side with Squid.