### PR TITLE
Adds a function to calculate checksums of multiple types at once.

### DIFF
--- a/server/pulp/plugins/util/metadata_writer.py
+++ b/server/pulp/plugins/util/metadata_writer.py
@@ -11,7 +11,7 @@ from xml.sax.saxutils import XMLGenerator
 
 from pulp.common import error_codes
 from pulp.server.exceptions import PulpCodedValidationException, PulpCodedException
-from verification import CHECKSUM_FUNCTIONS
+from pulp.server.util import CHECKSUM_FUNCTIONS
 
 _LOG = logging.getLogger(__name__)
 BUFFER_SIZE = 1024

--- a/server/pulp/plugins/util/verification.py
+++ b/server/pulp/plugins/util/verification.py
@@ -2,37 +2,7 @@
 Functions for verifying files.
 """
 
-import hashlib
-
-from pulp.common import error_codes
-
-from pulp.server.exceptions import PulpCodedException
-
-
-# Number of bytes to read into RAM at a time when validating the checksum
-VALIDATION_CHUNK_SIZE = 32 * 1024 * 1024
-
-# Constants to pass in as the checksum type in verify_checksum
-TYPE_MD5 = 'md5'
-TYPE_SHA = 'sha'
-TYPE_SHA1 = 'sha1'
-TYPE_SHA256 = 'sha256'
-
-HASHLIB_ALGORITHMS = (TYPE_MD5, TYPE_SHA, TYPE_SHA1, TYPE_SHA256)
-
-CHECKSUM_FUNCTIONS = {
-    TYPE_MD5: hashlib.md5,
-    TYPE_SHA: hashlib.sha1,
-    TYPE_SHA1: hashlib.sha1,
-    TYPE_SHA256: hashlib.sha256,
-}
-
-
-class InvalidChecksumType(ValueError):
-    """
-    Raised when the specified checksum isn't one of the supported TYPE_* constants.
-    """
-    pass
+from pulp.server.util import calculate_checksums
 
 
 class VerificationException(ValueError):
@@ -40,36 +10,6 @@ class VerificationException(ValueError):
     Raised when the verification of a file fails.
     """
     pass
-
-
-def sanitize_checksum_type(checksum_type):
-    """
-    Sanitize and validate the checksum type.
-
-    This function will always return the given checksum_type in lower case, unless it is sha, in
-    which case it will return "sha1". SHA and SHA-1 are the same algorithm, and so we prefer to use
-    "sha1", since it is a more specific name. For some unit types (such as RPM), this can cause
-    conflicts inside of Pulp when repos or uploads use a mix of sha and sha1. See
-    https://bugzilla.redhat.com/show_bug.cgi?id=1165355
-
-    This function also validates that the checksum_type is a recognized one from the list of known
-    hashing algorithms.
-
-    :param checksum_type: The checksum type we are sanitizing
-    :type  checksum_type: basestring
-
-    :return: A sanitized checksum type, converting "sha" to "sha1", otherwise returning the given
-             checksum_type in lowercase.
-    :rtype:  basestring
-
-    :raises PulpCodedException: if the checksum type is not recognized
-    """
-    lowercase_checksum_type = checksum_type.lower()
-    if lowercase_checksum_type == "sha":
-        lowercase_checksum_type = "sha1"
-    if lowercase_checksum_type not in HASHLIB_ALGORITHMS:
-        raise PulpCodedException(error_code=error_codes.PLP1005, checksum_type=checksum_type)
-    return lowercase_checksum_type
 
 
 def verify_size(file_object, expected_size):
