### PR TITLE
Make use of `wsgi.url_scheme`, a PEP333 required variable.

### DIFF
--- a/server/pulp/server/content/web/views.py
+++ b/server/pulp/server/content/web/views.py
@@ -99,7 +99,7 @@ class ContentView(View):
         :rtype: django.http.HttpResponse
         """
         path = os.path.realpath(request.path_info)
-        scheme = request.environ['REQUEST_SCHEME']
+        scheme = request.environ['wsgi.url_scheme']
         host = request.environ['SERVER_NAME']
         port = request.environ['SERVER_PORT']
         query = request.environ['QUERY_STRING']

--- a/server/test/unit/server/content/web/test_views.py
+++ b/server/test/unit/server/content/web/test_views.py
@@ -106,9 +106,9 @@ class TestContentView(TestCase):
     @patch(MODULE + '.HttpResponseRedirect')
     def test_redirect(self, redirect, pulp_conf, url):
         remote_ip = '172.10.08.20'
-        scheme = 'http'
+        scheme = 'https'
         host = 'localhost'
-        port = 80
+        port = 443
         path = '/var/pulp/content/zoo/lion'
         redirect_path = '/streamer'
         query = 'arch=x86'
@@ -124,15 +124,9 @@ class TestContentView(TestCase):
             }
         }
         pulp_conf.get.side_effect = lambda s, p: conf.get(s).get(p)
-        environ = {
-            'REQUEST_SCHEME': scheme,
-            'SERVER_NAME': host,
-            'SERVER_PORT': port,
-            'REDIRECT_URL': redirect_path,
-            'QUERY_STRING': query,
-            'REMOTE_ADDR': remote_ip
-        }
-        request = Mock(environ=environ, path_info=path)
+        self.environ['QUERY_STRING'] = query
+        self.environ['REMOTE_ADDR'] = remote_ip
+        request = Mock(environ=self.environ, path_info=path)
         key = Mock()
 
         # test


### PR DESCRIPTION
`REQUEST_SCHEME` is not a variable that must be present in the environ
dictionary, and in fact is _not_ present in EL6's version of Apache
httpd.