### PR TITLE
deal with libs dropping py2.4 support breaking PR tests

### DIFF
--- a/agent/setup.py
+++ b/agent/setup.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python2
+import sys
 
 from setuptools import setup, find_packages
+
+PYTHON_MAJOR_MINOR = '%s.%s' % (sys.version_info[0], sys.version_info[1])
+
+# m2crypto 0.25 broke compatability with py2.4
+if PYTHON_MAJOR_MINOR > '2.4':
+    M2CRYPTO_REQUIRES = 'm2crypto'
+else:
+    M2CRYPTO_REQUIRES = 'm2crypto<0.24'
 
 setup(
     name='pulp-agent',
@@ -9,5 +18,5 @@ setup(
     packages=find_packages(exclude=['test']),
     author='Pulp Team',
     author_email='pulp-list@redhat.com',
-    install_requires=['m2crypto']
+    install_requires=[M2CRYPTO_REQUIRES]
 )

--- a/bindings/setup.py
+++ b/bindings/setup.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python2
+import sys
 
 from setuptools import setup, find_packages
+
+PYTHON_MAJOR_MINOR = '%s.%s' % (sys.version_info[0], sys.version_info[1])
+
+# m2crypto 0.25 broke compatability with py2.4
+if PYTHON_MAJOR_MINOR > '2.4':
+    M2CRYPTO_REQUIRES = 'm2crypto'
+else:
+    M2CRYPTO_REQUIRES = 'm2crypto<0.24'
 
 setup(
     name='pulp-bindings',
@@ -9,5 +18,5 @@ setup(
     packages=find_packages(exclude=['test']),
     author='Pulp Team',
     author_email='pulp-list@redhat.com',
-    install_requires=['m2crypto', 'oauth2>=1.5.170']
+    install_requires=['oauth2>=1.5.170', M2CRYPTO_REQUIRES]
 )

--- a/client_lib/setup.py
+++ b/client_lib/setup.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python2
+import sys
 
 from setuptools import setup, find_packages
+
+PYTHON_MAJOR_MINOR = '%s.%s' % (sys.version_info[0], sys.version_info[1])
+
+# m2crypto 0.25 broke compatability with py2.4
+if PYTHON_MAJOR_MINOR > '2.4':
+    M2CRYPTO_REQUIRES = 'm2crypto'
+else:
+    M2CRYPTO_REQUIRES = 'm2crypto<0.24'
 
 setup(
     name='pulp-client-lib',
@@ -9,5 +18,5 @@ setup(
     packages=find_packages(exclude=['test']),
     author='Pulp Team',
     author_email='pulp-list@redhat.com',
-    install_requires=['isodate>0.5.0', 'm2crypto', 'okaara>=1.0.32', 'setuptools']
+    install_requires=['isodate>0.5.0', 'okaara>=1.0.32', 'setuptools', M2CRYPTO_REQUIRES]
 )

--- a/devel/setup.py
+++ b/devel/setup.py
@@ -1,5 +1,13 @@
+import sys
+
 from setuptools import setup, find_packages
 
+PYTHON_MAJOR_MINOR = '%s.%s' % (sys.version_info[0], sys.version_info[1])
+
+if PYTHON_MAJOR_MINOR < '2.7':
+    requires = {'install_requires': ['argparse']}
+else:
+    requires = {}
 
 setup(
     name='pulp-devel',
@@ -7,4 +15,5 @@ setup(
     license='GPLv2+',
     packages=find_packages(exclude=['test', 'test.*']),
     author='Pulp Team',
-    author_email='pulp-list@redhat.com')
+    author_email='pulp-list@redhat.com',
+    **requires)

--- a/server/setup.py
+++ b/server/setup.py
@@ -2,9 +2,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-
 PYTHON_MAJOR_MINOR = '%s.%s' % (sys.version_info[0], sys.version_info[1])
-
 
 # Django 1.8.0 requires Python >= 2.7
 if PYTHON_MAJOR_MINOR < '2.7':
@@ -12,6 +10,14 @@ if PYTHON_MAJOR_MINOR < '2.7':
 else:
     DJANGO_REQUIRES = 'django>=1.4.0'
 
+# semantic_version and m2crypto no longer install via pip on el5,
+# and need to be pinned to the highest known working version in py2.4
+if PYTHON_MAJOR_MINOR > '2.4':
+    SEMVER_REQUIRES = 'semantic_version>=2.2.0'
+    M2CRYPTO_REQUIRES = 'm2crypto'
+else:
+    SEMVER_REQUIRES = 'semantic_version>=2.2.0,<2.5'
+    M2CRYPTO_REQUIRES = 'm2crypto<0.24'
 
 setup(
     name='pulp-server',
@@ -26,7 +32,7 @@ setup(
         ]
     },
     install_requires=[
-        'blinker', 'celery >=3.1.0, <3.2.0', DJANGO_REQUIRES, 'httplib2', 'iniparse',
-        'isodate>=0.5.0', 'm2crypto', 'mongoengine>=0.10.0', 'oauth2>=1.5.211', 'pymongo>=3.0.0',
-        'semantic_version>=2.2.0', 'setuptools'],
+        'blinker', 'celery >=3.1.0, <3.2.0', 'httplib2', 'iniparse', 'isodate>=0.5.0',
+        'mongoengine>=0.10.0', 'oauth2>=1.5.211', 'pymongo>=3.0.0', 'setuptools',
+        DJANGO_REQUIRES, SEMVER_REQUIRES, M2CRYPTO_REQUIRES],
 )


### PR DESCRIPTION
As far as I know, the only place we install these libraries from pip is
in dev environments and in the PR tester. So, I think this change
therefore only affects developers working on environments running python
2.4, like el5, and our ability to test our pull requests on environments
running python 2.4, like el5. :)