### PR TITLE
Query needs to match the catalog unique index.

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -954,8 +954,6 @@ class LazyCatalogEntry(AutoRetryDocument):
         """
         revisions = set([0])
         query = dict(
-            unit_id=self.unit_id,
-            unit_type_id=self.unit_type_id,
             importer_id=self.importer_id,
             path=self.path
         )

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -1097,15 +1097,8 @@ class TestLazyCatalogEntry(unittest.TestCase):
         self.assertEqual(
             objects.filter.call_args_list,
             [
-                call(unit_id=entry.unit_id,
-                     unit_type_id=entry.unit_type_id,
-                     importer_id=entry.importer_id,
-                     path=entry.path),
-                call(revision__in=set([0, 1]),
-                     unit_id=entry.unit_id,
-                     unit_type_id=entry.unit_type_id,
-                     importer_id=entry.importer_id,
-                     path=entry.path),
+                call(importer_id=entry.importer_id, path=entry.path),
+                call(revision__in=set([0, 1]), importer_id=entry.importer_id, path=entry.path),
             ])
         self.assertEqual(entry.revision, 2)
         save.assert_called_once_with()


### PR DESCRIPTION
The query needs to match the catalog index when determining the next revision number.  When a  unit already exists and a plugin is generating catalog entries for a new that I **intends** to add causes duplicate key errors.

Needed for: https://pulp.plan.io/issues/1643