### PR TITLE
Translate _id only if it is in remapped fields

### DIFF
--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -205,12 +205,13 @@ class ModelSerializer(BaseSerializer):
                 new_key = key
                 new_value = self._translate_nested_query(model, value)
             else:
+                remapped = self._remapped_fields.itervalues()
                 if key == '_id':  # _id is a special case
                     new_key = '_id'
-                    new_value = self._translate__id(value)
+                    # Translate the value only if _id is in remapped_fields
+                    new_value = self._translate__id(value) if '_id' in remapped else value
                 else:
                     # Case 1 and 2 keys may need to be translated
-                    remapped = self._remapped_fields.itervalues()
                     new_key = self.translate_field(model, key) if key in remapped else key
                     # Keep the value (case 1) or translate the nested query (case 2)
                     new_value = self._translate_nested_query(model, value)

--- a/server/test/unit/server/webservices/views/serializers/test_serializers.py
+++ b/server/test/unit/server/webservices/views/serializers/test_serializers.py
@@ -325,6 +325,15 @@ class TestTranslateFilters(unittest.TestCase):
         self.assertDictEqual(result, {'_id': mock_trans_id.return_value})
         mock_trans_id.assert_called_once_with(self._id_val)
 
+    def test__id_not_remapped(self, mock_trans_id):
+        """Test translation of form `{_id: value}` when '_id' has not been remapped."""
+        self.serializer._remapped_fields.pop('id')
+        self._id_val = 'do not translate_me!'
+        to_translate = {'_id': self._id_val}
+        result = self.serializer.translate_filters(self.mock_doc, to_translate)
+        self.assertDictEqual(result, to_translate)
+        self.assertFalse(mock_trans_id.called)
+
     def test_query_value(self, mock_trans_id):
         """Test translation of form `{$key: value}`.
 


### PR DESCRIPTION
Do not attempt to objectidify `_id`s if `_id` is not a remapped field.