### PR TITLE
Allow the Celery process to resolve domain names.

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -71,9 +71,7 @@ ifndef(`distro_rhel6', `
 # pulp_ostree sync call on F23 calls out to gpg
 # temporary workaround for https://pulp.plan.io/issues/1731
 
-ifdef(`distro_fedora23', `
-    allow celery_t self:process { setrlimit };
-')
+allow celery_t self:process { setrlimit };
 
 ######################################
 


### PR DESCRIPTION
Fedora Rawhide restricts access to /etc/resolv.conf. This commit
adds the sysnet_dns_name_resolve policy to the celery_t context
which allows it to resolve hostnames.

https://pulp.plan.io/issues/1764

fixes #1764