### PR TITLE
Serve index.json for directory requests

### DIFF
--- a/server/etc/httpd/conf.d/pulp_apache_22.conf
+++ b/server/etc/httpd/conf.d/pulp_apache_22.conf
@@ -50,6 +50,10 @@ WSGIImportScript /usr/share/pulp/wsgi/webservices.wsgi process-group=pulp applic
     Include /etc/pulp/vhosts80/*.conf
 </VirtualHost>
 
+<IfModule dir_module>
+    DirectoryIndex index.html index.json
+</IfModule>
+
 
 Alias /pulp/static /var/lib/pulp/static
 

--- a/server/etc/httpd/conf.d/pulp_apache_24.conf
+++ b/server/etc/httpd/conf.d/pulp_apache_24.conf
@@ -39,6 +39,10 @@ WSGIImportScript /usr/share/pulp/wsgi/webservices.wsgi process-group=pulp applic
     Require all granted
 </Directory>
 
+<IfModule dir_module>
+    DirectoryIndex index.html index.json
+</IfModule>
+
 <Files webservices.wsgi>
     WSGIPassAuthorization On
     WSGIProcessGroup pulp


### PR DESCRIPTION
Python API requires serving a json file for a call to a directory. Using
index.html would return the incorrect `Content-Type`