### PR TITLE
Fixes upgrade instructions

### DIFF
--- a/docs/user-guide/release-notes/2.8.x.rst
+++ b/docs/user-guide/release-notes/2.8.x.rst
@@ -108,12 +108,7 @@ Upgrade Instructions for 2.7.x --> 2.8.x
     package installed. As result you will experience a problem when updating Pulp packages. If this
     package is present on your system you should remove it::
 
-        sudo yum remove python-semantic-version
-
-    This will remove a number of pulp packages also. You will install the new packages::
-
-        sudo yum update
-        sudo yum groupinstall pulp-server-qpid
+        sudo rpm -e --nodeps python-semantic-version
 
 Upgrade the packages using::
 


### PR DESCRIPTION
The previous instructions were too destructive. We should only recommend that the user remove pulp-semantic-version package.