### PR TITLE
Safely create tmp dir for the Nodes certificate (CVE-2016-3108).

### DIFF
--- a/nodes/common/bin/pulp-gen-nodes-certificate
+++ b/nodes/common/bin/pulp-gen-nodes-certificate
@@ -12,6 +12,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+set -e
 
 READ_PULP_CONF=\
 $(cat << END
@@ -33,16 +34,16 @@ PULP_CONF=(`python -c "$READ_PULP_CONF"`)
 NODE_CONF=(`python -c "$READ_NODE_CONF"`)
 
 
+# Safely create a temporary folder to be used to create the certificate authority.
+TMP=$(mktemp -d) || exit 1
 NODE_CRT=${NODE_CONF[0]}
 CA_KEY=${PULP_CONF[0]}
 CA_CRT=${PULP_CONF[1]}
 BASE='nodes'
-TMP=/tmp/$RANDOM
 CN=`hostname`
 ORG="PULP"
 ORG_UNIT="NODES"
 
-mkdir -p $TMP
 mkdir -p `dirname $NODE_CRT`
 
 # create client key


### PR DESCRIPTION
Security researcher Sander Bos contacted the Pulp team to notify us
that the pulp-gen-nodes-certificate script suffers from the same
exploit as was found in CVE-2016-3095, namely that the $TMP
directory that contains the Nodes private key was created in an
unsafe manner. This commit contains his proposed patch, using
mktemp -d to safely create the directory.

Additionally, I added a set -e so that the script would exit upon
error.

Thanks to Sander Bos for taking the time to carefully inspect the
Pulp codebase and for writing a wonderfully detailed report
describing the issue and the fix for it.

Credit also goes to Jeremy Cline (Red Hat) for independently
reporting this issue.

https://pulp.plan.io/issues/1830

fixes #1830