### PR TITLE
python-kombu-3.0.33-4.pulp is now included via external_deps.json

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -31,7 +31,7 @@
     },
     {
         "name": "python-kombu",
-        "version": "3.0.33-2.pulp",
+        "version": "3.0.33-4.pulp",
         "platform": [ "el6", "el7", "fc22", "fc23"]
     },
     {


### PR DESCRIPTION
closes #1635
https://pulp.plan.io/issues/1635

This PR should not be merged until these 3 packages are all present in `stable`.

https://bodhi.fedoraproject.org/updates/FEDORA-2016-5d43aca906
https://bodhi.fedoraproject.org/updates/FEDORA-2016-a172eb2efe
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2016-cd64dcfc3c

The EL6 Copr repo already has the package and doesn't require any karma promotion or delay. Also Rawhide already has the package; I manually verified that.