### PR TITLE
Configure vagrant and dev setup for packaging

### DIFF
--- a/playpen/ansible/roles/dev/tasks/main.yml
+++ b/playpen/ansible/roles/dev/tasks/main.yml
@@ -46,6 +46,7 @@
       - jnettop
       - koji
       - httpie
+      - mock
       - plantuml
       - python-django-bash-completion
       - python-gofer-qpid
@@ -67,6 +68,13 @@
       name: vagrant
       state: present
       groups: systemd-journal
+      append: true
+
+- name: allow vagrant user to use mock
+  user:
+      name: vagrant
+      state: present
+      groups: mock
       append: true
 
 - name: Install Pulp RPM dependencies

--- a/playpen/dev-setup.sh
+++ b/playpen/dev-setup.sh
@@ -36,7 +36,7 @@ echo "Choosing $GITHUB_USERNAME as your GitHub username."
 
 read -p 'Which plugin repos would you like to clone from your GitHub account? [crane pulp_deb pulp_docker pulp_openstack pulp_ostree pulp_puppet pulp_python pulp_rpm pulp-smash] ' REPOS
 if [ "$REPOS" = "" ]; then
-    REPOS="crane pulp_deb pulp_docker pulp_openstack pulp_ostree pulp_puppet pulp_python pulp_rpm pulp-smash"
+    REPOS="crane packaging pulp_deb pulp_docker pulp_openstack pulp_ostree pulp_puppet pulp_python pulp_rpm pulp-smash"
 fi
 # pulp is required and must be installed first so let's prepend it.
 REPOS="pulp $REPOS"


### PR DESCRIPTION
This change allows the vagrant user to use mock without sudo and checks
out the packaging repository so users can build RPMs inside Vagrant.