### PR TITLE
added distributor methods to ensure all units in a repo have been downloaded

### DIFF
--- a/common/pulp/common/error_codes.py
+++ b/common/pulp/common/error_codes.py
@@ -113,6 +113,10 @@ PLP0042 = Error("PLP0042", _("This request is forbidden."), [])
 PLP0043 = Error("PLP0043", _("Database 'write_concern' config can only be 'majority' or 'all'. "
                              "Refer to /etc/pulp/server.conf for proper use."), [])
 PLP0044 = Error("PLP0033", _("The target importer does not support the types from the source"), [])
+PLP0045 = Error("PLP0045", _("The repository cannot be exported because some units have "
+                             "not yet been downloaded."), [])
+PLP0046 = Error("PLP0046", _("The repository group cannot be exported because these repos have "
+                             "units that have not yet been downloaded: %(repos)s"), ['repos'])
 
 # Create a section for general validation errors (PLP1000 - PLP2999)
 # Validation problems should be reported with a general PLP1000 error with a more specific

--- a/server/pulp/plugins/distributor.py
+++ b/server/pulp/plugins/distributor.py
@@ -13,6 +13,10 @@
 
 import sys
 
+from pulp.common import error_codes
+from pulp.server.controllers import repository as repo_controller
+from pulp.server import exceptions
+
 
 class Distributor(object):
     """
@@ -187,6 +191,20 @@ class Distributor(object):
         """
         return {}
 
+    @staticmethod
+    def ensure_all_units_downloaded(repo_id):
+        """
+        Checks the database to make sure all units in the repo have been downloaded. If not, raises
+        an exception.
+
+        :param repo_id: repository id
+        :type  repo_id: basestring
+
+        :raises exceptions.PulpCodedException:  if any unit in the repo has un-downloaded files
+        """
+        if not repo_controller.has_all_units_downloaded(repo_id):
+            raise exceptions.PulpCodedException(error_code=error_codes.PLP0045)
+
 
 class GroupDistributor(object):
     """
@@ -337,3 +355,20 @@ class GroupDistributor(object):
         :raise SystemExit: raised through a call to sys.exit()
         """
         sys.exit()
+
+    @staticmethod
+    def ensure_all_units_downloaded(repo_group):
+        """
+        Checks the database to make sure all units in the repos have been downloaded. If not, raises
+        an exception.
+
+        :param repo_group:  RepositoryGroup instance that should be checked
+        :type  repo_group:  pulp.plugins.model.RepositoryGroup
+
+        :raises exceptions.PulpCodedException:  if any unit in the group has un-downloaded files
+        """
+        bad_repo_ids = filter(lambda x: not repo_controller.has_all_units_downloaded(x),
+                              repo_group.repo_ids or [])
+        if bad_repo_ids:
+            raise exceptions.PulpCodedException(error_code=error_codes.PLP0046,
+                                                repos=', '.join(bad_repo_ids))

--- a/server/test/unit/plugins/test_distributor.py
+++ b/server/test/unit/plugins/test_distributor.py
@@ -1,23 +1,109 @@
 # -*- coding: utf-8 -*-
 
-import unittest
 
 import mock
 
+from pulp.common.compat import unittest
+from pulp.common import error_codes
 from pulp.plugins.distributor import Distributor, GroupDistributor
+from pulp.plugins.model import RepositoryGroup
+from pulp.server.exceptions import PulpCodedException
 
 
-class TestDistributor(unittest.TestCase):
+class TestDistributorCancel(unittest.TestCase):
 
     @mock.patch('pulp.plugins.distributor.sys.exit', autospec=True)
-    def test_cancel_publish_repo_calls_sys_exit(self, mock_sys_exit):
+    def test_calls_sys_exit(self, mock_sys_exit):
         Distributor().cancel_publish_repo()
         mock_sys_exit.assert_called_once_with()
 
 
