### PR TITLE
Streamer download requests use permanently stored pem files.

### DIFF
--- a/server/pulp/plugins/util/nectar_config.py
+++ b/server/pulp/plugins/util/nectar_config.py
@@ -1,7 +1,7 @@
 """
 Contains functions related to working with the Nectar downloading library.
 """
-
+import copy
 from functools import partial
 
 from nectar.config import DownloaderConfig
@@ -10,43 +10,89 @@ from pulp.common.plugins import importer_constants as constants
 from pulp.server.managers.repo import _common as common_utils
 
 
-def importer_config_to_nectar_config(importer_config, working_dir=None):
-    """
-    Translates the Pulp standard importer configuration into a DownloaderConfig instance.
+# Mapping of importer config key to downloader config key
+IMPORTER_DOWNLADER_CONFIG_MAP = (
+    (constants.KEY_SSL_CA_CERT, 'ssl_ca_cert'),
+    (constants.KEY_SSL_VALIDATION, 'ssl_validation'),
+    (constants.KEY_SSL_CLIENT_CERT, 'ssl_client_cert'),
+    (constants.KEY_SSL_CLIENT_KEY, 'ssl_client_key'),
 
-    :param importer_config: use the PluginCallConfiguration.flatten method to retrieve a
-           single dict view on the configuration
-    :type  importer_config: dict
+    (constants.KEY_PROXY_HOST, 'proxy_url'),
+    (constants.KEY_PROXY_PORT, 'proxy_port'),
+    (constants.KEY_PROXY_USER, 'proxy_username'),
+    (constants.KEY_PROXY_PASS, 'proxy_password'),
+
+    (constants.KEY_BASIC_AUTH_USER, 'basic_auth_username'),
+    (constants.KEY_BASIC_AUTH_PASS, 'basic_auth_password'),
+
+    (constants.KEY_MAX_DOWNLOADS, 'max_concurrent'),
+    (constants.KEY_MAX_SPEED, 'max_speed'),
+)
+
+
+def importer_to_nectar_config(importer, working_dir=None):
+    """
+    Translates a Pulp Importer into a DownloaderConfig instance.
+
+    This function replaces importer_config_to_nectar_config. The primary difference is that it
+    requires the database Importer model and is able to use that to configure Nectar to use the
+    permanently stored TLS certificates and key rather than having Nectar write them out as
+    temporary files. For now, this function uses the deprected function to avoid duplicating code.
+    Once we have confirmed that the other function is no longer used by anything outside of this
+    module it can be removed and its functionality can be moved here.
+
+    :param importer:    The Importer that has a config to be translated to a Nectar config.
+    :type  importer:    pulp.server.db.model.Importer
     :param working_dir: Allow the caller to override the working directory used
