### PR TITLE
Fix misleading comment about last_publish date.

### DIFF
--- a/server/pulp/plugins/conduits/repo_publish.py
+++ b/server/pulp/plugins/conduits/repo_publish.py
@@ -53,8 +53,8 @@ class RepoPublishConduit(RepoScratchPadMixin, DistributorScratchPadMixin, Status
 
     def last_publish(self):
         """
-        Returns the timestamp of the last time this repo was published, regardless of the success
-        or failure of the publish. If the repo was never published, this call returns None.
+        Returns the timestamp of the last time this repo was successfully published. If the repo
+        was never published, this call returns None.
 
         :return: timestamp instance describing the last publish
         :rtype:  datetime.datetime or None


### PR DESCRIPTION
The value of last publish is set upon success https://github.com/pulp/pulp/blob/master/server/pulp/server/controllers/repository.py#L1053