@@ -109,17 +49,7 @@ def verify_checksum(file_object, checksum_type, checksum_value):
 
     :raises ValueError: if the checksum_type isn't one of the TYPE_* constants
     """
+    calculated_sum = calculate_checksums(file_object, [checksum_type])[checksum_type]
 
-    if checksum_type not in CHECKSUM_FUNCTIONS:
-        raise InvalidChecksumType('Unknown checksum type [%s]' % checksum_type)
-
-    hasher = CHECKSUM_FUNCTIONS[checksum_type]()
-
-    file_object.seek(0)
-    bits = file_object.read(VALIDATION_CHUNK_SIZE)
-    while bits:
-        hasher.update(bits)
-        bits = file_object.read(VALIDATION_CHUNK_SIZE)
-
-    if hasher.hexdigest() != checksum_value:
-        raise VerificationException(hasher.hexdigest())
+    if calculated_sum != checksum_value:
+        raise VerificationException(calculated_sum)

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -26,8 +26,7 @@ from pulp.plugins.loader import api as plugin_api
 from pulp.plugins.loader import exceptions as plugin_exceptions
 from pulp.plugins.model import SyncReport
 from pulp.plugins.util.misc import paginate
-from pulp.plugins.util.verification import (InvalidChecksumType, VerificationException,
-                                            verify_checksum)
+from pulp.plugins.util.verification import VerificationException, verify_checksum
 from pulp.server import exceptions as pulp_exceptions
 from pulp.server.async.tasks import (PulpTask, register_sigterm_handler, Task, TaskResult,
                                      get_current_task_id)
@@ -45,6 +44,7 @@ from pulp.server.exceptions import PulpCodedTaskException
 from pulp.server.lazy import URL, Key
 from pulp.server.managers import factory as manager_factory
 from pulp.server.managers.repo import _common as common_utils
+from pulp.server.util import InvalidChecksumType
 
 
 _logger = logging.getLogger(__name__)

--- a/server/test/unit/plugins/util/test_metadata_writer.py
+++ b/server/test/unit/plugins/util/test_metadata_writer.py
@@ -14,7 +14,7 @@ from pulp.devel.unit.server.util import assert_validation_exception
 from pulp.plugins.util.metadata_writer import MetadataFileContext, JSONArrayFileContext
 from pulp.plugins.util.metadata_writer import XmlFileContext
 from pulp.plugins.util.metadata_writer import FastForwardXmlFileContext
-from pulp.plugins.util.verification import TYPE_SHA1
+from pulp.server.util import TYPE_SHA1
 
 
 DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', 'data'))

--- a/server/test/unit/plugins/util/test_verification.py
+++ b/server/test/unit/plugins/util/test_verification.py
@@ -1,44 +1,8 @@
 from cStringIO import StringIO
-import hashlib
 import unittest
 
 from pulp.plugins.util import verification
-
-from pulp.server.exceptions import PulpCodedException
-
-
-class TestSanitizeChecksumType(unittest.TestCase):
-    """
-    This class contains tests for the sanitize_checksum_type() function.
-    """
-
-    def test_sha_to_sha1(self):
-        """
-        Assert that "sha" is converted to "sha1".
-        """
-        checksum_type = verification.sanitize_checksum_type('sha')
-
-        self.assertEqual(checksum_type, 'sha1')
-
-    def test_ShA_to_sha1(self):
-        """
-        Assert that "ShA" is converted to "sha1".
-        """
-        checksum_type = verification.sanitize_checksum_type('ShA')
-
-        self.assertEqual(checksum_type, 'sha1')
-
-    def test_SHA256_to_sha256(self):
-        """
-        Assert that "SHA256" is converted to "sha256".
-        """
-        checksum_type = verification.sanitize_checksum_type('SHA256')
-
-        self.assertEqual(checksum_type, 'sha256')
-
-    def test_invalid_type_raises_coded_exception(self):
-        self.assertRaises(PulpCodedException,
-                          verification.sanitize_checksum_type, 'not_a_real_checksum')
+from pulp.server import util
 
 
 class VerificationTests(unittest.TestCase):
@@ -64,7 +28,7 @@ class VerificationTests(unittest.TestCase):
         expected_checksum = 'cae99c6102aa3596ff9b86c73881154e340c2ea8'
 
         # Test - Should not raise an exception
-        verification.verify_checksum(test_file, verification.TYPE_SHA1, expected_checksum)
+        verification.verify_checksum(test_file, util.TYPE_SHA1, expected_checksum)
 
     def test_checksum_sha(self):
         # Setup (sha is an alias for sha1)
@@ -72,7 +36,7 @@ class VerificationTests(unittest.TestCase):
         expected_checksum = 'cae99c6102aa3596ff9b86c73881154e340c2ea8'
 
         # Test - Should not raise an exception
-        verification.verify_checksum(test_file, verification.TYPE_SHA, expected_checksum)
+        verification.verify_checksum(test_file, util.TYPE_SHA, expected_checksum)
 
     def test_checksum_sha256(self):
         # Setup
@@ -80,7 +44,7 @@ class VerificationTests(unittest.TestCase):
         expected_checksum = 'e27c8214be8b7cf5bccc7c08247e3cb0c1514a48ee1f63197fe4ef3ef51d7e6f'
 
         # Test - Should not raise an exception
-        verification.verify_checksum(test_file, verification.TYPE_SHA256, expected_checksum)
+        verification.verify_checksum(test_file, util.TYPE_SHA256, expected_checksum)
 
     def test_checksum_sha256_incorrect(self):
         # Setup
@@ -88,15 +52,8 @@ class VerificationTests(unittest.TestCase):
 
         # Test
         self.assertRaises(verification.VerificationException, verification.verify_checksum,
-                          test_file, verification.TYPE_SHA256, 'foo')
+                          test_file, util.TYPE_SHA256, 'foo')
 
     def test_checksum_invalid_checksum(self):
-        self.assertRaises(verification.InvalidChecksumType, verification.verify_checksum,
+        self.assertRaises(util.InvalidChecksumType, verification.verify_checksum,
                           StringIO(), 'fake-type', 'irrelevant')
-
-    def test_checksum_algorithm_mappings(self):
-        self.assertEqual(4, len(verification.CHECKSUM_FUNCTIONS))
-        self.assertEqual(verification.CHECKSUM_FUNCTIONS[verification.TYPE_MD5], hashlib.md5)
-        self.assertEqual(verification.CHECKSUM_FUNCTIONS[verification.TYPE_SHA1], hashlib.sha1)
-        self.assertEqual(verification.CHECKSUM_FUNCTIONS[verification.TYPE_SHA], hashlib.sha1)
-        self.assertEqual(verification.CHECKSUM_FUNCTIONS[verification.TYPE_SHA256], hashlib.sha256)


### PR DESCRIPTION
Calculation of checksums was moved out of the "verification"
module, because it is useful in many more cases than just in
the process of verification. The only plugin using the moved
code is pulp_rpm, and corresponding changes to that plugin
will be in a separate PR.

re #1618
https://pulp.plan.io/issues/1618