### PR TITLE
Allow xsendfile to serve /var/lib/pulp/content.

### DIFF
--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -11,8 +11,9 @@ from pulp.server.lazy import URL, Key
 from pulp.server.config import config as pulp_conf
 
 
-# Make sure all requested paths fall under this directory.
+# Make sure all requested paths fall under these directories.
 PUBLISH_DIR = '/var/lib/pulp/published'
+CONTENT_DIR = '/var/lib/pulp/content'
 
 
 class ContentView(View):
@@ -141,7 +142,7 @@ class ContentView(View):
             # Not Authorized
             return HttpResponseForbidden()
 
-        if not path.startswith(PUBLISH_DIR):
+        if not path.startswith(PUBLISH_DIR) and not path.startswith(CONTENT_DIR):
             # Someone is requesting something they shouldn't.
             return HttpResponseForbidden()
 

--- a/server/test/unit/server/content/web/test_views.py
+++ b/server/test/unit/server/content/web/test_views.py
@@ -152,7 +152,7 @@ class TestContentView(TestCase):
     def test_get_redirected(self, redirect, allow_access, mock_conf_get, exists, realpath):
         allow_access.return_value = True
         exists.return_value = False
-        realpath.side_effect = lambda p: '/var/lib/pulp/published/content'
+        realpath.side_effect = lambda p: '/var/lib/pulp/content/rpm'
 
         host = 'localhost'
         path = '/var/www/pub/content'
@@ -167,7 +167,7 @@ class TestContentView(TestCase):
         # validation
         allow_access.assert_called_once_with(request.environ, host)
         realpath.assert_called_once_with(path)
-        exists.assert_has_call('/var/lib/pulp/published/content')
+        exists.assert_has_call('/var/lib/pulp/content/rpm')
         self.assertTrue(exists.call_count > 0)
         redirect.assert_called_once_with(request, view.key)
         self.assertEqual(reply, redirect.return_value)


### PR DESCRIPTION
When I initially tested the directory index, I used lazy and links
resolved to /var/lib/pulp/published/.../. However, if the content
exists, os.path.realpath follows it into /var/lib/pulp/content/.

This is one of the issues blocking issue 1654.