### PR TITLE
moving "deleting" context manager into platform (from pulp_rpm)

### DIFF
--- a/server/pulp/server/util.py
+++ b/server/pulp/server/util.py
@@ -1,12 +1,17 @@
 """
 This module contains utility code to be used by pulp.server.
 """
+from contextlib import contextmanager
+import logging
 import os
 from shutil import copy, Error
 
 from gettext import gettext as _
 
 from pulp.server.exceptions import PulpExecutionException
+
+
+_logger = logging.getLogger(__name__)
 
 
 class Singleton(type):
@@ -237,3 +242,25 @@ def copytree(src, dst, symlinks=False, ignore=None):
             break
     if errors:
         raise Error(errors)
+
+
+@contextmanager
+def deleting(path):
+    """
+    Remove the file at path if possible, but don't let any exceptions bubble up. This is useful
+    when you want to do something with a file, and delete it afterward no matter what. Example:
+
+    with util.deleting(path):
+        unit = MyUnit.from_file(path)
+        unit.save()
+
+    Like contextlib.closing, but more fun!
+
+    :param path:    full path to a file that should be deleted
+    :type  path:    basestring
+    """
+    yield
+    try:
+        os.remove(path)
+    except Exception as e:
+        _logger.warning(_('Could not remove file from location: {0}').format(e))

--- a/server/test/unit/server/test_util.py
+++ b/server/test/unit/server/test_util.py
@@ -165,3 +165,24 @@ class TestCopyTree(unittest.TestCase):
         # Assert everything except for symlink is checked if it is a directory
         mock_isdir.assert_has_calls([call('src/dir1'), call('src/dir2'), call('src/dir2/file2'),
                                      call('src/file3')])
+
+
+class TestPackageListenerDeleting(unittest.TestCase):
+    @patch('os.remove')
+    def test_removes_path(self, mock_remove):
+        path = '/a/b/c'
+
+        with util.deleting(path):
+            pass
+
+        mock_remove.assert_called_once_with(path)
+
+    @patch('os.remove', side_effect=IOError)
+    def test_squashes_exception(self, mock_remove):
+        path = '/a/b/c'
+
+        # this should not raise any exceptions
+        with util.deleting(path):
+            pass
+
+        mock_remove.assert_called_once_with(path)


### PR DESCRIPTION
https://github.com/pulp/pulp_rpm/blob/pulp-rpm-2.8.2-1/plugins/pulp_rpm/plugins/importers/yum/listener.py#L172

Many plugins could benefit from using this. I have a use for it right now in
pulp_puppet. One this is merged, a follow-up PR will remove it from pulp_rpm.