### PR TITLE
CVE-2016-3107 & CVE-2016-3108: Safely generate Nodes certificate.

### DIFF
--- a/nodes/common/bin/pulp-gen-nodes-certificate
+++ b/nodes/common/bin/pulp-gen-nodes-certificate
@@ -12,6 +12,7 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+set -e
 
 READ_PULP_CONF=\
 $(cat << END
@@ -37,21 +38,25 @@ NODE_CRT=${NODE_CONF[0]}
 CA_KEY=${PULP_CONF[0]}
 CA_CRT=${PULP_CONF[1]}
 BASE='nodes'
-TMP=/tmp/$RANDOM
+# This temporary folder will contain the certificate signing request.
+TMP="$(mktemp -d)"
 CN=`hostname`
 ORG="PULP"
 ORG_UNIT="NODES"
 
-mkdir -p $TMP
 mkdir -p `dirname $NODE_CRT`
 
 # create client key
-openssl genrsa -out $TMP/$BASE.key 2048 &> /dev/null
+OLD_UMASK="$(umask)"
+umask 0027
+openssl genrsa -out $NODE_CRT 2048 &> /dev/null
+chgrp apache $NODE_CRT
+umask $OLD_UMASK
 
 # create signing request for client
 openssl req \
   -new \
-  -key $TMP/$BASE.key \
+  -key $NODE_CRT \
   -out $TMP/$BASE.req \
   -subj "/CN=$CN/O=$ORG/OU=$ORG_UNIT" &> /dev/null
 
@@ -59,7 +64,7 @@ openssl req \
 openssl x509 \
   -req  \
   -in $TMP/$BASE.req \
-  -out $TMP/$BASE.xx \
+  -out $TMP/$BASE.crt \
   -sha1 \
   -CA $CA_CRT \
   -CAkey $CA_KEY \
@@ -68,7 +73,9 @@ openssl x509 \
   -days 3650 &> /dev/null
 
 # bundle
-cat $TMP/$BASE.key $TMP/$BASE.xx > $NODE_CRT
+cat $TMP/$BASE.crt >> $NODE_CRT
 
 # clean
-rm -rf $TMP
+rm $TMP/$BASE.req
+rm $TMP/$BASE.crt
+rmdir $TMP


### PR DESCRIPTION
This commit fixes two CVEs.

CVE-2016-3107
=============

 Install Node certificate with 640, apache owned (CVE-2016-3107).

 Prior to this commit, the Node certificate had been installed
 world-readable:

 $ ls -lah /etc/pki/pulp/nodes/
 total 4.0K
 drwxr-xr-x. 2 root root   21 Apr  8 16:37 .
 drwxr-xr-x. 4 root root   90 Apr  8 16:37 ..
 -rw-r--r--. 1 root root 3.2K Apr  8 16:37 node.crt

 This commit adjusts the generation script to limit the permissions
 to 0640, and to adjust the group ownership to the apache group.

 Credit also goes to Jeremy Cline (Red Hat) for independently
 discovering and reporting this issue.

 https://pulp.plan.io/issues/1833

 fixes #1833

CVE-2016-3108
=============

 Safely create tmp dir for the Nodes certificate (CVE-2016-3108).

 Security researcher Sander Bos contacted the Pulp team to notify us
 that the pulp-gen-nodes-certificate script suffers from the same
 exploit as was found in CVE-2016-3095, namely that the $TMP
 directory that contains the Nodes private key was created in an
 unsafe manner. This commit contains his proposed fix to use
 mktemp -d to safely create the directory.

 Additionally, I added a set -e so that the script would exit upon
 error.

 Thanks to Sander Bos for taking the time to carefully inspect the
 Pulp codebase and for writing a wonderfully detailed report
 describing the issue and the fix for it.

 Credit also goes to Jeremy Cline (Red Hat) for independently
 reporting this issue.

 https://pulp.plan.io/issues/1830

 fixes #1830