### PR TITLE
Don't have requests re-serialize the http event data.

### DIFF
--- a/server/pulp/server/event/http.py
+++ b/server/pulp/server/event/http.py
@@ -55,7 +55,7 @@ def _send_post(notifier_config, json_body):
     else:
         auth = None
 
-    response = post(url, json=json_body, auth=auth)
+    response = post(url, data=json_body, auth=auth, headers={'Content-Type': 'application/json'})
     if response.status_code != 200:
         _logger.error(_('Received HTTP {code} from HTTP notifier to {url}.').format(
             code=response.status_code, url=url))


### PR DESCRIPTION
We make use of the BSON serializer, so we can't let requests do the
serializing for us. Therefore we need to use the `data` kwarg rather
than the `json` kwarg and just set the content type ourselves.

closes #1776