### PR TITLE
pulp.spec now generate RSA keys with umask 077 (CVE-2016-3111)

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -476,8 +476,12 @@ KEY_PATH="$KEY_DIR/rsa.key"
 KEY_PATH_PUB="$KEY_DIR/rsa_pub.key"
 if [ ! -f $KEY_PATH ]
 then
+  # Ensure the key generated is only readable by the owner.
+  OLD_UMASK=$(umask)
+  umask 077
   openssl genrsa -out $KEY_PATH 2048 &> /dev/null
   openssl rsa -in $KEY_PATH -pubout > $KEY_PATH_PUB 2> /dev/null
+  umask $OLD_UMASK
 fi
 chmod 640 $KEY_PATH
 chmod 644 $KEY_PATH_PUB
@@ -897,8 +901,12 @@ KEY_PATH="$KEY_DIR/rsa.key"
 KEY_PATH_PUB="$KEY_DIR/rsa_pub.key"
 if [ ! -f $KEY_PATH ]
 then
+  # Ensure the key generated is only readable by the owner.
+  OLD_UMASK=$(umask)
+  umask 077
   openssl genrsa -out $KEY_PATH 2048 &> /dev/null
   openssl rsa -in $KEY_PATH -pubout > $KEY_PATH_PUB 2> /dev/null
+  umask $OLD_UMASK
 fi
 chmod 640 $KEY_PATH
 


### PR DESCRIPTION
During installation, the RSA key pairs used to validate messages between
the pulp server and pulp consumers were generated in a directory that is
world-readable with a umask of 002. After it was written, the permissions
were modified to protect the key. For a brief moment, the RSA keys were
world-readable. This commit explicitly sets the umask in the %post
scriptlet to be 077 so it is only readable to the owner.

https://pulp.plan.io/issues/1837

fixes #1837