### PR TITLE
Specifies the queue_sync_with_auto_publish celery task name

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -677,7 +677,7 @@ def update_last_unit_removed(repo_id):
     repo_obj.save()
 
 
-@celery.task(base=PulpTask)
+@celery.task(base=PulpTask, name='pulp.server.tasks.repository.sync_with_auto_publish')
 def queue_sync_with_auto_publish(repo_id, overrides=None, scheduled_call_id=None):
     """
     Sync a repository and upon successful completion, publish any distributors that are configured


### PR DESCRIPTION
In commit cb99aa95 the task named sync_with_auto_publish was
deleted and was intented to have all usage switch to
queue_sync_with_auto_publish. This works for everything except
saved scheduled call database records which expect to call the
original task by name.

This updates the task name so when the old records call the task
by name it will still work. All other usage dispatches using the
object queue_sync_with_auto_publish and not by name so this
will continue to work with the existing new code. Also new
scheduled calls save into the db by looking up the task name,
so newly created schedule calls will save into the db just like
the old ones did with this change also.

https://pulp.plan.io/issues/1742
closes #1742