### PR TITLE
Update the documented Squid configuration.

### DIFF
--- a/docs/user-guide/deferred-download.rst
+++ b/docs/user-guide/deferred-download.rst
@@ -103,10 +103,18 @@ Squid
 +++++
 
 Squid requires significantly more configuration which is up to the user. To configure squid,
-edit ``/etc/squid/squid.conf``. The following is a basic configuration with inline documentation::
+edit ``/etc/squid/squid.conf``. The following is a basic configuration with inline documentation
+that should work for Squid 3.2 or greater. Since Red Hat Enterprise Linux 6 and CentOS 6 ships
+with Squid 3.1, users of those platforms will need to uncomment a few configuration options::
 
  # Recommended minimum configuration. It is important to note that order
  # matters in Squid's configuration; the configuration is applied top to bottom.
+
+  # Squid 3.1 doesn't define these Access Control Lists by default. RHEL/CentOS 6
+  # users should uncomment the following acl definitions.
+  # acl manager proto cache_object
+  # acl localhost src 127.0.0.1/32 ::1
+  # acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
 
   # Listen on port 3128 in Accelerator (caching) mode.
   http_port 3128 accel


### PR DESCRIPTION
RHEL6 and its derivatives ship with Squid 3.1. This version of Squid
does not define the access control lists used in the documented
configuration by default. This commit adds the necessary definitions
commented out by default with a note about when to uncomment them.

See the default values for each version:
3.1: http://www.squid-cache.org/Versions/v3/3.1/cfgman/acl.html
3.2: http://www.squid-cache.org/Versions/v3/3.2/cfgman/acl.html 