### PR TITLE
Use the api_prefix option from config

### DIFF
--- a/client_lib/pulp/client/launcher.py
+++ b/client_lib/pulp/client/launcher.py
@@ -203,10 +203,11 @@ def _create_bindings(config, cli_logger, username, password, verbose=None):
     # Create the connection and bindings
     verify_ssl = config.parse_bool(config['server']['verify_ssl'])
     ca_path = config['server']['ca_path']
+    path_prefix = config['server']['api_prefix']
     conn = PulpConnection(
         hostname, port, username=username, password=password, cert_filename=cert_filename,
         logger=cli_logger, api_responses_logger=api_logger, verify_ssl=verify_ssl,
-        ca_path=ca_path)
+        ca_path=ca_path, path_prefix=path_prefix)
     bindings = Bindings(conn)
 
     return bindings

--- a/client_lib/test/unit/client/test_launcher.py
+++ b/client_lib/test/unit/client/test_launcher.py
@@ -24,7 +24,7 @@ class TestCreateBindings(unittest.TestCase):
         self.ca_path = '/some/path'
         self.config['filesystem'] = {'id_cert_dir': '/dir/', 'id_cert_filename': 'file'}
         self.config['server'] = {'host': 'awesome_host', 'port': 1234, 'verify_ssl': 'true',
-                                 'ca_path': self.ca_path}
+                                 'ca_path': self.ca_path, 'api_prefix': '/mock/prefix'}
 
     def test_verify_ssl_false(self):
         """


### PR DESCRIPTION
https://pulp.plan.io/issues/1844

The config contains api_prefix, but it was not being utilized when
initializing a PulpConnection.