### PR TITLE
Issue #1113: If an instance of pulp_celerybeat dies unexpectedly, Pulp incorrectly tries to "cancel all tasks in its queue"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 This is an alphabetical (by last name) list of the authors of the Pulp project. If you submit a pull request
 to Pulp and your name is not on this list, please add yourself.
 
+Daniel Alley (dalley@redhat.com)
 Randy Barlow (rbarlow@redhat.com)
 Shubham Bhawsinka(sbhawsin@redhat.com)
 Sander Bos (www.sbosnet.nl)

--- a/common/pulp/common/constants.py
+++ b/common/pulp/common/constants.py
@@ -51,9 +51,23 @@ PRIMARY_ID = '___/primary/___'
 DEFAULT_CA_PATH = '/etc/pki/tls/certs/ca-bundle.crt'
 
 # celerybeat constants
-CELERYBEAT_WAIT_SECONDS = 200
-SCHEDULER_WORKER_NAME = 'scheduler'
-TICK_SECONDS = 90
+
+# Scheduler worker name
+SCHEDULER_WORKER_NAME = 'pulp_celerybeat'
+# Constant used as the default wait time for celerybeat instances with no lock
+CELERY_TICK_DEFAULT_WAIT_TIME = 90
+# Constant used to determine whether a CeleryBeatLock should be removed due to age
+CELERYBEAT_LOCK_MAX_AGE = 200
+# The amount of time in seconds before a Celery process is considered missing
+CELERY_TIMEOUT_SECONDS = 300
+# The interval in seconds for which the Celery Process monitor thread sleeps between
+# checking for missing Celery processes.
+CELERY_CHECK_INTERVAL = 60
+# The maximum number of seconds that will ever elapse before the scheduler looks for
+# new or changed schedules
+CELERY_MAX_INTERVAL = 90
 
 # resource manager constants
+
+# Resource manager worker name
 RESOURCE_MANAGER_WORKER_NAME = 'resource_manager'

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -122,8 +122,12 @@ class TestSchedulerTick(unittest.TestCase):
 
         sched_instance.tick()
 
-        expected_event = {'timestamp': 1449261335.275528, 'local_received': 1449261335.275528,
-                          'type': 'scheduler-event', 'hostname': 'scheduler@some_host'}
+        expected_event = {
+            'timestamp': 1449261335.275528,
+            'local_received': 1449261335.275528,
+            'type': 'scheduler-event',
+            'hostname': SCHEDULER_WORKER_NAME + '@some_host'
+        }
         mock_worker_watcher.handle_worker_heartbeat.assert_called_once_with(expected_event)
         mock_worker_watcher.assert_called_once()
 
@@ -139,7 +143,7 @@ class TestSchedulerTick(unittest.TestCase):
         sched_instance.tick()
 
         lock_timestamp = mock_timestamp.utcnow()
-        celerybeat_name = "scheduler" + "@" + platform.node()
+        celerybeat_name = SCHEDULER_WORKER_NAME + "@" + platform.node()
 
         mock_celerybeatlock.assert_called_once_with(
             timestamp=lock_timestamp, celerybeat_name=celerybeat_name)

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -15,7 +15,8 @@ from mongoengine import ValidationError
 
 from ...base import PulpServerTests, ResourceReservationTests
 from pulp.common import dateutils
-from pulp.common.constants import CALL_CANCELED_STATE, CALL_FINISHED_STATE
+from pulp.common.constants import (CALL_CANCELED_STATE, CALL_FINISHED_STATE,
+                                   SCHEDULER_WORKER_NAME, RESOURCE_MANAGER_WORKER_NAME)
 from pulp.common.tags import action_tag, resource_tag, RESOURCE_CONSUMER_TYPE
 from pulp.devel.unit.util import compare_dict
 from pulp.server.async import app, tasks
@@ -527,6 +528,7 @@ class TestTaskOnFailureHandler(ResourceReservationTests):
             """
             def __init__(self):
                 self.traceback = "string_repr_of_traceback"
+
         einfo = EInfo()
         mock_request.called_directly = False
 
@@ -561,6 +563,7 @@ class TestTaskOnFailureHandler(ResourceReservationTests):
             """
             def __init__(self):
                 self.traceback = "string_repr_of_traceback"
+
         einfo = EInfo()
         mock_request.called_directly = False
         TaskStatus(task_id).save()
@@ -584,6 +587,7 @@ class TestTaskOnFailureHandler(ResourceReservationTests):
             """
             def __init__(self):
                 self.traceback = "string_repr_of_traceback"
+
         einfo = EInfo()
         mock_request.called_directly = False
         TaskStatus(task_id).save()
@@ -1055,10 +1059,10 @@ class TestGetUnreservedWorker(ResourceReservationTests):
         self.assertTrue(tasks._is_worker("a_worker@some.hostname"))
 
     def test_is_not_worker_is_scheduler(self):
-        self.assertEquals(tasks._is_worker("scheduler@some.hostname"), False)
+        self.assertEquals(tasks._is_worker(SCHEDULER_WORKER_NAME + "@some.hostname"), False)
 
     def test_is_not_worker_is_resource_mgr(self):
-        self.assertEquals(tasks._is_worker("resource_manager@some.hostname"), False)
+        self.assertEquals(tasks._is_worker(RESOURCE_MANAGER_WORKER_NAME + "@some.hostname"), False)
 
 
 class TestPulpTask(unittest.TestCase):


### PR DESCRIPTION
Fixes a bug wherein duplicate celerybeat instances will see one or the other going offline as a worker going offline and treats them as such.  Hence, it will try to delete the scheduler's work queue and prints a misleading error message.

https://pulp.plan.io/issues/1113