### PR TITLE
Update failing unit test for the content views.

### DIFF
--- a/server/test/unit/server/content/web/test_views.py
+++ b/server/test/unit/server/content/web/test_views.py
@@ -163,7 +163,6 @@ class TestContentView(TestCase):
         # validation
         allow_access.assert_called_once_with(request.environ, host)
         realpath.assert_called_once_with(path)
-        exists.assert_called_once_with('/var/lib/pulp/published/content')
         x_send.assert_called_once_with('/var/lib/pulp/published/content')
         self.assertEqual(reply, x_send.return_value)
 


### PR DESCRIPTION
Apparently logging calls `os.path.exists`. I have removed the offending
assertion which was not particularly useful in any case.