### PR TITLE
Update Pulp Smash settings file

### DIFF
--- a/playpen/vagrant-setup.sh
+++ b/playpen/vagrant-setup.sh
@@ -59,7 +59,7 @@ if [ -d pulp-smash ]; then
     mkdir -p $HOME/.config/pulp_smash/
     cat << EOF > $HOME/.config/pulp_smash/settings.json
 {
-    "default": {
+    "pulp": {
         "base_url": "https://$(hostname)",
         "auth": ["admin", "admin"],
         "cli_transport": "local",


### PR DESCRIPTION
As of Pulp Smash version 2016.05.05, the various
`pulp_smash.config.ServerConfig` methods default to working with a
configuration file section named "pulp" In earlier versions, the
defaulted to working with a configuration file section named "default."
This change was made so that Pulp Smash can more sanely adapt to the
case where not all Pulp components are on the same host. If the various
components are on different hosts, then the configuration file might
have sections named "pulp," "pulp agent," etc.

No breakage has occurred because Pulp Smash has logic for backwards
compatibility. It's a good idea to update, regardless.