### PR TITLE
Dockerizing the 2.8 upgrade validation checker

### DIFF
--- a/playpen/mongoengine/README
+++ b/playpen/mongoengine/README
@@ -1,0 +1,48 @@
+The run.sh script will test your data from pulp < 2.8 to ensure that the
+upgrade process will succeed. It requires you to creata a database dump. It
+does not modify data in your running pulp server, nor does it modify the
+contents of the database dump you provide.
+
+The script starts a docker container running mongodb. It then starts a second
+container that loads your database dump into the mongodb container, and then
+runs the upgrade test script. At the end, both containers are stopped and
+removed.
+
+
+Requirements
+------------
+
+Docker
+Dump of pulp database from mongodb
+
+
+Usage
+-----
+
+1. Create an empty directory, and use it as the working directory for all further steps.
+
+2. Download the run.sh script found near this README.
+
+3. Use mongodump to create a dump of your pulp database. This will create a
+subdirectory called "dump". On EL6 and EL7, mongodump is found in package
+"mongodb".  On Fedora, it is in package "mongo-tools".
+
+For usage, see the documentation link below. In the simplest use case:
+mongodump --db pulp_database
+
+4. If selinux is enforcing, run this command so the docker container will have
+access to the dumped files: sudo chcon -Rt svirt_sandbox_file_t dump 
+
+5. sudo ./run.sh
+
+Progress information will appear on your screen, and that same data will be
+written to disk in a file whose name starts with "upgrade_validation-". If there are any errors,
+please share that log file with the pulp team. You can file an issue here:
+
+https://pulp.plan.io/
+
+
+References
+----------
+
+https://docs.mongodb.org/v2.6/reference/program/mongodump/

--- a/playpen/mongoengine/dockerimage/Dockerfile
+++ b/playpen/mongoengine/dockerimage/Dockerfile
@@ -1,0 +1,28 @@
+FROM centos/httpd
+MAINTAINER Pulp Team <pulp-list@redhat.com>
+
+ADD rhel-pulp.repo /etc/yum.repos.d/rhel-pulp.repo
+
+# We can't install or upgrade httpd on the docker hub build service because of
+# this issue: https://github.com/docker/docker/issues/6980
+# We have to force installing mod_ssl at a newer version than the httpd we
+# have, since the older version is no longer available. It's ok for it to be
+# broken, because we don't actually need to run httpd in this image.
+RUN yum install -y yum-utils && yumdownloader mod_ssl && rpm -i --nodeps mod_ssl-* && yum clean all
+RUN echo "" >> /etc/yum.conf && echo "exclude=httpd* iputils mod_ssl" >> /etc/yum.conf
+
+RUN yum install -y epel-release && yum clean all
+
+RUN yum update -y --skip-broken && \
+    yum groupinstall -y pulp-server && \
+    yum install -y pulp-python-plugins \
+    findutils nmap-ncat mongodb && \
+    yum clean all
+
+ADD run.sh /run.sh
+ADD validation_check.py /validation_check.py
+ADD server.conf /etc/pulp/server.conf
+RUN chgrp apache /etc/pulp/server.conf
+USER apache
+
+CMD ["/run.sh"]

--- a/playpen/mongoengine/dockerimage/rhel-pulp.repo
+++ b/playpen/mongoengine/dockerimage/rhel-pulp.repo
@@ -1,0 +1,10 @@
+# Place this file in your /etc/yum.repos.d/ directory
+
+# Version 2.8 Nightly Builds
+[pulp-v2-nightly]
+name=Pulp 2.8 Nightly Builds
+baseurl=http://repos.fedorapeople.org/repos/pulp/pulp/testing/automation/2.8/dev/7Server/$basearch/
+enabled=1
+skip_if_unavailable=0
+gpgcheck=0
+gpgkey=https://repos.fedorapeople.org/repos/pulp/pulp/GPG-RPM-KEY-pulp-2

