### PR TITLE
Adds two deps to Vagrant environment

### DIFF
--- a/playpen/ansible/roles/dev/tasks/main.yml
+++ b/playpen/ansible/roles/dev/tasks/main.yml
@@ -59,9 +59,11 @@
       - python2-rpdb
       - redhat-lsb-core
       - rpm-build
+      - ruby-devel
       - telnet
       - tito
       - yum-utils
+      - zlib-devel
 
 - name: allow vagrant user to read the systemd journal
   user:


### PR DESCRIPTION
These two deps make installing the Jekyll environment easier.
The Jekyll environment itself is done manually with docs
that will be kept in the pulpproject.org directory.

https://pulp.plan.io/issues/1862
re # 1862