### PR TITLE
Create consumer private keys with 600 permissions (CVE-2016-3112)

### DIFF
--- a/client_consumer/pulp/client/consumer/cli.py
+++ b/client_consumer/pulp/client/consumer/cli.py
@@ -178,7 +178,9 @@ class RegisterCommand(PulpCliCommand):
 
         id_cert_name = self.context.config['filesystem']['id_cert_filename']
         cert_filename = os.path.join(id_cert_dir, id_cert_name)
-        fp = open(cert_filename, 'w')
+        # os.WRONLY opens the file for writing only; os.O_CREAT will create the
+        # file if it does not already exist.
+        fp = os.fdopen(os.open(cert_filename, os.O_WRONLY | os.O_CREAT, 0600), 'w')
         try:
             fp.write(certificate)
         finally:


### PR DESCRIPTION
Prior to this commit, consumers wrote the certificate and private key
issued by the Pulp server's registration process to
/etc/pki/pulp/consumer/consumer-cert.pem with 644 permissions, which
allowed anyone on the host to read the private key. This ensures the
file is written with 600 permissions.

https://pulp.plan.io/issues/1834

fixes #1834