### PR TITLE
Refine playpen/all_27.sh script

### DIFF
--- a/playpen/all_27.sh
+++ b/playpen/all_27.sh
@@ -17,7 +17,7 @@ declare -rA repos_branches=(
 
 # Reinstall plugins we know how to handle, and uninstall all others.
 pushd ~/devel
-for repo in pulp*; do
+for repo in pulp pulp_*; do
     # Defend against e.g. a file named "pulp_log.txt".
     if [ ! -d "$repo" ]; then
         continue


### PR DESCRIPTION
The `all_27.sh` script walks through each repository in `~/devel/pulp*`, checks
out an appropriate branch, and either installs or uninstalls the code in that
branch using the `pulp-dev.py` script. This works so long as all of the
repositories found are, in fact, either Pulp or one of its plugins. pulp-smash
is neither. Refine the script to make it more precisely find correct
repositories.