### PR TITLE
gofer 2.7.5 loads pam libs on demand.

### DIFF
--- a/deps/external_deps.json
+++ b/deps/external_deps.json
@@ -16,7 +16,7 @@
     },
     {
         "name": "gofer",
-        "version": "2.6.6-2",
+        "version": "2.7.5-1",
         "platform": ["el5", "el6", "el7", "fc22", "fc23"]
     },
     {


### PR DESCRIPTION
https://pulp.plan.io/issues/1730