### PR TITLE
CVE-2016-3704: Use stronger seed and DB password.

### DIFF
--- a/server/bin/pulp-qpid-ssl-cfg
+++ b/server/bin/pulp-qpid-ssl-cfg
@@ -25,7 +25,6 @@ fi
 PWDFILE="password"
 SEEDFILE="seed"
 INST_DIR='/etc/pki/pulp/qpid'
-DB_PASSWORD=$RANDOM
 VALID="12"
 CA_PATH=""
 CA_KEY_PATH=""
@@ -57,6 +56,8 @@ read -sp "Enter a password:" ans
 if [ "${#ans}" -gt 0 ]
 then
   DB_PASSWORD=$ans
+else
+  DB_PASSWORD=$(dd if=/dev/urandom bs=8192 count=1 | sha256sum | cut -d " " -f 1)
 fi
 echo ""
 echo "Using password: [$DB_PASSWORD]"
@@ -94,16 +95,6 @@ echo ""
 echo "Using hostname: [$HOST]"
 
 #
-# ========== KEY SEED ===========
-#
-touch $DIR/$SEEDFILE
-i=0
-while [ $i -lt 20 ]; do
-  echo $RANDOM >> $DIR/$SEEDFILE
-  i=`expr $i + 1`
-done
-
-#
 # ========== PASSWORD ===========
 #
 
@@ -133,6 +124,7 @@ if [ "${#CA_PATH}" -eq 0 ]
 then
   echo "Creating CA certificate:"
   SUBJECT="CN=redhat,O=pulp,ST=Alabama,C=US"
+  dd if=/dev/urandom of=$DIR/$SEEDFILE bs=8192 count=1
   certutil -S -d $DIR -n "ca" -s $SUBJECT -t "TC,," -f $DIR/$PWDFILE -z $DIR/$SEEDFILE -x -v $VALID
   echo "CA created"
 else
@@ -153,6 +145,7 @@ certutil -L -d $DIR -n "ca" -a -o $DIR/ca.crt -f $DIR/$PWDFILE
 echo ""
 echo "Creating BROKER certificate:"
 SUBJECT="CN=$HOST,O=pulp,ST=Alabama,C=US"
+dd if=/dev/urandom of=$DIR/$SEEDFILE bs=8192 count=1
 certutil -R -d $DIR -s $SUBJECT -a -o $DIR/broker.req -f $DIR/$PWDFILE -z $DIR/$SEEDFILE
 
 # sign the broker cert w/ CA
@@ -176,6 +169,7 @@ certutil -N -d $DIR/client -f $DIR/$PWDFILE
 echo ""
 echo "Creating CLIENT certificate:"
 SUBJECT="CN=client,O=pulp,ST=Alabama,C=US"
+dd if=/dev/urandom of=$DIR/$SEEDFILE bs=8192 count=1
 certutil -R -d $DIR/client -s $SUBJECT -a -o $DIR/client.req -f $DIR/$PWDFILE -z $DIR/$SEEDFILE
 
 # sign the client cert w/ CA


### PR DESCRIPTION
Pulp's pulp-qpid-ssl-cfg script used bash's $RANDOM in unsafe
ways:

0) The default NSS DB password was a single value from $RANDOM,
limiting it to the strings from 0 to 32768.

1) The certutil -z flag receives a "noise file". The script
used $RANDOM to populate a file with numbers to generate this
file. Since $RANDOM was used in this way, the seed file
had low diversity since only 11 possible bytes appeared in the
file (ASCII 0-9 and newline).

This commit alters the script to use /dev/urandom as the source
for generating the DB password and the seed.

https://pulp.plan.io/issues/1858