### PR TITLE
Adds intersphinx name for 'platform' to sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -260,6 +260,7 @@ intersphinx_mapping = {'pylang': ('http://docs.python.org/2.7/', None),
                        'docker': ("http://pulp-docker.readthedocs.org/en/latest/", None),
                        'puppet': ("http://pulp-puppet.readthedocs.org/en/latest/", None),
                        'ostree': ("http://pulp-ostree.readthedocs.org/en/latest/", None),
+                       'platform': ("http://pulp.readthedocs.org/en/latest/", None),
                        'rpm':    ("http://pulp-rpm.readthedocs.org/en/latest/", None)}
 
 extlinks = {'redmine': ('https://pulp.plan.io/issues/%s', '#'),


### PR DESCRIPTION
The plugins refer to platform using the intersphinx keyword
'platform'. As the plugin content will start being  built as
one sphinx project, the platform sphinx must also support
the 'platform' keyword.

re #950
https://pulp.plan.io/issues/950