### PR TITLE
1626 - Fix yum repo sync cancellation.

### DIFF
--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -293,3 +293,19 @@ defined by the `working_directory` config in `server` section of `/etc/pulp/serv
 default value is `/var/cache/pulp`. Any user defined path needs to be owned by user and group
 `apache`. If running with SELinux in Enforcing mode, the path also needs to have
 `system_u:object_r:pulp_var_cache_t` security context. 
+
+Celery terminates the worker in case of sync cancellation.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For some plugin types, if the syncronization of the repo is cancelled, the worker process exits
+immediately with sys.exit(). A new worker process is created immediately, so further tasks are
+normally picked up and executed.
+
+Celery logs this behaviour and you can observe the traceback, which states that no further work can
+be done by that worker. This is normal for cancellation and is not a cause for concern. ::
+
+ celery.worker.job:ERROR: (15328-02560) Task pulp.server.managers.repo.sync.sync[049a534c-6bb1-4329-87c1-66b453348ba4] raised unexpected: Terminated(0,)
+ celery.worker.job:ERROR: (15328-02560) Traceback (most recent call last):
+ celery.worker.job:ERROR: (15328-02560)   File "/usr/lib64/python2.7/site-packages/billiard/pool.py", line 1673, in _set_terminated
+ celery.worker.job:ERROR: (15328-02560)     raise Terminated(-(signum or 0))
+ celery.worker.job:ERROR: (15328-02560) Terminated: 0

--- a/nodes/child/pulp_node/importers/http/importer.py
+++ b/nodes/child/pulp_node/importers/http/importer.py
@@ -135,9 +135,6 @@ class NodesHttpImporter(Importer):
             strategy.synchronize(request)
         except Exception, e:
             summary_report.errors.append(CaughtException(e, repo.id))
-        finally:
-            if downloader is not None:
-                downloader.config.finalize()
 
         summary_report.errors.update(repo_id=repo.id)
         report = conduit.build_success_report({}, summary_report.dict())

--- a/nodes/test/nodes_tests/test_plugins.py
+++ b/nodes/test/nodes_tests/test_plugins.py
@@ -162,6 +162,7 @@ class PluginTestBase(ServerTests):
         self.parentfs = self.tmpdir('parent-')
         self.childfs = self.tmpdir('child-')
         self.alias = (self.parentfs, self.parentfs)
+        self.temp_dir = tempfile.mkdtemp()
         Consumer.get_collection().remove()
         Bind.get_collection().remove()
         model.Repository.objects.delete()
@@ -184,6 +185,7 @@ class PluginTestBase(ServerTests):
         ServerTests.tearDown(self)
         shutil.rmtree(self.parentfs)
         shutil.rmtree(self.childfs)
+        shutil.rmtree(self.temp_dir)
         Consumer.get_collection().remove()
         Bind.get_collection().remove()
         model.Repository.objects.delete()
@@ -641,9 +643,11 @@ class ImporterTest(PluginTestBase):
     @patch('pulp_node.importers.http.importer.Downloader', LocalFileDownloader)
     @patch('pulp_node.importers.http.importer.importer_config_to_nectar_config',
            wraps=importer_config_to_nectar_config)
-    def test_import(self, *mocks):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_import(self, mock_get_working, *mocks):
         # Setup
         self.populate()
+        mock_get_working.return_value = self.temp_dir
         max_concurrency = 5
         max_bandwidth = 12345
         with mock_config.patch({'server': {'storage_dir': self.parentfs}}):
@@ -681,9 +685,11 @@ class ImporterTest(PluginTestBase):
 
     @patch('pulp_node.importers.http.importer.Downloader', LocalFileDownloader)
     @patch('pulp_node.manifest.RemoteManifest.fetch_units')
-    def test_import_cached_manifest_matched(self, mock_fetch, *unused):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_import_cached_manifest_matched(self, mock_get_working, mock_fetch, *unused):
         # Setup
         self.populate()
+        mock_get_working.return_value = self.temp_dir
         with mock_config.patch({'server': {'storage_dir': self.parentfs}}):
             dist = NodesHttpDistributor()
             working_dir = os.path.join(self.childfs, 'working_dir')
@@ -721,9 +727,11 @@ class ImporterTest(PluginTestBase):
             self.assertFalse(mock_fetch.called)
 
     @patch('pulp_node.importers.http.importer.Downloader', LocalFileDownloader)
-    def test_import_cached_manifest_missing_units(self, *unused):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_import_cached_manifest_missing_units(self, mock_get_working, *unused):
         # Setup
         self.populate()
+        mock_get_working.return_value = self.temp_dir
         with mock_config.patch({'server': {'storage_dir': self.parentfs}}):
             dist = NodesHttpDistributor()
             working_dir = os.path.join(self.childfs, 'working_dir')
@@ -758,9 +766,11 @@ class ImporterTest(PluginTestBase):
             self.assertEquals(len(units), self.NUM_UNITS)
 
     @patch('pulp_node.importers.http.importer.Downloader', LocalFileDownloader)
-    def test_import_cached_manifest_units_invalid(self, *unused):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_import_cached_manifest_units_invalid(self, mock_get_working, *unused):
         # Setup
         self.populate()
+        mock_get_working.return_value = self.temp_dir
         with mock_config.patch({'server': {'storage_dir': self.parentfs}}):
             dist = NodesHttpDistributor()
             working_dir = os.path.join(self.childfs, 'working_dir')
@@ -799,9 +809,11 @@ class ImporterTest(PluginTestBase):
     @patch('pulp_node.importers.http.importer.Downloader', LocalFileDownloader)
     @patch('pulp_node.importers.http.importer.importer_config_to_nectar_config',
            wraps=importer_config_to_nectar_config)
-    def test_import_unit_files_already_exist(self, *mocks):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_import_unit_files_already_exist(self, mock_get_working, *mocks):
         # Setup
         self.populate()
+        mock_get_working.return_value = self.temp_dir
         with mock_config.patch({'server': {'storage_dir': self.parentfs}}):
             dist = NodesHttpDistributor()
             working_dir = os.path.join(self.childfs, 'working_dir')
@@ -839,9 +851,11 @@ class ImporterTest(PluginTestBase):
     @patch('pulp_node.importers.http.importer.Downloader', LocalFileDownloader)
     @patch('pulp_node.importers.http.importer.importer_config_to_nectar_config',
            wraps=importer_config_to_nectar_config)
-    def test_import_unit_files_already_exist_size_mismatch(self, *mocks):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_import_unit_files_already_exist_size_mismatch(self, mock_get_working, *mocks):
         # Setup
         self.populate()
+        mock_get_working.return_value = self.temp_dir
         with mock_config.patch({'server': {'storage_dir': self.parentfs}}):
             dist = NodesHttpDistributor()
             working_dir = os.path.join(self.childfs, 'working_dir')
@@ -885,9 +899,11 @@ class ImporterTest(PluginTestBase):
     @patch('pulp_node.importers.http.importer.Downloader', LocalFileDownloader)
     @patch('pulp_node.importers.http.importer.importer_config_to_nectar_config',
            wraps=importer_config_to_nectar_config)
-    def test_import_modified_units(self, *mocks):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_import_modified_units(self, mock_get_working, *mocks):
         # Setup
         self.populate()
+        mock_get_working.return_value = self.temp_dir
         max_concurrency = 5
         max_bandwidth = 12345
         with mock_config.patch({'server': {'storage_dir': self.parentfs}}):

--- a/server/pulp/plugins/util/nectar_config.py
+++ b/server/pulp/plugins/util/nectar_config.py
@@ -1,15 +1,3 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) 2013 Red Hat, Inc.
-#
-# This software is licensed to you under the GNU General Public
-# License as published by the Free Software Foundation; either version
-# 2 of the License (GPLv2) or (at your option) any later version.
-# There is NO WARRANTY for this software, express or implied,
-# including the implied warranties of MERCHANTABILITY,
-# NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
-# have received a copy of GPLv2 along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
 """
 Contains functions related to working with the Nectar downloading library.
 """
@@ -19,6 +7,7 @@ from functools import partial
 from nectar.config import DownloaderConfig
 
 from pulp.common.plugins import importer_constants as constants
+from pulp.server.managers.repo import _common as common_utils
 
 
 def importer_config_to_nectar_config(importer_config):
@@ -51,7 +40,7 @@ def importer_config_to_nectar_config(importer_config):
         (constants.KEY_MAX_SPEED, 'max_speed'),
     )
 
-    download_config_kwargs = {}
+    download_config_kwargs = {'working_dir': common_utils.get_working_directory()}
     adder = partial(_safe_add_arg, importer_config, download_config_kwargs)
     map(adder, translations)
 

--- a/server/test/unit/plugins/util/test_nectar_config.py
+++ b/server/test/unit/plugins/util/test_nectar_config.py
@@ -1,4 +1,8 @@
+import shutil
+import tempfile
 import unittest
+
+from mock import patch
 
 from nectar.config import DownloaderConfig
 
@@ -8,8 +12,16 @@ from pulp.plugins.util import nectar_config
 
 class ConfigTranslationTests(unittest.TestCase):
 
-    def test_importer_config_to_nectar_config_complete(self):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_importer_config_to_nectar_config_complete(self, mock_get_working):
         # Setup
+        mock_get_working.return_value = self.temp_dir
         importer_config = {
             constants.KEY_SSL_CA_CERT: 'ca_cert',
             constants.KEY_SSL_VALIDATION: True,
@@ -46,8 +58,10 @@ class ConfigTranslationTests(unittest.TestCase):
         self.assertEqual(download_config.max_concurrent, 10)
         self.assertEqual(download_config.max_speed, 1024)
 
-    def test_importer_config_to_download_config_partial(self):
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_importer_config_to_download_config_partial(self, mock_get_working):
         # Setup
+        mock_get_working.return_value = self.temp_dir
         importer_config = {
             constants.KEY_SSL_CA_CERT: 'ca_cert',
             constants.KEY_PROXY_HOST: 'proxy',

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -999,7 +999,7 @@ class TestSync(unittest.TestCase):
         mock_spawn_auto_pub.return_value = []
         mock_fire_man = m_factory.event_fire_manager()
         m_repo = m_model.Repository.objects.get_repo_or_missing_resource.return_value
-        mock_result.RESULT_ERROR = 'err'
+        mock_result.RESULT_ERROR = 'error'
 
         m_repo = m_model.Repository.objects.get_repo_or_missing_resource.return_value
         mock_imp = mock.MagicMock()
@@ -1010,7 +1010,7 @@ class TestSync(unittest.TestCase):
         mock_result.expected_result.assert_called_once_with(
             m_repo.repo_id, mock_imp_inst['id'], mock_imp_inst['importer_type_id'],
             mock_now(), mock_now(), -1, -1, -1, mock_gettext(), mock_gettext(),
-            'err'
+            'error'
         )
         m_model.Importer.objects().update.assert_called_once_with(set__last_sync=mock_now())
         mock_result.get_collection().save.assert_called_once_with(mock_result.expected_result())


### PR DESCRIPTION
closes #1626
https://pulp.plan.io/issues/1626

1)This commit fixes the yum repo sync cancellation.
Now cancel_repo_sync() base class  cancels the yum repo sync via calling sys.exit()

2)Some dead code is also removed.
3)Since DownloadConfig.finalize() is not called anymore, nectar config was changed
to use temporary space that tasks use and not use the /tmp for writing temporary files.

I also need to fix tests and celery traceback in the logs
We decided to put the celery traceback into "common issues " in docs.

Another 2 PR should be merged
https://github.com/pulp/pulp_rpm/pull/810
https://github.com/pulp/nectar/pull/44