### PR TITLE
CVE-2016-3696: Safely generate qpid TLS keys.

### DIFF
--- a/server/bin/pulp-qpid-ssl-cfg
+++ b/server/bin/pulp-qpid-ssl-cfg
@@ -12,8 +12,11 @@
 # granted to use or replicate Red Hat trademarks that are incorporated
 # in this software or its documentation.
 #
+set -e
 
-DIR="/tmp/tmp$RANDOM"
+umask 0077
+
+DIR=$(mktemp -d) || exit 1
 HOST=`hostname -f`
 if [ -z "$HOST" ]
 then
@@ -90,17 +93,13 @@ fi
 echo ""
 echo "Using hostname: [$HOST]"
 
-# create temporary db directory
-rm -rf $DIR
-mkdir $DIR
-cd $DIR
 #
 # ========== KEY SEED ===========
 #
-touch $SEEDFILE
+touch $DIR/$SEEDFILE
 i=0
 while [ $i -lt 20 ]; do
-  echo $RANDOM >> $SEEDFILE
+  echo $RANDOM >> $DIR/$SEEDFILE
   i=`expr $i + 1`
 done
 
@@ -109,7 +108,7 @@ done
 #
 
 # create the password file
-echo "$DB_PASSWORD" > $PWDFILE
+echo "$DB_PASSWORD" > $DIR/$PWDFILE
 
 echo ""
 echo "Password file created."
@@ -119,7 +118,7 @@ echo "Password file created."
 #
 
 # create the nss db
-certutil -N -d . -f $PWDFILE
+certutil -N -d $DIR -f $DIR/$PWDFILE
 
 echo ""
 echo "Database created."
@@ -134,15 +133,16 @@ if [ "${#CA_PATH}" -eq 0 ]
 then
   echo "Creating CA certificate:"
   SUBJECT="CN=redhat,O=pulp,ST=Alabama,C=US"
-  certutil -S -d . -n "ca" -s $SUBJECT -t "TC,," -f $PWDFILE -z $SEEDFILE -x -v $VALID
+  certutil -S -d $DIR -n "ca" -s $SUBJECT -t "TC,," -f $DIR/$PWDFILE -z $DIR/$SEEDFILE -x -v $VALID
   echo "CA created"
 else
-  openssl pkcs12 -export -in $CA_PATH -inkey $CA_KEY_PATH -out ca.p12 -name "ca" -passout file:$PWDFILE
-  pk12util -d . -n "ca" -i ca.p12 -w $PWDFILE -k $PWDFILE
-  certutil -d . -n "ca" -M -t "TCu,Cu,Tuw" -f $PWDFILE
+  openssl pkcs12 -export -in $CA_PATH -inkey $CA_KEY_PATH -out $DIR/ca.p12 -name "ca" \
+      -passout file:$DIR/$PWDFILE
+  pk12util -d $DIR -n "ca" -i ca.p12 -w $DIR/$PWDFILE -k $DIR/$PWDFILE
+  certutil -d $DIR -n "ca" -M -t "TCu,Cu,Tuw" -f $DIR/$PWDFILE
   echo "CA certificate: $CA_PATH, imported"
 fi
-certutil -L -d . -n "ca" -a -o ca.crt -f $PWDFILE
+certutil -L -d $DIR -n "ca" -a -o $DIR/ca.crt -f $DIR/$PWDFILE
 
 
 #
@@ -153,13 +153,14 @@ certutil -L -d . -n "ca" -a -o ca.crt -f $PWDFILE
 echo ""
 echo "Creating BROKER certificate:"
 SUBJECT="CN=$HOST,O=pulp,ST=Alabama,C=US"
-certutil -R -d . -s $SUBJECT -a -o broker.req -f $PWDFILE -z $SEEDFILE
+certutil -R -d $DIR -s $SUBJECT -a -o $DIR/broker.req -f $DIR/$PWDFILE -z $DIR/$SEEDFILE
 
 # sign the broker cert w/ CA
