### PR TITLE
Switches SELinux netlink_route_socket to use a Refpol macro

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -36,7 +36,7 @@ require {
 # tcp_socket { shutdown } is needed for CentOS 6 `sudo service pulp_workers restart`
 #
 
-allow celery_t self:netlink_route_socket { bind create getattr nlmsg_read write read };
+allow celery_t self:netlink_route_socket r_netlink_socket_perms;
 allow celery_t self:process { signal signull };
 allow celery_t self:udp_socket { ioctl getattr create connect write read };
 allow celery_t self:unix_dgram_socket { create connect };


### PR DESCRIPTION
The old statement whitelisted explicit permissions and was not
fully complete. It worked on most distributions but not all.
This Refpol version will use a superset which is maintained in
Refpol and is appropriate for use anywhere Refpol is available.

closes #1484
https://pulp.plan.io/issues/1484