### PR TITLE
Move `list_files()` from FileContentUnit to ContentUnit.

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -690,6 +690,21 @@ class ContentUnit(AutoRetryDocument):
                 _hash.update(value)
         return _hash.hexdigest()
 
+    def list_files(self):
+        """
+        List absolute paths to files associated with this unit.
+
+        This *must* be overridden by multi-file unit subclasses. Units without files can use the
+        default implementation.
+
+        :return: A list of absolute file paths.
+        :rtype: list
+        """
+        if self._storage_path and not os.path.isdir(self._storage_path):
+            return [self._storage_path]
+        else:
+            return []
+
     def __hash__(self):
         """
         This should provide a consistent and unique hash where units of the same
@@ -747,19 +762,6 @@ class FileContentUnit(ContentUnit):
             else:
                 raise ValueError(_('must be relative path'))
         self._storage_path = path
-
-    def list_files(self):
-        """
-        List absolute paths to files associated with this unit.
-        This *must* be overridden by multi-file unit subclasses.
-
-        :return: A list of absolute file paths.
-        :rtype: list
-        """
-        if self._storage_path and not os.path.isdir(self._storage_path):
-            return [self._storage_path]
-        else:
-            return []
 
     def import_content(self, path, location=None):
         """

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -228,6 +228,25 @@ class TestContentUnit(unittest.TestCase):
     def test_unit_key_fields_is_not_defined_on_abstract_class(self):
         self.assertFalse(hasattr(model.ContentUnit, 'unit_key_fields'))
 
+    @patch('os.path.isdir')
+    def test_list_files(self, isdir):
+        isdir.return_value = False
+        unit = TestFileContentUnit.TestUnit()
+        unit._storage_path = '/some/dir/'
+        self.assertEqual(unit.list_files(), [unit._storage_path])
+
+    @patch('os.path.isdir')
+    def test_list_files_no_path(self, isdir):
+        isdir.return_value = False
+        unit = TestFileContentUnit.TestUnit()
+        self.assertEqual(unit.list_files(), [])
+
+    @patch('os.path.isdir')
+    def test_list_files_multi_file(self, isdir):
+        isdir.return_value = True
+        unit = TestFileContentUnit.TestUnit()
+        self.assertEqual(unit.list_files(), [])
+
 
 class TestContentUnitNamedTuple(unittest.TestCase):
     def setUp(self):
@@ -431,25 +450,6 @@ class TestFileContentUnit(unittest.TestCase):
         get_path.return_value = '/tmp'
         unit = TestFileContentUnit.TestUnit()
         self.assertRaises(ValueError, unit.set_storage_path, '/violation/test')
-
-    @patch('os.path.isdir')
-    def test_list_files(self, isdir):
-        isdir.return_value = False
-        unit = TestFileContentUnit.TestUnit()
-        unit._storage_path = '/some/dir/'
-        self.assertEqual(unit.list_files(), [unit._storage_path])
-
-    @patch('os.path.isdir')
-    def test_list_files_no_path(self, isdir):
-        isdir.return_value = False
-        unit = TestFileContentUnit.TestUnit()
-        self.assertEqual(unit.list_files(), [])
-
-    @patch('os.path.isdir')
-    def test_list_files_multi_file(self, isdir):
-        isdir.return_value = True
-        unit = TestFileContentUnit.TestUnit()
-        self.assertEqual(unit.list_files(), [])
 
     @patch('os.path.isfile')
     @patch('pulp.server.db.model.FileStorage')


### PR DESCRIPTION
Move the `list_files()` method definition to ContentUnit. This is
convenient when receiving a list of ContentUnit derivatives that may or
may not have inherited from FileContentUnit. The default implementation
on ContentUnit returns an empty list unless `_storage_path` is defined,
so a user can call `list_files` on any ContentUnit subclass when dealing
with content files.

closes #1735