### PR TITLE
Fix a typo in an init script.

### DIFF
--- a/server/etc/rc.d/init.d/pulp_celerybeat
+++ b/server/etc/rc.d/init.d/pulp_celerybeat
@@ -26,7 +26,7 @@ echo "celery init v${VERSION}."
 
 if [ "$EUID" != "0" ]; then
     echo "Error: This program can only be used by the root user."
-    echo "       Unpriviliged users must use 'celery beat --detach'"
+    echo "       Unprivileged users must use 'celery beat --detach'"
     exit 1
 fi
 


### PR DESCRIPTION
Thanks to Sander Bos for pointing out the spelling error.