### PR TITLE
Create mongoengine indexes only after migrations

### DIFF
--- a/server/pulp/plugins/loader/api.py
+++ b/server/pulp/plugins/loader/api.py
@@ -432,15 +432,18 @@ def load_content_types(types_dir=_TYPES_DIR, dry_run=False, drop_indices=False):
 
     # to handle node.json only
     descriptors = _load_type_descriptors(types_dir)
-    definitions = parser.parse(descriptors)
+    pre_mongoengine_definitions = parser.parse(descriptors)
 
     # get information about content unit types from entry points
-    definitions += _generate_plugin_definitions()
+    mongoengine_definitions = _generate_plugin_definitions()
 
     if dry_run:
-        return _check_content_definitions(definitions)
+        return _check_content_definitions(pre_mongoengine_definitions + mongoengine_definitions)
     else:
-        database.update_database(definitions, drop_indices=drop_indices)
+        database.update_database(pre_mongoengine_definitions, drop_indices=drop_indices,
+                                 create_indexes=True)
+        database.update_database(mongoengine_definitions, drop_indices=drop_indices,
+                                 create_indexes=False)
 
 # initialization methods -------------------------------------------------------
 

--- a/server/test/unit/plugins/types/test_database.py
+++ b/server/test/unit/plugins/types/test_database.py
@@ -28,7 +28,7 @@ class TypesDatabaseTests(base.PulpServerTests):
 
         # Test
         defs = [DEF_1, DEF_2, DEF_3, DEF_4]
-        types_db.update_database(defs)
+        types_db.update_database(defs, create_indexes=True)
 
         # Verify
         all_collection_names = types_db.all_type_collection_names()
@@ -57,7 +57,7 @@ class TypesDatabaseTests(base.PulpServerTests):
         # Test
         # no real reason for this, just felt better than using the previous list
         same_defs = [DEF_4, DEF_3, DEF_2, DEF_1]
-        types_db.update_database(same_defs)
+        types_db.update_database(same_defs, create_indexes=True)
 
         # Verify
         all_collection_names = types_db.all_type_collection_names()
@@ -81,11 +81,11 @@ class TypesDatabaseTests(base.PulpServerTests):
 
         # Setup
         defs = [DEF_1, DEF_2, DEF_3]
-        types_db.update_database(defs)
+        types_db.update_database(defs, create_indexes=True)
 
         # Test
         new_defs = [DEF_4]
-        types_db.update_database(new_defs)
+        types_db.update_database(new_defs, create_indexes=True)
 
         # Verify
         all_collection_names = types_db.all_type_collection_names()


### PR DESCRIPTION
Fixes a bug that broke upgrades due to the fact that indexes were being
generated for newly renamed fields before the migrations were run
populating the indexes with 'null' and breaking upgrades if there are
uniqueness contstraints.

closes https://pulp.plan.io/issues/1738