### PR TITLE
All Pulp services should wait until the network is online to start.

### DIFF
--- a/server/usr/lib/systemd/system/pulp_celerybeat.service
+++ b/server/usr/lib/systemd/system/pulp_celerybeat.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Pulp's Celerybeat
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 EnvironmentFile=/etc/default/pulp_celerybeat

--- a/server/usr/lib/systemd/system/pulp_resource_manager.service
+++ b/server/usr/lib/systemd/system/pulp_resource_manager.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Pulp Resource Manager
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 EnvironmentFile=/etc/default/pulp_resource_manager

--- a/server/usr/lib/systemd/system/pulp_workers.service
+++ b/server/usr/lib/systemd/system/pulp_workers.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Pulp Celery Workers
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot

--- a/streamer/usr/lib/systemd/system/pulp_streamer.service
+++ b/streamer/usr/lib/systemd/system/pulp_streamer.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=The Pulp lazy content loading streamer
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=apache


### PR DESCRIPTION
On Fedora 24, the /etc/resolv.conf symlink is not set up when the
network.target starts. This causes a race condition during boot,
and our Celery workers often read the /etc/resolv.conf symlink
before it points at its final destination. This causes our workers
to be unable to resolve domain names.

This commit adjusts our unit files so they wait for the
network-online.target which occurs once the network is ready to
use.