-certutil -C -d . -c "ca" -v $VALID -uV -m1 -a -i broker.req -f $PWDFILE -o broker.crt
+certutil -C -d $DIR -c "ca" -v $VALID -uV -m1 -a -i $DIR/broker.req -f $DIR/$PWDFILE \
+    -o $DIR/broker.crt
 
 # import the broker cert
-certutil -A -d . -n "broker" -t ",," -a -i broker.crt
+certutil -A -d $DIR -n "broker" -t ",," -a -i $DIR/broker.crt
 
 echo "Broker certificate created."
 
@@ -168,27 +169,29 @@ echo "Broker certificate created."
 #
 
 # create the nss db
-mkdir client
-certutil -N -d client -f $PWDFILE
+mkdir $DIR/client
+certutil -N -d $DIR/client -f $DIR/$PWDFILE
 
 # create client cert signing request
 echo ""
 echo "Creating CLIENT certificate:"
 SUBJECT="CN=client,O=pulp,ST=Alabama,C=US"
-certutil -R -d client -s $SUBJECT -a -o client.req -f $PWDFILE -z $SEEDFILE
+certutil -R -d $DIR/client -s $SUBJECT -a -o $DIR/client.req -f $DIR/$PWDFILE -z $DIR/$SEEDFILE
 
 # sign the client cert w/ CA
-certutil -C -d . -c "ca" -v $VALID -uC -m2 -a -i client.req -f $PWDFILE -o client.crt
+certutil -C -d $DIR -c "ca" -v $VALID -uC -m2 -a -i $DIR/client.req -f $DIR/$PWDFILE \
+    -o $DIR/client.crt
 
 # import the client cert
-certutil -A -d client -n "client" -t ",," -a -i client.crt
+certutil -A -d $DIR/client -n "client" -t ",," -a -i $DIR/client.crt
 echo "Client certificate created."
 
 # export client p12 bundle
-pk12util -d client -n "client" -o client.p12 -w $PWDFILE -W $DB_PASSWORD -k $PWDFILE -K $DB_PASSWORD
+pk12util -d $DIR/client -n "client" -o $DIR/client.p12 -w $DIR/$PWDFILE -W $DB_PASSWORD \
+    -k $DIR/$PWDFILE -K $DB_PASSWORD
 
 # using openssl, generate a key & cert using the p12.
-openssl pkcs12 -in client.p12 -nodes -out client.crt -password file:$PWDFILE
+openssl pkcs12 -in $DIR/client.p12 -nodes -out $DIR/client.crt -password file:$DIR/$PWDFILE
 
 echo "Client key & certificate exported"
 
@@ -197,9 +200,12 @@ echo "Client key & certificate exported"
 #
 
 # clean unused artifacts
-rm -f *.req
-rm -f *.p12
-rm -rf client
+rm $DIR/broker.req
+rm $DIR/client.req
+rm $DIR/client/cert8.db
+rm $DIR/client/key3.db
+rm $DIR/client/secmod.db
+rmdir $DIR/client
 
 # create target directory and install files
 mkdir -p $INST_DIR
@@ -222,8 +228,10 @@ echo ""
 # =========== CLEANUP =============
 #
 
-cd /tmp
-rm -rf $DIR
+for f in broker.crt ca.crt cert8.db client.crt client.p12 key3.db password secmod.db seed; do
+    rm $DIR/$f
+done
+rmdir $DIR
 
 #
 # =========== POST =============


### PR DESCRIPTION
Sander Bos reported that the pulp-qpid-ssl-cfg script creates
certificate files and NSS database files in world-readable unsafe
temporary directory $DIR, from which is than the content copied to
permanent installation directory $INST_DIR with wrongly assigned
permissions, which are corrected only after the copying process is
done. This bug gives attacker a time frame for stealing sensitive
data.

This commit reworks the script to use safe practices to create the
secrets so that they begin their lives in a protected state.

https://pulp.plan.io/issues/1854

fixes #1854