### PR TITLE
Fix performance regression in associated unit queries.

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -74,8 +74,8 @@ def get_associated_unit_ids(repo_id, unit_type, repo_content_unit_q=None):
     qs = model.RepositoryContentUnit.objects(q_obj=repo_content_unit_q,
                                              repo_id=repo_id,
                                              unit_type_id=unit_type)
-    for assoc in qs.only('unit_id'):
-        yield assoc.unit_id
+    for assoc in qs.only('unit_id').as_pymongo():
+        yield assoc['unit_id']
 
 
 def get_unit_model_querysets(repo_id, model_class, repo_content_unit_q=None):

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -32,26 +32,26 @@ class DemoModel(model.ContentUnit):
 class TestGetAssociatedUnitIDs(unittest.TestCase):
     def setUp(self):
         self.associations = [
-            model.RepositoryContentUnit(repo_id='repo1', unit_id='a', unit_type_id='demo_model'),
-            model.RepositoryContentUnit(repo_id='repo1', unit_id='b', unit_type_id='demo_model'),
+            dict(repo_id='repo1', unit_id='a', unit_type_id='demo_model'),
+            dict(repo_id='repo1', unit_id='b', unit_type_id='demo_model'),
         ]
 
     def test_returns_ids(self, mock_objects):
-        mock_objects.return_value.only.return_value = self.associations
+        mock_objects.return_value.only.return_value.as_pymongo.return_value = self.associations
 
         ret = list(repo_controller.get_associated_unit_ids('repo1', 'demo_model'))
 
         self.assertEqual(ret, ['a', 'b'])
 
     def test_returns_generator(self, mock_objects):
-        mock_objects.return_value.only.return_value = self.associations
+        mock_objects.return_value.only.return_value.as_pymongo.return_value = self.associations
 
         ret = repo_controller.get_associated_unit_ids('repo1', 'demo_model')
 
         self.assertTrue(inspect.isgenerator(ret))
 
     def test_uses_q(self, mock_objects):
-        mock_objects.return_value.only.return_value = self.associations
+        mock_objects.return_value.only.return_value.as_pymongo.return_value = self.associations
         q = mongoengine.Q(foo='bar')
 
         list(repo_controller.get_associated_unit_ids('repo1', 'demo_model', q))


### PR DESCRIPTION
Returning dictionaries instead of document objects reduces the elapsed time by 30x.  For example: An RPM repository containing 12k units - the time for `get_associated_unit_ids()` is reduced from ~3 seconds to ~100 milliseconds. 