### PR TITLE
bashrc: I went overboard

### DIFF
--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -81,6 +81,22 @@ pclean() {
     ppopulate;
 }
 
+pjournal() {
+    # build up the journalctl cmdline per-unit
+    journal_cmd="journalctl"
+    for svc in ${SERVICES[@]}; do
+        journal_cmd="$journal_cmd -u $svc"
+    done
+
+    if [ -z $1 ]; then
+        # not passed any args, follow the units' journals by default
+        $journal_cmd -f
+    else
+        # passed some args, send all args through to journalctl
+        $journal_cmd $@
+    fi
+}
+
 ptests() {
     pushd $HOME/devel;
     for repo in ${REPOS[@]}; do

--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -19,6 +19,9 @@ source /usr/bin/virtualenvwrapper.sh
 
 alias phttp="http --verify no --cert ~/.pulp/user-cert.pem"
 
+REPOS=("pulp" "pulp_deb" "pulp_docker" "pulp_openstack" "pulp_ostree" "pulp_puppet" "pulp_python" "pulp_rpm")
+SERVICES=("goferd" "httpd" "pulp_workers" "pulp_celerybeat" "pulp_resource_manager" "pulp_streamer")
+
 pstart() {
     _paction start
 }
@@ -46,24 +49,26 @@ pclean() {
     pstop;
 
     pushd ~/devel/
-    # Remove and unlink all development files
-    for r in {pulp_deb,pulp_docker,pulp_openstack,pulp_ostree,pulp_puppet,pulp_python,pulp_rpm,pulp}; do
-        if [ -d $r ]; then
-            pushd $r
+    # Remove and unlink all development files in reverse order (uninstall pulp last)
+    for (( idx=${#REPOS[@]} ; idx>0 ; idx-- )) ; do
+        repo="${REPOS[idx-1]}"
+        if [ -d $repo ]; then
+            pushd $repo
             sudo ./pulp-dev.py -U
             popd
         fi
     done
 
+    # Destroy mongo DB and clean up pulp-related files
     mongo pulp_database ~/drop_database.js;
     sudo rm -rf /var/lib/pulp/*;
     find ~/devel/pulp* -name '*.py[co]' -delete;
     rm -f ~/.pulp/user-cert.pem
 
     # Re-install and relink development files
-    for r in {pulp,pulp_deb,pulp_docker,pulp_openstack,pulp_ostree,pulp_puppet,pulp_python,pulp_rpm}; do
-        if [ -d $r ]; then
-            pushd $r
+    for repo in ${REPOS[@]}; do
+        if [ -d $repo ]; then
+            pushd $repo
             sudo ./pulp-dev.py -I
             popd
         fi
@@ -78,10 +83,10 @@ pclean() {
 
 ptests() {
     pushd $HOME/devel;
-    for r in {pulp,pulp_deb,pulp_docker,pulp_openstack,pulp_ostree,pulp_puppet,pulp_python,pulp_rpm}; do
-        if [ -d $r ]; then
-            pushd $r;
-            workon $r;
+    for repo in ${REPOS[@]}; do
+        if [ -d $repo ]; then
+            pushd $repo;
+            workon $repo;
             ./run-tests.py -x --enable-coverage;
             deactivate;
             popd;
@@ -91,7 +96,7 @@ ptests() {
 }
 
 _paction() {
-    sudo systemctl $1 goferd httpd pulp_workers pulp_celerybeat pulp_resource_manager pulp_streamer
+    sudo systemctl $1 ${SERVICES[@]}
 }
 
 psmash() {

--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -9,6 +9,8 @@ fi
 # export SYSTEMD_PAGER=
 
 # User specific aliases and functions
+# If adding new functions to this file, note that you can add help text to the function
+# by defining a variable with name _<function>_help containing the help text
 
 # Set up virtualenvwrapper
 export WORKON_HOME=$HOME/.virtualenvs
@@ -25,18 +27,22 @@ SERVICES=("goferd" "httpd" "pulp_workers" "pulp_celerybeat" "pulp_resource_manag
 pstart() {
     _paction start
 }
+_pstart_help="Start all pulp-related services"
 
 pstop() {
     _paction stop
 }
+_pstop_help="Stop all pulp-related services"
 
 prestart() {
     _paction restart
 }
+_prestart_help="Restart all pulp-related services"
 
 pstatus() {
     _paction status
 }
+_pstatus_help="Report the status of all pulp-related services"
 
 preset() {
     echo "Due to its similarity to 'prestart', 'preset' has been renamed to 'pclean'."
@@ -44,6 +50,7 @@ preset() {
     sleep 3
     pclean
 }
+# intentionally undocumented, only list pclean in help for this
 
 pclean() {
     pstop;
@@ -80,6 +87,9 @@ pclean() {
     pstart;
     ppopulate;
 }
+_pclean_help="Restore pulp to a clean-installed state"
+# can get away with not resetting terminal settings here since it gets reset in phelp
+_pclean_help="$_pclean_help - `setterm -foreground red -bold on`THIS DESTROYS YOUR PULP DATA"
 
 pjournal() {
     # build up the journalctl cmdline per-unit
@@ -96,6 +106,8 @@ pjournal() {
         $journal_cmd $@
     fi
 }
+_pjournal_help="Interact with the journal for pulp-related units
+    pjournal takes optional journalctl args e.g. 'pjournal -r', runs pjournal -f by default"
 
 ptests() {
     pushd $HOME/devel;
@@ -110,6 +122,7 @@ ptests() {
     done;
     popd;
 }
+_ptests_help="Run tests for pulp and all installed plugins/services"
 
 _paction() {
     sudo systemctl $1 ${SERVICES[@]}
@@ -128,6 +141,7 @@ psmash() {
     deactivate;
     popd;
 }
+_psmash_help="Run pulp smash against the currently running pulp installation"
 
 ppopulate() {
     if [ ! -f $HOME/.pulp/user-cert.pem ]; then
@@ -156,6 +170,7 @@ ppopulate() {
             --package-names=pip
     fi
 }
+_ppopulate_help="Populate pulp with repositories"
 
 pprocs() {
     print_procs() {
@@ -174,10 +189,40 @@ pprocs() {
     print_procs "Pulp WSGI processes:" `pgrep -f "wsgi:pulp"`
     unset IFS
 }
+_pprocs_help="Print running pulp processes IDs"
 
 pdebug() {
     telnet 127.0.0.1 4444
 }
+_pdebug_help="Telnet to a debugger listening locally on port 4444"
+
+phelp() {
+    # get a list of declared functions, filter out ones with leading underscores as "private"
+    funcs=$(declare -F | awk '{ print $3 }'| grep -v ^_)
+
+    # for each func, if a help string is defined, assume it's a pulp function and print its help
+    # (this is bash introspection via variable variables)
+    for func in $funcs; do
+        # get the "help" variable name for this function
+        help_var="_${func}_help"
+        # use ${!<varname>} syntax to eval the help_var
+        help=${!help_var}
+        # If the help var had a value, echo its value here (the value is function help text)
+        if [ ! -z "$help" ]; then
+            # make the function name easy to spot
+            setterm -foreground yellow -bold on
+            echo -n "$func"
+            # reset terminal formatting before printing the help text
+            # (implicitly format it as normal text)
+            setterm -default
+            echo ": $help"
+        fi
+    done
+
+    # explicitly restore terminal formatting is reset before exiting function
+    setterm -default
+}
+_phelp_help="Print this help"
 
 setup_crane_links() {
     # If Crane is present, let's set up the publishing symlinks so that the app files can be used

--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -158,17 +158,21 @@ ppopulate() {
 }
 
 pprocs() {
-    printf "Pulp Worker processes:\n"
-    ps ax | grep "pulp.server.async.app -c 1" | grep -v grep | awk '{ print $1 }'
+    print_procs() {
+        # prints a header string with number of pids, list of pids, and a newline spacer
+        # $1 is the header string, $2 is a newline-separated list of pids, see usage below
+        echo "$1 ($(echo $2|wc -w)):"
+        echo $2
+        echo
+    }
 
-    printf "\nPulp Resource Manager processes:\n"
-    ps ax | grep "pulp.server.async.app -n resource_manager" | grep -v grep | awk '{ print $1 }'
-
-    printf "\nPulp Celerybeat processes:\n"
-    ps ax | grep "pulp.server.async.celery_instance.celery" | grep -v grep | awk '{ print $1 }'
-
-    printf "\nPulp WSGI processes:\n"
-    ps ax | grep "wsgi:pulp" | grep -v grep | awk '{ print $1 }'
+    # override IFS to prevent bash splitting pgrep output on newlines
+    IFS=''
+    print_procs "Pulp worker processes" `pgrep -f "pulp.server.async.app -c 1"`
+    print_procs "Pulp Resource Manager processes" `pgrep -f "pulp.server.async.app -n resource_manager"`
+    print_procs "Pulp Celerybeat processes:" `pgrep -f "pulp.server.async.celery_instance.celery"`
+    print_procs "Pulp WSGI processes:" `pgrep -f "wsgi:pulp"`
+    unset IFS
 }
 
 pdebug() {

--- a/playpen/ansible/roles/dev/files/bashrc
+++ b/playpen/ansible/roles/dev/files/bashrc
@@ -36,6 +36,13 @@ pstatus() {
 }
 
 preset() {
+    echo "Due to its similarity to 'prestart', 'preset' has been renamed to 'pclean'."
+    echo "Please use 'pclean' instead, and remember to update any script that might be calling it."
+    sleep 3
+    pclean
+}
+
+pclean() {
     pstop;
 
     pushd ~/devel/

--- a/playpen/ansible/roles/dev/files/motd
+++ b/playpen/ansible/roles/dev/files/motd
@@ -16,18 +16,9 @@ Here are some tips:
 
 * Each project has a "run-tests.py" to run the unit tests.
 
-* There are a set of bash functions in your .bashrc that are useful:
+* There are a set of bash functions in your .bashrc that are useful.
 
-    pstart:    Start all Pulp services
-    pstop:     Stop all Pulp services
-    prestart:  Restart all Pulp services
-    pstatus:   Report status on all Pulp services
-    ptests:    Run all unit test on all the Pulp repositories
-    psmash:    Run Pulp Smash!
-    preset:    Reset Pulp to a clean install state
-    ppopulate: Populate Pulp with test repositories of several types
-    pprocs:    List all Pulp-related process IDs
-    pdebug:    Start a remote PDB session on localhost
+  Run 'phelp' to list the available functions and what they do.
 
 * phttp is an alias that gives you authenticated access to the rest API using httpie:
 


### PR DESCRIPTION
We'd talked about renaming `preset`, so I started off with that (I renamed it to `pclean`). I also wanted a handy command for easily interacting with the journal for all pulp-related units, but wasn't willing to make yet another copy of the services list, so I converted some repeated lists to arrays and *then* implemented `pjournal`. The `ps ax| grep foo | grep -v grep` is a reimplementation of pgrep`, so I refactored `pprocs`, and now we have so many functions I thought it'd be good to put in a (relatively) easy way to autogenerate a help summary for all the functions in our bashrc.

This PR is broken up into 5 commits so each idea can be reviewed and accepted/rejected. The commits are mostly interdependent, so breaking it up into multiple PRs would probably be tedious for everyone involved.