### PR TITLE
Move the log function definition up in the init script.

### DIFF
--- a/streamer/etc/rc.d/init.d/pulp_streamer
+++ b/streamer/etc/rc.d/init.d/pulp_streamer
@@ -26,6 +26,13 @@ TWISTD_LOG_DIR="/var/log/pulp"
 TWISTD_OPTS="--pidfile=$TWISTD_PID_FILE --syslog \
  --prefix=pulp_streamer --python /usr/share/pulp/wsgi/streamer.tac"
 
+# this function implements the fix for bz #1145723
+write_log_message () {
+  touch $TWISTD_LOG_FILE && chown $TWISTD_USER $TWISTD_LOG_FILE
+  echo -n `date "+%Y-%m-%d %T"` >> $TWISTD_LOG_FILE
+  echo " $1" >> $TWISTD_LOG_FILE
+}
+
 export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 
 if [ -L "$0" ]; then
@@ -151,13 +158,6 @@ wait_pid () {
             fi
         fi
     done
-}
-
-# this function implements the fix for bz #1145723
-write_log_message () {
-  touch $TWISTD_LOG_FILE && chown $TWISTD_USER $TWISTD_LOG_FILE
-  echo -n `date "+%Y-%m-%d %T"` >> $TWISTD_LOG_FILE
-  echo " $1" >> $TWISTD_LOG_FILE
 }
 
 case "$1" in


### PR DESCRIPTION
This change is required because there is a log statement above the
function definition.