-    :type working_dir: str
+    :type  working_dir: str
 
     :rtype: nectar.config.DownloaderConfig
     """
+    download_config_kwargs = {}
 
-    # Mapping of importer config key to downloader config key
-    translations = (
-        (constants.KEY_SSL_CA_CERT, 'ssl_ca_cert'),
-        (constants.KEY_SSL_VALIDATION, 'ssl_validation'),
-        (constants.KEY_SSL_CLIENT_CERT, 'ssl_client_cert'),
-        (constants.KEY_SSL_CLIENT_KEY, 'ssl_client_key'),
+    # If the Importer config has TLS certificates and keys, we need to remove them and configure
+    # nectar to use the permanently stored paths on the filesystem.
+    config = copy.copy(importer.config)
+    if constants.KEY_SSL_CA_CERT in config:
+        del config[constants.KEY_SSL_CA_CERT]
+        download_config_kwargs['ssl_ca_cert_path'] = importer.tls_ca_cert_path
+    if constants.KEY_SSL_CLIENT_CERT in config:
+        del config[constants.KEY_SSL_CLIENT_CERT]
+        download_config_kwargs['ssl_client_cert_path'] = importer.tls_client_cert_path
+    if constants.KEY_SSL_CLIENT_KEY in config:
+        del config[constants.KEY_SSL_CLIENT_KEY]
+        download_config_kwargs['ssl_client_key_path'] = importer.tls_client_key_path
 
-        (constants.KEY_PROXY_HOST, 'proxy_url'),
-        (constants.KEY_PROXY_PORT, 'proxy_port'),
-        (constants.KEY_PROXY_USER, 'proxy_username'),
-        (constants.KEY_PROXY_PASS, 'proxy_password'),
+    return importer_config_to_nectar_config(config, working_dir, download_config_kwargs)
 
-        (constants.KEY_BASIC_AUTH_USER, 'basic_auth_username'),
-        (constants.KEY_BASIC_AUTH_PASS, 'basic_auth_password'),
 
-        (constants.KEY_MAX_DOWNLOADS, 'max_concurrent'),
-        (constants.KEY_MAX_SPEED, 'max_speed'),
-    )
+def importer_config_to_nectar_config(importer_config, working_dir=None,
+                                     download_config_kwargs=None):
+    """
+    DEPRECATED. Use importer_to_nectar_config instead.
+
+    Translates the Pulp standard importer configuration into a DownloaderConfig instance.
+
+    :param importer_config:        use the PluginCallConfiguration.flatten method to retrieve a
+                                   single dict view on the configuration
+    :type  importer_config:        dict
+    :param working_dir:            Allow the caller to override the working directory used
+    :type  working_dir:            str
+    :param download_config_kwargs: Any additional keyword arguments you would like to include in the
+                                   download config.
+    :type  download_config_kwargs: dict
+
+    :rtype: nectar.config.DownloaderConfig
+    """
+    if download_config_kwargs is None:
+        download_config_kwargs = {}
+
     if working_dir is None:
         working_dir = common_utils.get_working_directory()
 
-    download_config_kwargs = {'working_dir': working_dir}
+    download_config_kwargs['working_dir'] = working_dir
     adder = partial(_safe_add_arg, importer_config, download_config_kwargs)
-    map(adder, translations)
+    map(adder, IMPORTER_DOWNLADER_CONFIG_MAP)
 
     download_config = DownloaderConfig(**download_config_kwargs)
     return download_config

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -454,14 +454,17 @@ def queue_delete(repo_id):
 
 def get_importer_by_id(object_id):
     """
-    Get a plugin and call configuration using the document ID
+    Get a plugin, call configuration, and Importer document object using the document ID
     of the repository-importer association document.
 
     :param object_id: The document ID.
-    :type object_id: str
+    :type  object_id: str
+
     :return: A tuple of:
