### PR TITLE
Add fedora-easy-karma to the dev environment.

### DIFF
--- a/playpen/ansible/roles/core/tasks/main.yml
+++ b/playpen/ansible/roles/core/tasks/main.yml
@@ -3,6 +3,7 @@
   dnf: name={{ item }} state=present
   with_items:
       - bash-completion
+      - fedora-easy-karma
       - htop
       - screen
       - tmux


### PR DESCRIPTION
This CLI tool automatically inspects your box for packages that were installed from the updates-testing repository, and then prompts you for Bodhi
feedback. It's a handy way for us to participate in the updates that are coming our way.