### PR TITLE
Adds plantuml to ansible dev role so that docs can be built

### DIFF
--- a/playpen/ansible/roles/dev/tasks/main.yml
+++ b/playpen/ansible/roles/dev/tasks/main.yml
@@ -45,6 +45,7 @@
       - jnettop
       - koji
       - httpie
+      - plantuml
       - python-django-bash-completion
       - python-gofer-qpid
       - python-ipdb


### PR DESCRIPTION
Without this `make html` will fail so you can't build docs in an environment setup by ansible. This issue is so small that I didn't make a PR for it.