### PR TITLE
2.8.5 release notes

### DIFF
--- a/docs/user-guide/release-notes/2.8.x.rst
+++ b/docs/user-guide/release-notes/2.8.x.rst
@@ -2,11 +2,54 @@
 Pulp 2.8 Release Notes
 ======================
 
+Pulp 2.8.5
+==========
+
+.. warning::
+
+    User action is required to address the CVEs associated with this upgrade! Read the upgrade
+    instructions below.
+
+2.8.5 is a security and bugfix release.
+
+Included in the list of :fixedbugs:`2.8.5` are two CVEs:
+
+    * `CVE-2016-3696 <https://pulp.plan.io/issues/1854>`_: Leakage of CA key in pulp-qpid-ssl-cfg
+    * `CVE-2016-3704 <https://pulp.plan.io/issues/1858>`_: Unsafe use of bash $RANDOM for NSS DB
+      password and seed
+
+
+Upgrade instructions
+--------------------
+
+The CVEs require user interaction to remedy if you have been using qpid, and if you used
+``pulp-qpid-ssl-cfg`` to generate the TLS keys. Rabbit users and users who generated their own keys
+for qpidd are not affected by these CVEs. Begin by upgrading to Pulp 2.8.5 and running migrations::
+
+    $ sudo systemctl stop qpidd httpd pulp_workers pulp_resource_manager pulp_celerybeat goferd
+    $ sudo yum upgrade
+    $ sudo -u apache pulp-manage-db
+
+.. note::
+
+    You don't need to restart goferd if goferd isn't installed.
+
+Any qpidd CA, server and client certificate and key pairs that were generated with
+``pulp-qpid-ssl-cfg`` are unsafe and should be replaced. After upgrading to 2.8.5 (as we did above),
+you can use the script to replace the certificates and keys::
+
+    $ sudo pulp-qpid-ssl-cfg
+
+Now we are ready to start the services again::
+
+    $ sudo systemctl start qpidd httpd pulp_workers pulp_resource_manager pulp_celerybeat goferd
+
+
 Pulp 2.8.4
 ==========
 
 This is a hotfix release to address migration failures introduced in earlier versions
-of Pulp. 
+of Pulp.
 
 
 Upgrade instructions
@@ -27,45 +70,6 @@ Bug Fixes
 ---------
 
 See the list of :fixedbugs:`2.8.4`
-
-
-Pulp 2.8.4
-==========
-
-.. warning::
-
-    User action is required to address the CVEs associated with this upgrade! Read the upgrade
-    instructions below.
-
-2.8.4 is a security and bugfix release.
-
-Included in the list of :fixedbugs:`2.8.4` are two CVEs:
-
-    * `CVE-2016-3696 <https://pulp.plan.io/issues/1854>`_: Leakage of CA key in pulp-qpid-ssl-cfg
-    * `CVE-2016-3704 <https://pulp.plan.io/issues/1858>`_: Unsafe use of bash $RANDOM for NSS DB
-      password and seed
-
-
-Upgrade instructions
---------------------
-
-The CVEs require user interaction to remedy if you have been using qpid, and if you used
-``pulp-qpid-ssl-cfg`` to generate the TLS keys. Rabbit users and users who generated their own keys
-for qpidd are not affected by these CVEs. Begin by upgrading to Pulp 2.8.4 and running migrations::
-
-    $ sudo systemctl stop qpidd httpd pulp_workers pulp_resource_manager pulp_celerybeat goferd
-    $ sudo yum upgrade
-    $ sudo -u apache pulp-manage-db
-
-Any qpidd CA, server and client certificate and key pairs that were generated with
-``pulp-qpid-ssl-cfg`` are unsafe and should be replaced. After upgrading to 2.8.4 (as we did above),
-you can use the script to replace the certificates and keys::
-
-    $ sudo pulp-qpid-ssl-cfg
-
-Now we are ready to start the services again::
-
-    $ sudo systemctl start qpidd httpd pulp_workers pulp_resource_manager pulp_celerybeat goferd
 
 
 Pulp 2.8.3


### PR DESCRIPTION
We actually had 2.8.4 release notes in there twice due to the 2.8.4
hotfix preempting what became the 2.8.5 release. This pulls the
original 2.8.4 release notes up and labels them as 2.8.5.