### PR TITLE
Fix the HTTP event notifier unit tests.

### DIFF
--- a/server/test/unit/server/event/test_http.py
+++ b/server/test/unit/server/event/test_http.py
@@ -35,7 +35,9 @@ class TestHTTPNotifierTests(unittest.TestCase):
         http._send_post(notifier_config, data)
         mock_post.assert_called_once_with(
             'https://localhost/api/',
-            json=data, auth=None
+            data=data,
+            headers={'Content-Type': 'application/json'},
+            auth=None,
         )
 
     @mock.patch(MODULE_PATH + 'HTTPBasicAuth')
@@ -51,8 +53,9 @@ class TestHTTPNotifierTests(unittest.TestCase):
         http._send_post(notifier_config, data)
         mock_post.assert_called_once_with(
             'https://localhost/api/',
-            json=data,
-            auth=mock_basic_auth.return_value
+            data=data,
+            headers={'Content-Type': 'application/json'},
+            auth=mock_basic_auth.return_value,
         )
         mock_basic_auth.assert_called_once_with('jcline', 'hunter2')
 
@@ -83,7 +86,8 @@ class TestHTTPNotifierTests(unittest.TestCase):
         http._send_post(notifier_config, data)
         mock_post.assert_called_once_with(
             'https://localhost/api/',
-            json=data,
-            auth=mock_basic_auth.return_value
+            data=data,
+            headers={'Content-Type': 'application/json'},
+            auth=mock_basic_auth.return_value,
         )
         mock_log.error.assert_called_once_with(expected_log)


### PR DESCRIPTION
This commit of shame contains fixes for the unit tests I broke in the
commit a6f8f83514fb7255d540a61028a842860a8fb422.