### PR TITLE
Ensure streamer logging is clear about database lookup failures

### DIFF
--- a/streamer/pulp/streamer/server.py
+++ b/streamer/pulp/streamer/server.py
@@ -182,7 +182,7 @@ class Streamer(resource.Resource):
                     raise DoesNotExist()
                 self._download(catalog_entry, request, responder)
             except DoesNotExist:
-                logger.debug(_('Failed to find a catalog entry with path'
+                logger.error(_('Failed to find a catalog entry with path'
                                ' "{rel}".'.format(rel=catalog_path)))
                 request.setResponseCode(NOT_FOUND)
             except PluginNotFound:
@@ -220,17 +220,26 @@ class Streamer(resource.Resource):
         # Build the alternate content source download request
         unit_model = plugins_api.get_unit_model_by_id(catalog_entry.unit_type_id)
         qs = unit_model.objects.filter(id=catalog_entry.unit_id).only(*unit_model.unit_key_fields)
-        unit = qs.get()
-        download_request = content_models.Request(
-            catalog_entry.unit_type_id,
-            unit.unit_key,
-            catalog_entry.url,
-            responder
-        )
+        try:
+            unit = qs.get()
+            download_request = content_models.Request(
+                catalog_entry.unit_type_id,
+                unit.unit_key,
+                catalog_entry.url,
+                responder,
+            )
 
-        alt_content_container = content_container.ContentContainer(threaded=False)
-        alt_content_container.download(primary_downloader, [download_request], listener)
-        primary_downloader.config.finalize()
+            alt_content_container = content_container.ContentContainer(threaded=False)
+            alt_content_container.download(primary_downloader, [download_request], listener)
+        except DoesNotExist:
+            # A catalog entry is referencing a unit that doesn't exist which is bad.
+            msg = _('The catalog entry for {path} references {unit_type}:{id}, but '
+                    'that unit is not in the database.')
+            logger.error(msg.format(path=catalog_entry.path, unit_type=catalog_entry.unit_type_id,
+                                    id=catalog_entry.unit_id))
+            request.setResponseCode(NOT_FOUND)
+        finally:
+            primary_downloader.config.finalize()
 
 
 class Responder(object):

--- a/streamer/test/unit/streamer/test_server.py
+++ b/streamer/test/unit/streamer/test_server.py
@@ -178,7 +178,7 @@ class TestStreamer(unittest.TestCase):
             order_by('importer_id').first.return_value = None
 
         self.streamer._handle_get(self.request)
-        mock_logger.debug.assert_called_once_with('Failed to find a catalog entry '
+        mock_logger.error.assert_called_once_with('Failed to find a catalog entry '
                                                   'with path "/a/resource".')
         self.request.setResponseCode.assert_called_once_with(NOT_FOUND)
 


### PR DESCRIPTION
The commit ensures that failures to find a catalog entry and failures to
find the content unit referenced by a catalog entry are logged much more
clearly.

I ran across a case where the content unit referenced by a catalog entry was missing from the database. That's bad, and I still don't know how it happened, but this ensures the logging is much clearer. Previously it would complain that the catalog entry was missing even when it was, in fact, the content unit. Both these cases shouldn't happen unless the database is very wrong, so I've made them both error-level.