### PR TITLE
Create consumer private keys with 600 permissions (CVE-2016-3112)

### DIFF
--- a/client_consumer/pulp/client/consumer/cli.py
+++ b/client_consumer/pulp/client/consumer/cli.py
@@ -178,7 +178,9 @@ class RegisterCommand(PulpCliCommand):
 
         id_cert_name = self.context.config['filesystem']['id_cert_filename']
         cert_filename = os.path.join(id_cert_dir, id_cert_name)
-        fp = open(cert_filename, 'w')
+        # os.WRONLY opens the file for writing only; os.O_CREAT will create the
+        # file if it does not already exist.
+        fp = os.fdopen(os.open(cert_filename, os.O_WRONLY | os.O_CREAT, 0600), 'w')
         try:
             fp.write(certificate)
         finally:


### PR DESCRIPTION
I accidentally merged into master instead of 2.8-dev (see #2531). I've cherry-picked the commit back onto a branch based off 2.8-dev. This means there will be two commits on master for this change, but the second one applied (this one when it's merged forward) will be a no-op.