### PR TITLE
Use the unit_fields from criteria in unit_association.

### DIFF
--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -178,6 +178,7 @@ class RepoUnitAssociationManager(object):
             repository=source_repo,
             repo_content_unit_q=association_q,
             units_q=unit_q,
+            unit_fields=criteria['unit_fields'],
             yield_content_unit=True)
 
     @classmethod

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -31,6 +31,17 @@ class TestUnitsFromCriteria(unittest.TestCase):
         self.manager = association_manager.RepoUnitAssociationManager()
         self.repo = me_model.Repository(repo_id='repo1')
 
+    def test_criteria_unit_fields(self, mock_find):
+        """
+        Ensure that the criteria unit_fields are passed on to the find_repo_content_units function.
+        """
+        criteria = UnitAssociationCriteria(unit_fields=['secret_location', 'pasword'])
+
+        self.manager._units_from_criteria(self.repo, criteria)
+
+        self.assertEqual(mock_find.call_count, 1)
+        self.assertEqual(mock_find.mock_calls[0][2]['unit_fields'], ['secret_location', 'pasword'])
+
     def test_limits_by_type(self, mock_find):
         criteria = UnitAssociationCriteria(type_ids=['foo'])
 


### PR DESCRIPTION
pulp.server.managers.repo.unit_association.RepoUnitAssociationManager._units_from_criteria()
was not passing the criteria's unit_fields list along to the next
callee. This caused significant memory usage in certian Pulp
operations. This commit corrects that oversight.

https://pulp.plan.io/issues/1662

fixes #1662