### PR TITLE
Install Node certificate with 640, apache owned (CVE-2016-3107).

### DIFF
--- a/nodes/common/bin/pulp-gen-nodes-certificate
+++ b/nodes/common/bin/pulp-gen-nodes-certificate
@@ -68,7 +68,13 @@ openssl x509 \
   -days 3650 &> /dev/null
 
 # bundle
-cat $TMP/$BASE.key $TMP/$BASE.xx > $NODE_CRT
+cat $TMP/$BASE.key $TMP/$BASE.xx > $TMP/$BASE.crt
+chmod 640 $TMP/$BASE.crt
+chgrp apache $TMP/$BASE.crt
+mv -Z $TMP/$BASE.crt $NODE_CRT
 
 # clean
-rm -rf $TMP
+rm $TMP/$BASE.key
+rm $TMP/$BASE.req
+rm $TMP/$BASE.xx
+rmdir $TMP


### PR DESCRIPTION
Prior to this commit, the Node certificate had been installed
world-readable:

$ ls -lah /etc/pki/pulp/nodes/
total 4.0K
drwxr-xr-x. 2 root root   21 Apr  8 16:37 .
drwxr-xr-x. 4 root root   90 Apr  8 16:37 ..
-rw-r--r--. 1 root root 3.2K Apr  8 16:37 node.crt

This commit adjusts the generation script to limit the permissions
to 0640, and to adjust the group ownership to the apache group. It
also uses the -Z flag on the mv command to ensure the correct
SELinux context is used on the installed file.

Credit also goes to Jeremy Cline (Red Hat) for independently
discovering and reporting this issue.

https://pulp.plan.io/issues/1833

fixes #1833