### PR TITLE
Enable logging for the content.wsgi application.

### DIFF
--- a/server/pulp/server/content/web/settings.py
+++ b/server/pulp/server/content/web/settings.py
@@ -1,4 +1,47 @@
+import ConfigParser
+import logging
 import os
+
+from pulp.server import logs as pulp_logs
+from pulp.server import config
+
+
+try:
+    log_level = config.config.get('server', 'log_level')
+    log_level = getattr(logging, log_level.upper())
+except (ConfigParser.NoOptionError, AttributeError):
+    # If the user didn't provide a log level, or if they provided an invalid one, let's use the
+    # default log level
+    log_level = pulp_logs.DEFAULT_LOG_LEVEL
+
+# Rather than using `pulp.server.logs.start_logging`, which dates back to the
+# pre-Django days, use Django to set up the logging. This is intended to mimic
+# the functionality of `start_logging`.
+LOGGING = {
+    'version': 1,
+    'formatters': {
+        'simple': {'format': pulp_logs.LOG_FORMAT_STRING},
+    },
+    'handlers': {
+        'syslog': {
+            'address': pulp_logs.LOG_PATH,
+            'facility': pulp_logs.CompliantSysLogHandler.LOG_DAEMON,
+            'class': 'pulp.server.logs.CompliantSysLogHandler',
+            'formatter': 'simple',
+        },
+    },
+    'loggers': {
+        # Logger for the content.wsgi application.
+        'pulp.server.content.web': {
+            'handlers': ['syslog'],
+            'level': log_level,
+        },
+        # Logs from unhandled exceptions in the view layer come from django
+        'django': {
+            'handlers': ['syslog'],
+        },
+    }
+}
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))


### PR DESCRIPTION
This commit configures loggers for the content.wsgi application. This
ensures unhandled exceptions are logged to syslog and that logging is
configured so messages can be sent from the views.

closes #1739