### PR TITLE
Fixed a simple argument mismatch bug in content sources code.

### DIFF
--- a/server/pulp/server/controllers/content.py
+++ b/server/pulp/server/controllers/content.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from gettext import gettext as _
 from logging import getLogger
-import threading
 
 import celery
 
@@ -70,9 +69,8 @@ class ContentSourcesRefreshStep(Step):
     def process_main(self, item=None):
         if item:
             self.progress_description = item.descriptor['name']
-            e = threading.Event()
             self.progress_details = self.progress_description
-            report = item.refresh(e)[0]
+            report = item.refresh()[0]
             if not report.succeeded:
                 raise PulpCodedTaskException(error_code=error_codes.PLP0031, id=report.source_id,
                                              url=report.url)

--- a/server/test/unit/server/content/sources/test_content.py
+++ b/server/test/unit/server/content/sources/test_content.py
@@ -1,0 +1,44 @@
+import inspect
+
+from pulp.common import error_codes
+from pulp.common.compat import unittest
+from pulp.server.content.sources.model import ContentSource, RefreshReport
+from pulp.server.controllers.content import ContentSourcesRefreshStep
+
+import mock
+from pulp.server.exceptions import PulpCodedException
+
+
+class TestRefreshStepProcessMain(unittest.TestCase):
+    def setUp(self):
+        self.conduit = mock.MagicMock()
+        self.step = ContentSourcesRefreshStep(self.conduit)
+        self.source = ContentSource('foo', {'name': 'foo'})
+        self.report = RefreshReport('foo', 'http://foo.com')
+        self.report.succeeded = True
+
+    def test_calls_refresh(self):
+        """
+        Ensure the source's refresh method gets called with the right args.
+        """
+        with mock.patch.object(self.source, 'refresh', spec_set=True) as mock_refresh:
+            mock_refresh.return_value = [self.report]
+            self.step.process_main(item=self.source)
+
+        # assert that the real function takes the args we think it takes
+        self.assertEqual(inspect.getargspec(ContentSource.refresh).args, ['self'])
+        # then make sure we pass the right args
+        mock_refresh.assert_called_once_with()
+
+    def test_report_failed_raises_exception(self):
+        """
+        Ensure that a pulp coded exception is raised with the correct error code.
+        """
+        self.report.succeeded = False
+
+        with mock.patch.object(self.source, 'refresh', spec_set=True) as mock_refresh:
+            mock_refresh.return_value = [self.report]
+            with self.assertRaises(PulpCodedException) as assertion:
+                self.step.process_main(item=self.source)
+
+        self.assertEqual(assertion.exception.error_code, error_codes.PLP0031)


### PR DESCRIPTION
https://pulp.plan.io/issues/1692
The bug was introduced here: https://github.com/pulp/pulp/pull/2116/files#diff-4e345a77fb83e6a3dbcb29e9e12b7808R65
... without a corresponding change to the calling code.

fixes #1692