### PR TITLE
Do not use autospec with the mock MongoEngine objects

### DIFF
--- a/streamer/test/unit/streamer/test_server.py
+++ b/streamer/test/unit/streamer/test_server.py
@@ -73,14 +73,14 @@ class TestStreamerListener(unittest.TestCase):
                          self.listener.request.setHeader.call_args_list[0][0])
         self.listener.request.setResponseCode.assert_called_once_with('418')
 
-    @patch(MODULE_PREFIX + 'model.DeferredDownload', autospec=True)
+    @patch(MODULE_PREFIX + 'model.DeferredDownload')
     def test_download_succeeded(self, mock_deferred_download):
         """Assert a deferred download entry is made."""
         self.listener.download_succeeded(None)
         mock_deferred_download.assert_called_once_with(unit_id='abc', unit_type_id='123')
         mock_deferred_download.return_value.save.assert_called_once_with()
 
-    @patch(MODULE_PREFIX + 'model.DeferredDownload', autospec=True)
+    @patch(MODULE_PREFIX + 'model.DeferredDownload')
     def test_download_succeeded_entry_not_unique(self, mock_deferred_download):
         """Assert NotUniqueError exceptions are ignored."""
         # Setup
@@ -90,7 +90,7 @@ class TestStreamerListener(unittest.TestCase):
         self.listener.download_succeeded(None)
         mock_deferred_download.return_value.save.assert_called_once_with()
 
-    @patch(MODULE_PREFIX + 'model.DeferredDownload', autospec=True)
+    @patch(MODULE_PREFIX + 'model.DeferredDownload')
     def test_download_succeeded_pulp_request(self, mock_deferred_download):
         # Setup
         self.listener.pulp_request = True


### PR DESCRIPTION
This was causing code to execute that required a database connection,
but the tests themselves never used the database.

closes #1494