-        (pulp.plugins.importer.Importer, pulp.plugins.config.PluginCallConfiguration)
-    :rtype: tuple
+        (pulp.plugins.importer.Importer, pulp.plugins.config.PluginCallConfiguration,
+         pulp.server.db.model.Importer)
+    :rtype:  tuple
+
     :raise pulp.plugins.loader.exceptions.PluginNotFound: not found.
     """
     try:
@@ -474,7 +477,7 @@ def get_importer_by_id(object_id):
         raise plugin_exceptions.PluginNotFound()
     plugin, cfg = plugin_api.get_importer_by_id(document.importer_type_id)
     call_conf = PluginCallConfiguration(cfg, document.config)
-    return plugin, call_conf
+    return plugin, call_conf, document
 
 
 @celery.task(base=Task, name='pulp.server.tasks.repository.delete')

--- a/server/test/unit/plugins/test_importer.py
+++ b/server/test/unit/plugins/test_importer.py
@@ -3,11 +3,86 @@
 from unittest import TestCase
 
 from mock import patch, Mock
+from nectar import config
+from nectar.downloaders import local, threaded
 
+from pulp.common.plugins import importer_constants
 from pulp.plugins.importer import Importer
 
 
-class TestImporter(TestCase):
+class TestBuildDownloader(TestCase):
+    """
+    This class contains tests for pulp.plugins.importer.Importer.build_downloader().
+    """
+    def test_http(self):
+        """
+        Test with http:// as the scheme.
+        """
+        url = 'http://martin.com/test'
+        nectar_config = config.DownloaderConfig(max_speed=42)
+
+        downloader = Importer.build_downloader(url, nectar_config)
+
+        self.assertTrue(isinstance(downloader, threaded.HTTPThreadedDownloader))
+        self.assertEqual(downloader.config.max_speed, 42)
+
+    # This mock allows us to use fake paths to the TLS certs/key. Without it, Nectar tries to read
+    # them when the DownloaderConfig is instantiated.
+    @patch('nectar.config.DownloaderConfig._process_ssl_settings')
+    def test_https(self, _process_ssl_settings):
+        """
+        Test with https:// as the scheme.
+        """
+        url = 'https://martin.com/test'
+        nectar_config = config.DownloaderConfig(
+            ssl_ca_cert='CA Cert', ssl_ca_cert_path='/path/to/ca.crt',
+            ssl_client_cert='Client Cert', ssl_client_cert_path='/path/to/client.crt',
+            ssl_client_key='Client Cert', ssl_client_key_path='/path/to/client.key')
+
+        downloader = Importer.build_downloader(url, nectar_config)
+
+        self.assertTrue(isinstance(downloader, threaded.HTTPThreadedDownloader))
+        self.assertEqual(downloader.config.ssl_ca_cert_path, '/path/to/ca.crt')
+        self.assertEqual(downloader.config.ssl_client_cert_path, '/path/to/client.crt')
+        self.assertEqual(downloader.config.ssl_client_key_path, '/path/to/client.key')
+        _process_ssl_settings.assert_called_once_with()
+
+    def test_invalid_scheme(self):
+        """
+        Test with an invalid scheme in the URL.
+        """
+        url = 'ftpx://martin.com/test'
+        nectar_config = config.DownloaderConfig(max_speed=42)
+
+        self.assertRaises(ValueError, Importer.build_downloader, url, nectar_config)
+
+    def test_local(self):
+        """
+        Test with a file:// scheme.
+        """
+        url = 'file:///martin.com/test'
+        nectar_config = config.DownloaderConfig(max_concurrent=23)
+
+        downloader = Importer.build_downloader(url, nectar_config)
+
+        self.assertTrue(isinstance(downloader, local.LocalFileDownloader))
+        self.assertEqual(downloader.config.max_concurrent, 23)
+
+
+class TestCancelSyncRepo(TestCase):
+    """
+    This class contains tests for pulp.plugins.importer.Importer.cancel_sync_repo().
+    """
+    @patch('pulp.plugins.importer.sys.exit', autospec=True)
+    def test_cancel_sync_repo_calls_sys_exit(self, mock_sys_exit):
+        Importer().cancel_sync_repo()
+        mock_sys_exit.assert_called_once_with()
+
+
+class TestGetDownloader(TestCase):
+    """
+    This class contains tests for pulp.plugins.importer.Importer.get_downloader().
+    """
 
     @patch('pulp.plugins.importer.LocalFileDownloader')
     @patch('pulp.plugins.importer.importer_config_to_nectar_config')
@@ -56,7 +131,72 @@ class TestImporter(TestCase):
         url = 'ftpx://martin.com/test'
         self.assertRaises(ValueError, Importer.get_downloader, Mock(), url)
 
-    @patch('pulp.plugins.importer.sys.exit', autospec=True)
-    def test_cancel_sync_repo_calls_sys_exit(self, mock_sys_exit):
-        Importer().cancel_sync_repo()
-        mock_sys_exit.assert_called_once_with()
+
+class TestGetDownloaderForDBImporter(TestCase):
+    """
+    This class contains tests for pulp.plugins.importer.Importer.get_downloader_for_db_importer().
+    """
+    def test_http(self):
+        """
+        Test with http:// as the scheme.
+        """
+        url = 'http://martin.com/test'
+        importer = Mock()
+        importer.config = {importer_constants.KEY_MAX_SPEED: 5555}
+
+        downloader = Importer.get_downloader_for_db_importer(importer, url, '/working/dir')
+
+        self.assertTrue(isinstance(downloader, threaded.HTTPThreadedDownloader))
+        self.assertEqual(downloader.config.max_speed, 5555)
+        self.assertEqual(downloader.config.working_dir, '/working/dir')
+
+    # This mock allows us to use fake paths to the TLS certs/key. Without it, Nectar tries to read
+    # them when the DownloaderConfig is instantiated.
+    @patch('nectar.config.DownloaderConfig._process_ssl_settings')
+    def test_https(self, _process_ssl_settings):
+        """
+        Test with https:// as the scheme.
+        """
+        url = 'https://martin.com/test'
+        importer = Mock()
+        importer.config = {
+            importer_constants.KEY_SSL_CA_CERT: 'CA Cert',
+            importer_constants.KEY_SSL_CLIENT_CERT: 'Client Cert',
+            importer_constants.KEY_SSL_CLIENT_KEY: 'Client Key'}
+        importer.tls_ca_cert_path = '/path/to/ca.crt'
+        importer.tls_client_cert_path = '/path/to/client.crt'
+        importer.tls_client_key_path = '/path/to/client.key'
+
+        downloader = Importer.get_downloader_for_db_importer(importer, url, '/working/dir')
+
+        self.assertTrue(isinstance(downloader, threaded.HTTPThreadedDownloader))
+        self.assertEqual(downloader.config.ssl_ca_cert_path, '/path/to/ca.crt')
+        self.assertEqual(downloader.config.ssl_client_cert_path, '/path/to/client.crt')
+        self.assertEqual(downloader.config.ssl_client_key_path, '/path/to/client.key')
+        self.assertEqual(downloader.config.working_dir, '/working/dir')
+        _process_ssl_settings.assert_called_once_with()
+
+    def test_invalid_scheme(self):
+        """
+        Test with an invalid scheme in the URL.
+        """
+        url = 'ftpx://martin.com/test'
+        importer = Mock()
+        importer.config = {}
+
+        self.assertRaises(ValueError, Importer.get_downloader_for_db_importer, importer, url,
+                          '/working/dir')
+
+    def test_local(self):
+        """
+        Test with a file:// scheme.
+        """
+        url = 'file:///martin.com/test'
+        importer = Mock()
+        importer.config = {importer_constants.KEY_MAX_DOWNLOADS: 123}
+
+        downloader = Importer.get_downloader_for_db_importer(importer, url, '/working/dir')
+
+        self.assertTrue(isinstance(downloader, local.LocalFileDownloader))
+        self.assertEqual(downloader.config.max_concurrent, 123)
+        self.assertEqual(downloader.config.working_dir, '/working/dir')

--- a/server/test/unit/plugins/util/test_nectar_config.py
+++ b/server/test/unit/plugins/util/test_nectar_config.py
@@ -2,8 +2,7 @@ import shutil
 import tempfile
 import unittest
 
-from mock import patch
-
+from mock import MagicMock, patch
 from nectar.config import DownloaderConfig
 
 from pulp.common.plugins import importer_constants as constants
@@ -17,6 +16,56 @@ class ConfigTranslationTests(unittest.TestCase):
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
+
+    # This mock allows us to use fake paths to the TLS certs/key. Without it, Nectar tries to read
+    # them when the DownloaderConfig is instantiated.
+    @patch('nectar.config.DownloaderConfig._process_ssl_settings')
+    def test_importer_to_nectar_config(self, _process_ssl_settings):
+        """
+        Run importer_to_nectar_config to make sure the TLS settings are used correctly.
+        """
+        importer = MagicMock()
+        importer.config = {
+            constants.KEY_SSL_CA_CERT: 'ca_cert',
+            constants.KEY_SSL_VALIDATION: True,
+            constants.KEY_SSL_CLIENT_CERT: 'client_cert',
+            constants.KEY_SSL_CLIENT_KEY: 'client_key',
+
+            constants.KEY_PROXY_HOST: 'proxy',
+            constants.KEY_PROXY_PORT: 8080,
+            constants.KEY_PROXY_USER: 'user',
+            constants.KEY_PROXY_PASS: 'pass',
+
+            constants.KEY_BASIC_AUTH_USER: 'basicuser',
+            constants.KEY_BASIC_AUTH_PASS: 'basicpass',
+
+            constants.KEY_MAX_DOWNLOADS: 10,
+            constants.KEY_MAX_SPEED: 1024,
+        }
+        importer.tls_ca_cert_path = '/path/to/ca.crt'
+        importer.tls_client_cert_path = '/path/to/client.crt'
+        importer.tls_client_key_path = '/path/to/client.key'
+
+        download_config = nectar_config.importer_to_nectar_config(importer, '/working/dir')
+
+        self.assertTrue(isinstance(download_config, DownloaderConfig))
+        self.assertEqual(download_config.ssl_ca_cert, None)
+        self.assertEqual(download_config.ssl_ca_cert_path, '/path/to/ca.crt')
+        self.assertEqual(download_config.ssl_validation, True)
+        self.assertEqual(download_config.ssl_client_cert, None)
+        self.assertEqual(download_config.ssl_client_cert_path, '/path/to/client.crt')
+        self.assertEqual(download_config.ssl_client_key, None)
+        self.assertEqual(download_config.ssl_client_key_path, '/path/to/client.key')
+        self.assertEqual(download_config.proxy_url, 'proxy')
+        self.assertEqual(download_config.proxy_port, 8080)
+        self.assertEqual(download_config.proxy_username, 'user')
+        self.assertEqual(download_config.proxy_password, 'pass')
+        self.assertEqual(download_config.basic_auth_username, 'basicuser')
+        self.assertEqual(download_config.basic_auth_password, 'basicpass')
+        self.assertEqual(download_config.max_concurrent, 10)
+        self.assertEqual(download_config.max_speed, 1024)
+        self.assertEqual(download_config.working_dir, '/working/dir')
+        _process_ssl_settings.assert_called_once_with()
 
     @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
     def test_importer_config_to_nectar_config_complete(self, mock_get_working):

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -1342,7 +1342,7 @@ class TestGetImporterById(unittest.TestCase):
         plugin_api.get_importer_by_id.return_value = (plugin, cfg)
 
         # test
-        _plugin, _conf = repo_controller.get_importer_by_id(_id)
+        _plugin, _conf, _db_plugin = repo_controller.get_importer_by_id(_id)
 
         # validation
         object_id.assert_called_once_with(_id)
@@ -1350,6 +1350,7 @@ class TestGetImporterById(unittest.TestCase):
         call_conf.assert_called_once_with(cfg, document.config)
         self.assertEqual(_plugin, plugin)
         self.assertEqual(_conf, call_conf.return_value)
+        self.assertEqual(_db_plugin, document)
 
     @patch('pulp.server.controllers.repository.ObjectId', MagicMock())
     @patch('pulp.server.db.model.Importer')

--- a/streamer/pulp/streamer/server.py
+++ b/streamer/pulp/streamer/server.py
@@ -208,9 +208,10 @@ class Streamer(resource.Resource):
         :type  responder:       Responder
         """
         # Configure the primary downloader for alternate content sources