--- a/playpen/mongoengine/dockerimage/run.sh
+++ b/playpen/mongoengine/dockerimage/run.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# a hacky way of waiting until mongo is done initializing itself
+until echo "" | nc db 27017 2>/dev/null
+do
+    echo "waiting for mongodb"
+    sleep 1
+done
+
+# Load user data into mongodb. The /dump/ directory should be bind-mounted into
+# the container.
+mongorestore --quiet --host db /dump/
+if [ "$?" -ne "0" ]; then
+    echo ""
+    echo "Could not read dump directory."
+    echo "If selinux in enforcing, consider: chcon -Rt svirt_sandbox_file_t dump"
+    echo ""
+    exit 1
+fi
+
+# supress warnings from mongoengine
+export PYTHONWARNINGS="ignore"
+
+python /validation_check.py
+

--- a/playpen/mongoengine/dockerimage/server.conf
+++ b/playpen/mongoengine/dockerimage/server.conf
@@ -1,0 +1,310 @@
+# =========================
+# Pulp Server Configuration
+# =========================
+
+# This settings in this file are all commented by default, and the commented settings show the
+# default values that Pulp will choose if not specified here.
+
+# -- Common Configuration -----------------------------------------------------
+
+# = Database =
+#
+# Controls the behavior of MongoDB under Pulp's usage.
+#
+# name: name of the database to use
+# seeds: comma-separated list of hostname:port of database replica seed hosts
+# operation_retries: number of retries on database operations to
+#     perform before giving up and reporting an error
+#
+# Authentication - If the username and the password keys have values provided,
+# the pulp server will attempt to authenticate to the MongoDB server.  The
+# username and password provided here will be used to authenticate with the
+# database specified in the name field.
+#
+# username: The user name to use for authenticating to the MongoDB server
+# password: The password to use for authenticating to the MongoDB server
+# replica_set: uncomment and set this value to the name of replica set configured
+#     in MongoDB, if one is in use
+
+[database]
+# name: pulp_database
+seeds: db:27017
+# operation_retries: 2
+# username: admin
+# password: admin
+# replica_set: replica_set_name
+
+
+# = Server =
+#
+# Controls general Pulp web server behavior.
+#
+# server_name:      hostname the admin client and consumers should use when accessing
+#                   the server; if not specified, this is defaulted to the server's hostname
+# default_login:    default admin username of the Pulp server; this user will be
+#                   the first time the server is started
+# default_password: default password for admin when it is first created; this
+#                   should be changed once the server is operational
+# debugging_mode:   boolean; toggles Pulp's debugging capabilities
+# log_level:        The desired logging level. Options are: CRITICAL, ERROR, WARNING, INFO, DEBUG,
+#                   and NOTSET. Pulp will default to INFO.
+[server]
+server_name: pulpapi
+# key_url: /pulp/gpg
+# ks_url: /pulp/ks
+# default_login: admin
+# default_password: admin
+# debugging_mode: false
+# log_level: INFO
+
+
+# = Authentication =
+#
+# Keys used for message authentication.
+#
+# rsa_key:
+#   The RSA private key used for authentication.
+# rsa_pub:
+#   The RSA public key used for authentication.
+
+[authentication]
+# rsa_key = /etc/pki/pulp/rsa.key
+# rsa_pub = /etc/pki/pulp/rsa_pub.key
+
+
+# = Security =
+#
+# Controls aspects of the Pulp web server security.
+#
+# For production installations, it is recommended that a new CA certificate be
+# generated for the signing of user and consumer certificates and configured
+# using the following properties.
+#
+# cacert: full path to the CA certificate that will be used to sign consumer
+#     and admin identification certificates; this must match the value of
+#     SSLCACertificateFile in /etc/httpd/conf.d/pulp.conf
+#
+# cakey: path to the private key for the above CA certificate
+#
+# ssl_ca_certificate: full path to the CA certificate used to sign the Pulp
+#     server's SSL certificate; consumers will use this to verify the
+#     Pulp server's SSL certificate during the SSL handshake
+#
+# user_cert_expiration: number of days a user certificate is valid
+#
+# consumer_cert_expiration: number of days a consumer certificate is valid
+#
+
+[security]
+# cacert: /etc/pki/pulp/ca.crt
+# cakey: /etc/pki/pulp/ca.key
+# ssl_ca_certificate: /etc/pki/pulp/ssl_ca.crt
+# user_cert_expiration: 7
+# consumer_cert_expiration: 3650
+# serial_number_path: /var/lib/pulp/sn.dat
+
+
+# -- Advanced Configuration ---------------------------------------------------
+
+# = Consumer History =
+#
+# Controls the storage of recorded consumer events.
+#
+# lifetime: number of days to store consumer events; events older
+#     than this will be purged; set to -1 to disable
+
+[consumer_history]
+# lifetime: 180
+
+
+# = Data Reaping =
+#
+# Controls the frequency in which reporting data is automatically removed from
+# the database. Database entries that exceed the given thresholds will be
+# deleted from the database when the reaper runs.
+#
+# reaper_interval: float; time in days between checks for old data in
+#     the database
+#
+# archived_calls: float; time in days to store archived calls
+#
+# consumer_history: float; time in days to store consumer history events
+#
+# repo_sync_history: float; time in days to store repository sync history events
+#
+# repo_publish_history: float; time in days to store repository publish history
+#     events
+#
+# repo_group_publish_history: float; time in days to store repository group
+#     publish history events
+#
+# task_status_history: float; time in days to store task status history in the db
+# task_result_history: float; time in days to store task results history
+
+[data_reaping]
+# reaper_interval: 0.25
+# archived_calls: 0.5
+# consumer_history: 60
+# repo_sync_history: 60
+# repo_publish_history: 60
+# repo_group_publish_history: 60
+# task_status_history: 7
+# task_result_history: 3
+
+
+# = LDAP =
+#
+# Uncomment the below section with appropriate values to use an external LDAP
+# server for user authentication.
+#
+# enabled: boolean; controls whether or not LDAP authentication is enabled
+#
+# uri: url of LDAP server
+#
+# base: location in the directory from which the LDAP search begins
+#
+# tls: boolean; controls whether or not to use TLS security
+#
+# default_role: Id of the role to assign LDAP users to by default. This is
+#     optional. This role must first be created on the Pulp server. If
+#     default_role is not set or doesn't exist, LDAP users are given same
+#     default permissions as local users.
+#
+# filter: directive to set more restrictive LDAP filter to limit the LDAP
+#     users who can authenticate to Pulp
+
+# Deprecated! Please use apache's mod_authnz_ldap to do preauthentication. See
+# pulp's user guide for details.
+# [ldap]
+# enabled: true # are you sure? This has been deprecated.
+# uri: ldap://localhost
+# base: dc=localhost
+# tls: no
+# default_role: <role-id>
+# filter: (gidNumber=200)
+
+
+# = OAuth =
+#
+# Uncomment the below section with appropriate values to use OAuth
+# authentication.
+#
+# enabled: boolean; controls whether OAuth authentication is enabled
+#
+# oauth_key: string; key to enable OAuth style authentication
+#
+# oauth_secret: string; shared secret that can be used for OAuth style
+#     authentication
+
+[oauth]
+# enabled: true
+# oauth_key:
+# oauth_secret:
+
+
+# = Messaging =
+#
+# Controls Pulp's configuration of broker settings for communicating to the Consumer Agent.
+#
+# url: the url used to contact the broker. This setting uses the form:
+#
+#         <protocol>://<host>:<port>/<virtual-host>
+#
+#     Or to use a username and password:
+#
+#         <protocol>://<user>:<password>@<host>:<port>/<virtual-host>
+#
+#     Supported <protocol>  values are 'tcp' or 'ssl' depending on if SSL should be used or not.
+#     The <virtual-host> is optional, and is only applicable to RabbitMQ broker environments.
+#
+#     The default broker string is 'tcp://localhost:5672'.
+#
+# transport: The type of broker you are connecting to. The default is 'qpid'. For RabbitMQ,
+#     'rabbitmq' should be used.
+#
+# cacert: Absolute path to PEM encoded CA certificate file, used by Pulp to validate the identity
+#     of the broker using SSL. The default is '/etc/pki/qpid/ca/ca.crt'.
+#
+# clientcert: Absolute path to PEM encoded file containing both the private key and
+#     certificate Pulp should present to the broker to be authenticated by the broker. The default
+#     is '/etc/pki/qpid/client/client.pem'.
+#
+# auth_enabled:
+#     Message authentication enabled flag. The default is 'true' which enables authentication.
+#     To disable authentication, use 'false'.
+#
+# topic_exchange: The name of the exchange to use. The exchange must be a topic exchange. The
+#     default is 'amq.topic', which is a default exchange that is guaranteed to exist on a Qpid
+#     broker. This setting is a string, and therefore includes the single quotes.
+#
+
+[messaging]
+url: tcp://qpid:5672
+# transport: qpid
+auth_enabled: false
+# cacert: /etc/pki/qpid/ca/ca.crt
+# clientcert: /etc/pki/qpid/client/client.pem
+# topic_exchange: 'amq.topic'
+
+
+# = Asynchronous Tasks =
+#
+# Controls Pulp's Celery settings. These settings are used by the Pulp Server and Pulp Workers to
+# perform asynchronous, server-side task work such as syncing, publishing, or deletion of content.
+# Communication between these different components occurs through the broker.
+#
+# broker_url: A URL to a broker that Celery can use to queue tasks. For example, to configure
+#     Celery with a Qpid backend, set broker_url to:
+#
+#         qpid://<username>:<password>@<hostname>:<port>/
+#
+#     For RabbitMQ you can use the following broker_url style:
+#
+#         amqp://<username>:<password>@<hostname>:<port>/<vhost>
+#
+# celery_require_ssl: Require SSL if set to 'true', otherwise do not require SSL. The default is
+#     'false'.
+#
+# cacert: The absolute path to the PEM encoded CA Certificate allowing identity validation of the
+#     message bus. The default is '/etc/pki/pulp/qpid/ca.crt'.
+#
+# keyfile: The absolute path to the keyfile used for authentication to the message bus. This is the
+#     private key that corresponds with the certificate. The default value is
+#     '/etc/pki/pulp/qpid/client.crt'. Sometimes the key is kept in the same file as the
+#     certificate it corresponds with, and the default assumes this is the case.
+#
+# certfile: The absolute path to the PEM encoded certificate used for authentication to the message
+#     bus. The default value is '/etc/pki/pulp/qpid/client.crt'.
+#
+
+[tasks]
+broker_url: qpid://qpid:5672/
+# celery_require_ssl: false
+# cacert: /etc/pki/pulp/qpid/ca.crt
+# keyfile: /etc/pki/pulp/qpid/client.crt
+# certfile: /etc/pki/pulp/qpid/client.crt
+
+
+# = Email =
+#
+# Settings that allow the system to send email. It is recommended that
+# the system relay through a local MTA on the machine. Pulp does not retry in
+# case of error, so it is important to have a real MTA available locally.
+#
+# If there is a need to test email sending, it is recommended to run this:
+#   $ python -m smtpd -n -c DebuggingServer localhost:1025
+# which will write each message to stdout.
+#
+# host: host name of the MTA pulp should relay through
+#
+# port: destination port to connect on
+#
+# from: the "From" address of each email the system sends
+#
+# enabled: boolean controls whether or not emails will be sent
+
+[email]
+# host: localhost
+# port: 25
+# from: no-reply@your.domain
+# enabled: false

--- a/playpen/mongoengine/run.sh
+++ b/playpen/mongoengine/run.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+DBNAME="28upgradedb"
+LINKS="--link $DBNAME:db"
+DUMPDIR=`pwd`/dump
+MOUNTS="-v $DUMPDIR:/dump/:ro -v /dev/log:/dev/log"
+LOGFILE=upgrade_validation-`date -u +%Y%m%d%H%M%S`.log
+
+docker run -d --name $DBNAME -v /dev/log:/dev/log pulp/mongodb
+docker run -it --rm $LINKS $MOUNTS pulp/28upgradetest | tee $LOGFILE
+docker stop $DBNAME
+docker rm $DBNAME


### PR DESCRIPTION
https://pulp.plan.io/issues/1416

re #1416

This can be tested now. I'm building from this branch into the correct docker hub repository, so you can follow the instructions in the README exactly.