### PR TITLE
saxwriter attributes and values can have utf-8 non-ascii chars

### DIFF
--- a/server/pulp/plugins/util/saxwriter.py
+++ b/server/pulp/plugins/util/saxwriter.py
@@ -37,14 +37,24 @@ class XMLWriter(ContentHandler):
         :type  short_empty_elements: bool
         """
         ContentHandler.__init__(self)
-        self._write = stream.write
-        self._flush = stream.flush
+        self._stream = stream
         self._encoding = encoding
         self._short_empty_elements = short_empty_elements
         self._pending_start_element = False
         self._indent_lvl = 0
         self._indent_sep = '  '
         self._start_element = False
+
+    def _write(self, text):
+        """
+        Write text to the stream, encoding with the configured encoding if possible.
+
+        :param text:    text that should be written to the stream
+        :type  text:    basestring
+        """
+        if isinstance(text, unicode):
+            text = text.encode(self._encoding)
+        self._stream.write(text)
 
     def _finish_pending_start_element(self):
         """
@@ -92,7 +102,7 @@ class XMLWriter(ContentHandler):
         """
         Flush the buffer after generating the XML document.
         """
-        self._flush()
+        self._stream.flush()
 
     def startElement(self, name, attrs={}):
         """
@@ -144,7 +154,4 @@ class XMLWriter(ContentHandler):
         """
         if content:
             self._finish_pending_start_element()
-            if isinstance(content, unicode):
-                self._write(escape(content).encode(self._encoding))
-            else:
-                self._write(escape(content))
+            self._write(escape(content))

--- a/server/test/unit/plugins/util/test_saxwriter.py
+++ b/server/test/unit/plugins/util/test_saxwriter.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from cStringIO import StringIO
 
 from pulp.common.compat import unittest
@@ -60,3 +62,17 @@ class TestXMLWriter(unittest.TestCase):
                        '</outer_tag1>\n' \
                        '<outer_tag2></outer_tag2>\n'
         self.assertEqual(generated_xml, expected_xml)
+
+    def test_utf8_writes(self):
+        """
+        Test that utf-8 non-ascii characters are handled without complaint.
+        """
+        xml_generator = XMLWriter(StringIO())
+
+        tag = u'𝅘𝅥𝅮'
+        xml_generator.startDocument()
+        xml_generator.writeDoctype('<!DOCTYPE string here>')
+        xml_generator.startElement(tag, {u'𝆑': u'𝆒'})
+        xml_generator.completeElement(u'inner_tag2 Ώ', {u'attr1 ỳ': u'value1 ỳ'}, u'ỳ')
+        xml_generator.endElement(tag)
+        xml_generator.endDocument()


### PR DESCRIPTION
fixes #2015 
https://pulp.plan.io/issues/2015