### PR TITLE
Adds pulp-streamer SELinux policy

### DIFF
--- a/server/selinux/server/build.sh
+++ b/server/selinux/server/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PACKAGE_NAMES=( "pulp-server" "pulp-celery" )
+PACKAGE_NAMES=( "pulp-server" "pulp-celery" "pulp-streamer" )
 SELINUX_VARIANTS="targeted"
 
 for selinuxvariant in ${SELINUX_VARIANTS}

--- a/server/selinux/server/enable.sh
+++ b/server/selinux/server/enable.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PACKAGE_NAMES=( "pulp-server" "pulp-celery" )
+PACKAGE_NAMES=( "pulp-server" "pulp-celery" "pulp-streamer")
 SELINUX_VARIANTS="targeted"
 
 #This script will be called from pulp RPM and needs the ability to use the specified macro

--- a/server/selinux/server/install.sh
+++ b/server/selinux/server/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PACKAGE_NAMES=( "pulp-server" "pulp-celery" )
+PACKAGE_NAMES=( "pulp-server" "pulp-celery" "pulp-streamer" )
 MODULE_TYPE="apps"
 SELINUX_VARIANTS="targeted"
 #This script will be called from pulp RPM and needs the ability to install

--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -167,8 +167,8 @@ ifndef(`distro_rhel6', `
 
 ######################################
 #
-# We can't include this reference policy statement in EL6 because it doesn't know this definition
-# I'm not sure why the allow statements provided by the auth_read_passwd are not needed on EL6
+# systemd start/stop/restart related
+# EL6 does not use systemd
 #
 
 ifndef(`distro_rhel6', `

--- a/server/selinux/server/pulp-server.fc
+++ b/server/selinux/server/pulp-server.fc
@@ -8,4 +8,3 @@
 # Pulp uses python logging to handle logrotate, this requires
 # write/unlink and httpd_log_t only allows httpd_t to append
 /var/log/pulp(/.*)? gen_context(system_u:object_r:httpd_sys_rw_content_t,s0)
-

--- a/server/selinux/server/pulp-streamer.fc
+++ b/server/selinux/server/pulp-streamer.fc
@@ -1,0 +1,1 @@
+/usr/bin/pulp_streamer -- gen_context(system_u:object_r:streamer_exec_t,s0)

--- a/server/selinux/server/pulp-streamer.if
+++ b/server/selinux/server/pulp-streamer.if
@@ -1,0 +1,1 @@
+## <summary></summary>

--- a/server/selinux/server/pulp-streamer.te
+++ b/server/selinux/server/pulp-streamer.te
@@ -1,0 +1,98 @@
+# When built from RPM, the below version of "0.0.0" will be
+# replaced with the version in the spec file
+policy_module(pulp-streamer, 0.0.0)
+type streamer_t;
+type streamer_exec_t;
+init_daemon_domain(streamer_t, streamer_exec_t)
+
+require {
+        type streamer_t;
+        type proc_t;
+        type celery_exec_t;
+}
+
+#============= streamer_t ==============
+#
+allow streamer_t self:netlink_route_socket r_netlink_socket_perms;
+
+allow streamer_t self:tcp_socket create_stream_socket_perms;
+allow streamer_t self:udp_socket create_socket_perms;
+
+# Read from a socket in proc
+allow streamer_t proc_t:file read_sock_file_perms;
+
+# Read /usr/bin/celery for some reason?
+allow streamer_t celery_exec_t:file getattr_file_perms;
+
+
+## Send messages to kernel unix datagram sockets
+kernel_dgram_send(streamer_t)
+
+
+##### Network Related #####
+
+## Read the network config files
+sysnet_read_config(streamer_t)
+
+## Fetching remote content
+corenet_tcp_connect_all_ports(streamer_t)
+
+## Listens on 8751
+corenet_tcp_bind_unreserved_ports(streamer_t)
+corenet_tcp_bind_generic_node(streamer_t)
+
+## Interact with mongodb directly
+corenet_tcp_connect_mongod_port(streamer_t)
+
+
+##### Content Related #####
+
+## Reads certs while fetching content
+miscfiles_read_generic_certs(streamer_t)
+
+## Read /tmp
+files_list_tmp(streamer_t)
+
+## Read Pulp content
+apache_read_sys_content(streamer_t)
+
+
+##### Execute Priviledges #####
+## Exec files in system bin directories
+corecmd_exec_bin(streamer_t)
+
+## Execute ldconfig
+libs_exec_ldconfig(streamer_t)
+
+
+##### Entry Points  #####
+# An entry point allows a transition to streamer_t from
+# another context. For example: shell_exec_t and rpm_exec_t
+
+## Make rpm_exec_t an entry point
+rpm_entry_type(streamer_t)
+
+## Make the shell an entry point
+corecmd_shell_entry_type(streamer_t)
+
+
+##### Logging #####
+
+## Connect to the syslog control unix stream socket
+logging_create_devlog_dev(streamer_t)
+
+## Allow domain to read the syslog pid files.
+logging_read_syslog_pid(streamer_t)
+
+## send logs to syslog
+logging_send_syslog_msg(streamer_t)
+
+
+##### Startup/Shutdown #####
+
+# systemd start/stop/restart related
+# EL6 does not use systemd
+
+ifndef(`distro_rhel6', `
+    auth_read_passwd(streamer_t)
+')

--- a/server/selinux/server/pulp-streamer.te
+++ b/server/selinux/server/pulp-streamer.te
@@ -3,96 +3,73 @@
 policy_module(pulp-streamer, 0.0.0)
 type streamer_t;
 type streamer_exec_t;
-init_daemon_domain(streamer_t, streamer_exec_t)
+init_daemon_domain(streamer_t, streamer_exec_t);
 
 require {
         type streamer_t;
         type proc_t;
         type celery_exec_t;
+        type squid_t;
+        type rpm_exec_t;
 }
 
-#============= streamer_t ==============
-#
-allow streamer_t self:netlink_route_socket r_netlink_socket_perms;
 
-allow streamer_t self:tcp_socket create_stream_socket_perms;
-allow streamer_t self:udp_socket create_socket_perms;
+##### getattr Files #####
 
-# Read from a socket in proc
-allow streamer_t proc_t:file read_sock_file_perms;
-
-# Read /usr/bin/celery for some reason?
+# { getattr } on /usr/bin/celery
 allow streamer_t celery_exec_t:file getattr_file_perms;
 
+# { getattr } on /usr/bin/yum
+allow streamer_t rpm_exec_t:file getattr_file_perms;
 
-## Send messages to kernel unix datagram sockets
-kernel_dgram_send(streamer_t)
+
+##### Kernel Related #####
+
+## Read from /proc/meminfo
+kernel_read_system_state(streamer_t);
 
 
-##### Network Related #####
+##### Network #####
 
-## Read the network config files
-sysnet_read_config(streamer_t)
+## Use nsswitch to look up user, password, group, or host information
+auth_use_nsswitch(streamer_t);
 
 ## Fetching remote content
-corenet_tcp_connect_all_ports(streamer_t)
+corenet_tcp_connect_all_ports(streamer_t);
 
 ## Listens on 8751
-corenet_tcp_bind_unreserved_ports(streamer_t)
-corenet_tcp_bind_generic_node(streamer_t)
-
-## Interact with mongodb directly
-corenet_tcp_connect_mongod_port(streamer_t)
+allow streamer_t self:tcp_socket { listen accept};
+corenet_tcp_bind_all_unreserved_ports(streamer_t);
+corenet_tcp_bind_generic_node(streamer_t);
 
 
-##### Content Related #####
-
-## Reads certs while fetching content
-miscfiles_read_generic_certs(streamer_t)
+##### Content #####
 
 ## Read /tmp
-files_list_tmp(streamer_t)
+files_list_tmp(streamer_t);
 
 ## Read Pulp content
-apache_read_sys_content(streamer_t)
+apache_read_sys_content(streamer_t);
 
 
-##### Execute Priviledges #####
+##### Execute Privileges #####
+
 ## Exec files in system bin directories
-corecmd_exec_bin(streamer_t)
+corecmd_exec_bin(streamer_t);
 
-## Execute ldconfig
-libs_exec_ldconfig(streamer_t)
-
-
-##### Entry Points  #####
-# An entry point allows a transition to streamer_t from
-# another context. For example: shell_exec_t and rpm_exec_t
-
-## Make rpm_exec_t an entry point
-rpm_entry_type(streamer_t)
-
-## Make the shell an entry point
-corecmd_shell_entry_type(streamer_t)
+## Execute ldconfig shared libraries
+libs_exec_ldconfig(streamer_t);
 
 
 ##### Logging #####
 
-## Connect to the syslog control unix stream socket
-logging_create_devlog_dev(streamer_t)
-
-## Allow domain to read the syslog pid files.
-logging_read_syslog_pid(streamer_t)
-
 ## send logs to syslog
-logging_send_syslog_msg(streamer_t)
+logging_send_syslog_msg(streamer_t);
 
 
-##### Startup/Shutdown #####
+##### Squid #####
 
-# systemd start/stop/restart related
-# EL6 does not use systemd
-
-ifndef(`distro_rhel6', `
-    auth_read_passwd(streamer_t)
-')
+# Squid needs tmpfs access to start
+# http://bugs.squid-cache.org/show_bug .cgi?id=4444
+fs_rw_inherited_tmpfs_files(squid_t);
+fs_read_tmpfs_files(squid_t);

--- a/server/selinux/server/relabel.sh
+++ b/server/selinux/server/relabel.sh
@@ -6,16 +6,15 @@ then
     /sbin/restorecon -i -R /etc/httpd/conf.d/pulp.conf
     /sbin/restorecon -i -R /etc/pulp
     /sbin/restorecon -i -R /etc/pki/pulp
-    /sbin/restorecon -i -R /usr/bin/pulp-admin
-    /sbin/restorecon -i -R /usr/bin/pulp-consumer
+    /sbin/restorecon -i /usr/bin/pulp-admin
+    /sbin/restorecon -i /usr/bin/pulp-consumer
     /sbin/restorecon -i -R /var/lib/pulp
     /sbin/restorecon -i -R /var/log/pulp
 fi
 # If upgrading from before 2.5.0
 if [[ $1 < '2.5.0' ]]
 then
-    # Relabel the celery binary
-    /sbin/restorecon -i -R /usr/bin/celery
+    /sbin/restorecon -i /usr/bin/celery
 fi
 # If upgrading from before 2.7.0
 if [[ $1 < '2.7.0' ]]
@@ -27,4 +26,5 @@ fi
 if [[ $1 < '2.8.0' ]]
 then
     /sbin/restorecon -i -R /usr/share/pulp/wsgi
+    /sbin/restorecon -i /usr/bin/pulp_streamer
 fi


### PR DESCRIPTION
I tested this by having lazy installed and all the services running. It compiles on EL6, EL6, and Fedora 22+. Lazy performed correctly on all systems.

If you want to see for yourself, you need to compile the policy and then install it on top of pulp-selinux on a 2.8.0 nightly. You can put SELinux into Enforcing mode and then checkout this PR on the rpm machine.

0. Install and update the `selinux-policy-devel` package on your rpm installation.

1. Set SELinux to Enforcing, or Permissive and monitor for denials `sudo journalctl -f -l | grep denied`. I usually do the Permissive

2. Get the code:  `git fetch`, `git reset --hard origin/1459-Dortmunder-Export`

3. Compile the policy:

```
make NAME=pulp-streamer -f /usr/share/selinux/devel/Makefile DISTRO=rhel7 clean
make NAME=pulp-streamer -f /usr/share/selinux/devel/Makefile DISTRO=rhel6
```

4. Install the policy: `sudo semodule -i pulp-streamer.pp`

5. Run restorecon to label the pulp_streamer file with the correct SELinux label.  `/sbin/restorecon -i /usr/bin/pulp_streamer`

6. Restart all the services for good measure
```
for s in {pulp_celerybeat,pulp_resource_manager,pulp_workers,pulp_streamer,httpd,squid}; do sudo service $s restart; done;
sudo service pulp_streamer stop
sudo service pulp_streamer start
```

7. Do lazy stuff:
```
pulp-admin rpm repo delete --repo-id zoo
pulp-admin orphan remove --all
pulp-admin rpm repo create --repo-id zoo --feed http://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo/
pulp-admin rpm repo update --repo-id zoo --download-policy on_demand
pulp-admin rpm repo sync run --repo-id zoo
pulp-admin repo download --repo-id zoo
```

8. Observe that all that worked and you received no denials. You can check by verifying there are no recommendations for `streamer_t` from `sudo audit2allow -Ral`.

9. You can verify the process is running as streamer_t by showing the process with `ps -awfuxZ | grep streamer` And verifying it is running as `system_u:system_r:streamer_t:s0`.

Thanks to #selinux on freenode for the help, recommendation, and policy review.