### PR TITLE
address new deprecation warnings seen in ansible2

### DIFF
--- a/playpen/ansible/dev-playbook.yml
+++ b/playpen/ansible/dev-playbook.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: all
-  sudo: true
+  become: true
+  become_method: sudo
   vars:
   roles:
     - core

--- a/playpen/ansible/vagrant-playbook.yml
+++ b/playpen/ansible/vagrant-playbook.yml
@@ -1,12 +1,14 @@
 ---
 - hosts: all
-  sudo: true
+  become: true
+  become_method: sudo
   vars:
   roles:
     - core
 
 - hosts: dev
-  sudo: true
+  become: true
+  become_method: sudo
   vars:
   roles:
     - db


### PR DESCRIPTION
Specifically, replace the refs to "sudo:" with "become:",
and explicitly configure it as described in the docs for that
mechanism: https://docs.ansible.com/ansible/become.html