-class TestGroupDistributor(unittest.TestCase):
+@mock.patch('pulp.server.controllers.repository.has_all_units_downloaded', return_value=True)
+class TestDistributorEnsureUnitsDownloaded(unittest.TestCase):
+    def test_files_not_downloaded(self, mock_has_all_units):
+        """
+        If all files have not been downloaded, make sure exception is raised.
+        """
+        mock_has_all_units.return_value = False
+
+        with self.assertRaises(PulpCodedException) as assertion:
+            Distributor().ensure_all_units_downloaded('repo1')
+
+        self.assertEqual(assertion.exception.error_code, error_codes.PLP0045)
+
+    def test_files_downloaded(self, mock_has_all_units):
+        """
+        If all files have been downloaded, make sure no exception is raised.
+        """
+        Distributor().ensure_all_units_downloaded('repo1')
+
+    def test_calls_controller(self, mock_has_all_units):
+        """
+        Make sure it calls the controller with the right argument.
+        """
+        Distributor().ensure_all_units_downloaded('repo1')
+
+        mock_has_all_units.assert_called_once_with('repo1')
+
+
+class TestGroupDistributorCancel(unittest.TestCase):
 
     @mock.patch('pulp.plugins.distributor.sys.exit', autospec=True)
-    def test_cancel_publish_group_calls_sys_exit(self, mock_sys_exit):
+    def test_calls_sys_exit(self, mock_sys_exit):
         GroupDistributor().cancel_publish_group(mock.Mock(), mock.Mock())
         mock_sys_exit.assert_called_once_with()
+
+
+@mock.patch('pulp.server.controllers.repository.has_all_units_downloaded', return_value=True)
+class TestGroupDistributorEnsureUnitsDownloaded(unittest.TestCase):
+    def setUp(self):
+        super(TestGroupDistributorEnsureUnitsDownloaded, self).setUp()
+        self.distributor = GroupDistributor()
+        self.group = RepositoryGroup(id='g1', display_name='g1', description='g1', notes={},
+                                     repo_ids=['repo1', 'repo2'])
+
+    def test_all_false(self, mock_has_all_units):
+        """
+        If all repos are found to have un-downloaded units, make sure the exception is raised.
+        """
+        mock_has_all_units.return_value = False
+
+        with self.assertRaises(PulpCodedException) as assertion:
+            self.distributor.ensure_all_units_downloaded(self.group)
+
+        self.assertEqual(assertion.exception.error_code, error_codes.PLP0046)
+
+    def test_one_false(self, mock_has_all_units):
+        """
+        If only 1 repo is found to have un-downloaded units, make sure the exception is raised.
+        """
+        mock_has_all_units.side_effect = [False, True]
+
+        with self.assertRaises(PulpCodedException) as assertion:
+            self.distributor.ensure_all_units_downloaded(self.group)
+
+        self.assertEqual(assertion.exception.error_code, error_codes.PLP0046)
+
+    def test_does_not_raise_exception(self, mock_has_all_units):
+        """
+        If all units are found to be downloaded, make sure an exception is not raised.
+        """
+        self.distributor.ensure_all_units_downloaded(self.group)
+
+    def test_repo_ids_none(self, mock_has_all_units):
+        """
+        It seems like repo_ids shouldn't be allowed to be None, but in case it happens, it's easy
+        enough to handle.
+        """
+        self.group.repo_ids = None
+        self.distributor.ensure_all_units_downloaded(self.group)
+
+    def test_calls_controller(self, mock_has_all_units):
+        """
+        Make sure it calls the controller with the right argument.
+        """
+        self.distributor.ensure_all_units_downloaded(self.group)
+
+        mock_has_all_units.assert_has_call('repo1')
+        mock_has_all_units.assert_has_call('repo2')
+        self.assertEqual(mock_has_all_units.call_count, 2)


### PR DESCRIPTION
A follow-up PR in pulp_rpm will call the new methods from actual distributors.

https://pulp.plan.io/issues/1835

re #1835