### PR TITLE
Enabling use of the django template engine.

### DIFF
--- a/server/pulp/server/webservices/settings.py
+++ b/server/pulp/server/webservices/settings.py
@@ -10,6 +10,12 @@ DEBUG = False
 
 TEMPLATE_DEBUG = False
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    },
+]
+
 ALLOWED_HOSTS = ['*']
 
 


### PR DESCRIPTION
This change is required in pulp_rpm to templatize repo metadata.

re #1618
https://pulp.plan.io/issues/1618