### PR TITLE
Adds apache_manage_sys_content_rw to pulp-streamer SELinux policy

### DIFF
--- a/server/selinux/server/pulp-streamer.te
+++ b/server/selinux/server/pulp-streamer.te
@@ -69,6 +69,13 @@ files_list_tmp(streamer_t)
 ## Read Pulp content
 apache_read_sys_content(streamer_t)
 
+## Read Pulp importer certs
+# There isn't a Refpol interface for read-only so we use
+# a read-write interface. Reading has a larger security impact than writing
+# so this is OK for now.
+# Long term fix is https://pulp.plan.io/issues/1811
+apache_manage_sys_content_rw(streamer_t)
+
 
 ##### Execute Privileges #####
 


### PR DESCRIPTION
re #1771
https://pulp.plan.io/issues/1771

This was compiled and installed on the machine where the SELinux denial was encountered. After being applied no more SELinux denials were shown. The original denial was:

```
type=SYSCALL msg=audit(1459639923.760:2537): arch=c000003e syscall=21 success=no exit=-13 a0=7fe61c00e3d0 a1=4 a2=7fe644bc0fa8 a3=3 items=0 ppid=1 pid=25805 auid=4294967295 uid=48 gid=48 euid=48 suid=48 fsuid=48 egid=48 sgid=48 fsgid=48 tty=(none) ses=4294967295 comm="pulp_streamer" exe="/usr/bin/python2.7" subj=system_u:system_r:streamer_t:s0 key=(null)
type=AVC msg=audit(1459639923.760:2537): avc:  denied  { search } for pid=25805 comm="pulp_streamer" name="pulp" dev="dm-0" ino=68703432 scontext=system_u:system_r:streamer_t:s0 tcontext=system_u:object_r:httpd_sys_rw_content_t:s0 tclass=dir 
```