-        importer, config = repo_controller.get_importer_by_id(catalog_entry.importer_id)
-        primary_downloader = importer.get_downloader(config, catalog_entry.url, working_dir='/tmp',
-                                                     **catalog_entry.data)
+        plugin_importer, config, db_importer = repo_controller.get_importer_by_id(
+            catalog_entry.importer_id)
+        primary_downloader = plugin_importer.get_downloader_for_db_importer(
+            db_importer, catalog_entry.url, working_dir='/tmp')
         pulp_request = request.getHeader(PULP_STREAM_REQUEST_HEADER)
         listener = StreamerListener(request, self.config, catalog_entry, pulp_request)
         primary_downloader.session = self.session

--- a/streamer/test/unit/streamer/test_server.py
+++ b/streamer/test/unit/streamer/test_server.py
@@ -209,18 +209,18 @@ class TestStreamer(unittest.TestCase):
         mock_responder = Mock()
         mock_importer = Mock()
         mock_importer_config = Mock()
-        mock_repo_controller.get_importer_by_id.return_value = (mock_importer,
-                                                                mock_importer_config)
+        mock_db_importer = Mock()
+        mock_repo_controller.get_importer_by_id.return_value = (
+            mock_importer, mock_importer_config, mock_db_importer)
         mock_get_unit_model.return_value.unit_key_fields = tuple()
 
         # Test
         self.streamer._download(mock_catalog, mock_request, mock_responder)
         mock_repo_controller.get_importer_by_id.assert_called_once_with(mock_catalog.importer_id)
-        mock_importer.get_downloader.assert_called_once_with(
-            mock_importer_config,
+        mock_importer.get_downloader_for_db_importer.assert_called_once_with(
+            mock_db_importer,
             mock_catalog.url,
-            working_dir=mock_catalog.working_dir,
-            **mock_catalog.data)
+            working_dir=mock_catalog.working_dir)
 
         mock_container.return_value.download.assert_called_once()
 


### PR DESCRIPTION
This commit begins a shift towards storing repository PEM data (CA
certificates, client certificates, and client keys) on the
filesystem, and passing paths to those certs to Nectar rather than
allowing nectar to write them in temporary files.

This commit provides the infrastructure for this change, but only
converts the streamer to using it. All other downloads in Pulp
still take the old, now deprecated path.

https://pulp.plan.io/issues/1771

fixes #1771