### PR TITLE
Prevent more than one resource manager from operating in parallel - #898

### DIFF
--- a/docs/dev-guide/integration/rest-api/status.rst
+++ b/docs/dev-guide/integration/rest-api/status.rst
@@ -18,12 +18,11 @@ and ``known_workers`` to get more detailed status information.
     of a Pulp deployment, and is not meant to replace monitoring of Pulp
     components in a production environment.
 
-A healthy Pulp installation will contain exactly one record for
-"resource_manager" and "scheduler" in the worker list, and one or more
-"reserved_resource_worker" records. It will also have
-``messaging_connection`` and ``database_connection`` entries that contain ``{connected: True}``.
-Note that if the scheduler is not running, other workers may be running but not
-updating their last heartbeat record.
+A healthy Pulp installation will contain one or more records for "resource_manager",
+one or more records for "scheduler", and one or more records for "reserved_resource_worker"
+in the worker list. It will also have ``messaging_connection`` and ``database_connection``
+entries that contain ``{connected: True}``. Note that if the scheduler is not running,
+other workers may be running but not updating their last heartbeat record.
 
 The version of Pulp is also returned via ``platform_version`` in the
 ``versions`` object. This field is calculated from the "pulp-server" python

--- a/docs/user-guide/installation/f23-.rst
+++ b/docs/user-guide/installation/f23-.rst
@@ -220,14 +220,13 @@ Server
       $ sudo systemctl enable pulp_celerybeat
       $ sudo systemctl start pulp_celerybeat
 
-   .. warning::
+   Lastly, a ``pulp_resource_manager`` process must be running in the installation. This process
+   acts as a task router, deciding which worker should perform certain types of tasks. As with
+   ``pulp_celerybeat``, multiple instances of ``pulp_resource_manager`` may be run concurrently on
+   separate hosts to increase fault tolerance, however, only one instance will ever be active at a
+   time. Should the active instance become unavailable, another instance will take over after some
+   delay.
 
-      ``pulp_resource_manager`` must be singleton, so be sure that you
-      only enable this on one host if you are Pulp's clustered deployment.
-
-   Lastly, one ``pulp_resource_manager`` process must be running in the installation. This process
-   acts as a task router, deciding which worker should perform certain types of tasks. Apologies
-   for the repetitive message, but it is important that this process only be enabled on one host.
    Edit ``/etc/default/pulp_resource_manager`` to your liking. Then, for upstart::
 
       $ sudo chkconfig pulp_resource_manager on
@@ -319,7 +318,7 @@ specific consumer dependencies with one command by running:
    By default, the agent will connect using a plain TCP connection.
 
 
-4. Set the agent to start at boot.  For upstart::
+4. Set the agent to start at boot. For upstart::
 
       $ sudo chkconfig goferd on
       $ sudo service goferd start

--- a/docs/user-guide/installation/f24+.rst
+++ b/docs/user-guide/installation/f24+.rst
@@ -178,18 +178,17 @@ Now we are ready to install and configure the Pulp server!
       $ sudo systemctl enable pulp_celerybeat
       $ sudo systemctl start pulp_celerybeat
 
-   Lastly, exactly one ``pulp_resource_manager`` process must be running in the installation. This
-   process acts as a task router, deciding which worker should perform certain types of tasks.
-   Apologies for the repetitive message, but it is important that this process only be enabled on
-   one host. Edit ``/etc/default/pulp_resource_manager`` to your liking. Then::
+   Lastly, a ``pulp_resource_manager`` process must be running in the installation. This process
+   acts as a task router, deciding which worker should perform certain types of tasks. As with
+   ``pulp_celerybeat``, multiple instances of ``pulp_resource_manager`` may be run concurrently on
+   separate hosts to increase fault tolerance, however, only one instance will ever be active at a
+   time. Should the active instance become unavailable, another instance will take over after some
+   delay.
+
+   Edit ``/etc/default/pulp_resource_manager`` to your liking. Then::
 
       $ sudo systemctl enable pulp_resource_manager
       $ sudo systemctl start pulp_resource_manager
-
-   .. warning::
-
-      ``pulp_resource_manager`` must be singleton, so be sure that you
-      only enable this on one host if you are deploying Pulp in a clustered environment.
 
 
 Admin Client
@@ -250,7 +249,7 @@ repositories.
    and Puppet plugins support the Pulp Agent.
 
    ::
- 
+
       $ sudo dnf install pulp-puppet-consumer-extensions pulp-rpm-consumer-extensions
 
 

--- a/docs/user-guide/release-notes/2.10.x.rst
+++ b/docs/user-guide/release-notes/2.10.x.rst
@@ -1,0 +1,13 @@
+=======================
+Pulp 2.10 Release Notes
+=======================
+
+Pulp 2.10.0
+===========
+
+New Features
+------------
+
+* Multiple instances of ``pulp_resource_manager`` can now exist in parallel without interfering with
+  each other. The original copy will now hold an exclusive lock until it dies or is killed, at
+  which point another instance of ``pulp_resource_manager`` can acquire the lock and take its place.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.10.x
    2.9.x
    2.8.x
    2.7.x

--- a/docs/user-guide/scaling.rst
+++ b/docs/user-guide/scaling.rst
@@ -37,7 +37,9 @@ Pulp consists of several components:
 
 * ``pulp_resource_manager`` - The resource manager assigns tasks to workers,
   and ensures multiple conflicting tasks on a repo are not executed at the same
-  time. In a Pulp cluster, exactly one of these should be running!
+  time. Multiple instances of ``pulp_resource_manager`` can be running at a time,
+  but if the active ``pulp_resource_manager`` instance becomes unavailable, there
+  will be a delay before another can take over, potentially causing a gap in service.
 
 Additionally, Pulp relies on other components:
 
@@ -45,9 +47,6 @@ Additionally, Pulp relies on other components:
 
 * `Apache Qpid`_ or `RabbitMQ`_ - the queuing system that Pulp uses to assign
   work to workers. Pulp can operate equally well with either Qpid or RabbitMQ.
-
-.. warning:: It is critical to note that ``pulp_resource_manager`` should
-   *never* have more than a single instance running under any circumstance!
 
 The diagram below shows an example default deployment.
 
@@ -131,8 +130,7 @@ httpd workers are.
     `Load Balancing Requirements`_ for more information.
 
 To add additional httpd server capacity, configure the desired number of
-`Pulp clustered servers` and start ``httpd`` on them. Remember only one
-instance of ``pulp_resource_manager`` should be running across all `Pulp clustered servers`.
+`Pulp clustered servers` and start ``httpd`` on them.
 
 
 Scaling workers

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -20,7 +20,7 @@ Pulp's log level can be adjusted with the ``log_level`` setting in the ``[server
 CRITICAL, ERROR, WARNING, INFO, DEBUG, and NOTSET.
 
 .. note::
-   
+
    This setting will only adjust the verbosity of the messages that Pulp emits. If you wish to see
    all of these messages, you may also need to set the log level on your syslog handler. For example,
    rsyslog typically only displays INFO and higher, so if you set Pulp to DEBUG it will still be
@@ -196,12 +196,6 @@ configured and running correctly. If you are using systemd, please see the speci
    those services are still running. It is possible to ask for pulp_worker statuses using wildcards,
    such as ``systemctl status pulp_worker-\* -a``, for example.
 
-.. warning::
-
-   Remember that ``pulp_celerybeat`` and ``pulp_resource_manager`` must be singletons across the
-   entire Pulp distributed installation. Please be sure to only start one instance of each of these.
-   ``pulp_workers`` is safe to start on as many machines as you like.
-
 qpid.messaging is not installed
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -255,7 +249,7 @@ User permissions not behaving as expected
 Resource names should always start with ``/v2`` and end with a trailing ``/``.  For example, the
 following command will add a permission to ``test-user`` to create repositories::
 
-    pulp-admin auth permission grant --resource /v2/repositories/ --login test-user -o create 
+    pulp-admin auth permission grant --resource /v2/repositories/ --login test-user -o create
 
 Pulp workers not starting due to Permission Denied Exception
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -264,7 +258,7 @@ Pulp workers attempt create working directory on startup. The path for working d
 defined by the `working_directory` config in `server` section of `/etc/pulp/server.conf`. The
 default value is `/var/cache/pulp`. Any user defined path needs to be owned by user and group
 `apache`. If running with SELinux in Enforcing mode, the path also needs to have
-`system_u:object_r:pulp_var_cache_t` security context. 
+`system_u:object_r:pulp_var_cache_t` security context.
 
 Celery terminates the worker in case of sync cancellation.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/server/pulp/server/async/app.py
+++ b/server/pulp/server/async/app.py
@@ -3,18 +3,35 @@ This module is the Pulp Celery App. It is passed to the workers from the command
 will see the "celery" module attribute and use it. This module also initializes the Pulp app after
 Celery setup finishes.
 """
+
+import contextlib
+import logging
+import platform
+import sys
+import signal
+import time
+from datetime import datetime
+from gettext import gettext as _
+
+import mongoengine
 from celery.signals import celeryd_after_setup
+
+from pulp.common import constants
+from pulp.server import initialization
+from pulp.server.async import tasks
+from pulp.server.db.model import ResourceManagerLock, Worker
+from pulp.server.managers.repo import _common as common_utils
 
 # This import will load our configs
 from pulp.server import config  # noqa
-from pulp.server import initialization
 # We need this import so that the Celery setup_logging signal gets registered
 from pulp.server import logs  # noqa
-from pulp.server.async import tasks
 # This import is here so that Celery will find our application instance
 from pulp.server.async.celery_instance import celery  # noqa
-from pulp.server.managers.repo import _common as common_utils
+
 import pulp.server.tasks  # noqa
+
+_logger = logging.getLogger(__name__)
 
 
 @celeryd_after_setup.connect
@@ -22,7 +39,7 @@ def initialize_worker(sender, instance, **kwargs):
     """
     This function performs all the necessary initialization of the Celery worker.
 
-    It starts by cleaning up old state if this worker was previously running, but died unexpectedly.
+    We clean up old state in case this worker was previously running, but died unexpectedly.
     In such cases, any Pulp tasks that were running or waiting on this worker will show incorrect
     state. Any reserved_resource reservations associated with the previous worker will also be
     removed along with the worker entry in the database itself. The working directory specified in
@@ -38,6 +55,15 @@ def initialize_worker(sender, instance, **kwargs):
     It uses the celeryd_after_setup signal[0] so that it gets called by Celery after logging is
     initialized, but before Celery starts to run tasks.
 
+    If the worker is a resource manager, it tries to acquire a lock stored within the database.
+    If the lock cannot be acquired immediately, it will wait until the currently active instance
+    becomes unavailable, at which point the worker cleanup routine will clear the lock for us to
+    acquire. While the worker remains in this waiting state, it is not connected to the broker and
+    will not attempt to do any work. A side effect of this is that, if terminated while in this
+    state, the process will not send the "worker-offline" signal used by the EventMonitor to
+    immediately clean up terminated workers. Therefore, we override the SIGTERM signal handler
+    while in this state so that cleanup is done properly.
+
     [0] http://celery.readthedocs.org/en/latest/userguide/signals.html#celeryd-after-setup
 
     :param sender:   The hostname of the worker
@@ -49,8 +75,77 @@ def initialize_worker(sender, instance, **kwargs):
     """
     initialization.initialize()
 
+    # Delete any potential old state
     tasks._delete_worker(sender, normal_shutdown=True)
 
     # Create a new working directory for worker that is starting now
     common_utils.delete_worker_working_directory(sender)
     common_utils.create_worker_working_directory(sender)
+
+    # If the worker is a resource manager, try to acquire the lock, or wait until it
+    # can be acquired
+    if sender.startswith(constants.RESOURCE_MANAGER_WORKER_NAME):
+        get_resource_manager_lock(sender)
+
+
+def get_resource_manager_lock(sender):
+    """
+    Tries to acquire the resource manager lock. If the lock cannot be acquired immediately, it
+    will wait until the currently active instance becomes unavailable, at which point the worker
+    cleanup routine will clear the lock for us to acquire. A worker record will be created so that
+    the waiting resource manager will appear in the Status API. We override the SIGTERM signal
+    handler so that that the worker record will be immediately cleaned up if the process is killed
+    while in this states.
+
+    :param sender:   The hostname of the worker
+    :type  sender:   basestring
+    """
+    name = constants.RESOURCE_MANAGER_WORKER_NAME + "@" + platform.node()
+    lock = ResourceManagerLock(name=name)
+
+    assert name.startswith(constants.RESOURCE_MANAGER_WORKER_NAME)
+
+    with custom_sigterm_handler(name):
+        # Whether this is the first lock availability check for this instance
+        _first_check = True
+
+        while True:
+            # Create / update the worker record so that Pulp knows we exist
+            Worker.objects(name=sender).update_one(set__last_heartbeat=datetime.utcnow(),
+                                                   upsert=True)
+            try:
+                lock.save()
+
+                msg = _("Resource manager '%s' has acquired the resource manager lock" % name)
+                _logger.info(msg)
+                break
+            except mongoengine.NotUniqueError:
+                # Only log the message the first time
+                if _first_check:
+                    msg = _("Resource manager '%s' attempted to acquire the the resource manager "
+                            "lock but was unable to do so. It will retry every %d seconds until "
+                            "the lock can be acquired." % (name, constants.CELERY_CHECK_INTERVAL))
+                    _logger.info(msg)
+                    _first_check = False
+
+                time.sleep(constants.CELERY_CHECK_INTERVAL)
+
+
+@contextlib.contextmanager
+def custom_sigterm_handler(name):
+    """
+    Temporarily installs a custom SIGTERM handler that performs cleanup of the worker record with
+    the provided name. Resets the signal handler to the default one after leaving.
+
+    :param name:   The hostname of the worker
+    :type  name:   basestring
+    """
+    def sigterm_handler(_signo, _stack_frame):
+        msg = _("Worker '%s' shutdown" % name)
+        _logger.info(msg)
+        tasks._delete_worker(name, normal_shutdown=True)
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, sigterm_handler)
+    yield
+    signal.signal(signal.SIGTERM, signal.SIG_DFL)

--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -247,8 +247,12 @@ class Scheduler(beat.Scheduler):
         # this is not an event that gets sent anywhere. We process it
         # immediately.
         scheduler_event = {
-            'timestamp': time.time(), 'local_received': time.time(), 'type': 'scheduler-event',
-            'hostname': celerybeat_name}
+            'timestamp': time.time(),
+            'local_received': time.time(),
+            'type': 'scheduler-event',
+            'hostname': celerybeat_name
+        }
+
         worker_watcher.handle_worker_heartbeat(scheduler_event)
 
         old_timestamp = datetime.utcnow() - timedelta(seconds=constants.CELERYBEAT_LOCK_MAX_AGE)

--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -14,13 +14,13 @@ from celery.app import control, defaults
 from celery.result import AsyncResult
 from mongoengine.queryset import DoesNotExist
 
-from pulp.common.constants import SCHEDULER_WORKER_NAME
+from pulp.common.constants import SCHEDULER_WORKER_NAME, RESOURCE_MANAGER_WORKER_NAME
 from pulp.common import constants, dateutils, tags
 from pulp.server.async.celery_instance import celery, RESOURCE_MANAGER_QUEUE, \
     DEDICATED_QUEUE_EXCHANGE
 from pulp.server.exceptions import PulpException, MissingResource, \
     PulpCodedException
-from pulp.server.db.model import Worker, ReservedResource, TaskStatus
+from pulp.server.db.model import Worker, ReservedResource, TaskStatus, ResourceManagerLock
 from pulp.server.exceptions import NoWorkers
 from pulp.server.managers.repo import _common as common_utils
 from pulp.server.managers import factory as managers
@@ -251,6 +251,10 @@ def _delete_worker(name, normal_shutdown=False):
 
     # Delete all reserved_resource documents for the worker
     ReservedResource.objects(worker_name=name).delete()
+
+    # If the worker is a resource manager, we also need to delete the associated lock
+    if name.startswith(RESOURCE_MANAGER_WORKER_NAME):
+        ResourceManagerLock.objects(name=name).delete()
 
     # Cancel all of the tasks that were assigned to this worker's queue
     for task_status in TaskStatus.objects(worker_name=name,

--- a/server/pulp/server/db/manage.py
+++ b/server/pulp/server/db/manage.py
@@ -159,6 +159,7 @@ def ensure_database_indexes():
     model.TaskStatus.ensure_indexes()
     model.Worker.ensure_indexes()
     model.CeleryBeatLock.ensure_indexes()
+    model.ResourceManagerLock.ensure_indexes()
     model.LazyCatalogEntry.ensure_indexes()
     model.DeferredDownload.ensure_indexes()
     model.Distributor.ensure_indexes()

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -983,6 +983,24 @@ class CeleryBeatLock(AutoRetryDocument):
     _ns = StringField(default='celery_beat_lock')
 
 
+class ResourceManagerLock(AutoRetryDocument):
+    """
+    Single document collection which gives information about the current resource manager lock.
+
+    :ivar name: string representing the resource manager instance name
+    :type name: basestring
+    :ivar lock: A unique key set to "locked" when lock is acquired.
+    :type lock: basestring
+    :ivar _ns: (Deprecated), Contains the name of the collection this model represents
+    :type _ns: mongoengine.StringField
+    """
+    name = StringField(required=True)
+    lock = StringField(required=True, default="locked", unique=True)
+
+    # For backward compatibility
+    _ns = StringField(default='resource_manager_lock')
+
+
 class LazyCatalogEntry(AutoRetryDocument):
     """
     A catalog of content that can be downloaded by the specified plugin.

--- a/server/test/unit/server/async/test_app.py
+++ b/server/test/unit/server/async/test_app.py
@@ -1,11 +1,20 @@
 """
 This module contains tests for the pulp.server.async.app module.
 """
+
+import mongoengine
+import platform
 import unittest
+import signal
 
 import mock
 
+from pulp.common.constants import RESOURCE_MANAGER_WORKER_NAME, CELERY_CHECK_INTERVAL
 from pulp.server.async import app
+from pulp.server.managers.factory import initialize
+
+
+initialize()
 
 
 class InitializeWorkerTestCase(unittest.TestCase):
@@ -16,17 +25,103 @@ class InitializeWorkerTestCase(unittest.TestCase):
     @mock.patch('pulp.server.async.app.common_utils.create_worker_working_directory')
     @mock.patch('pulp.server.async.app.initialization.initialize')
     @mock.patch('pulp.server.async.app.tasks._delete_worker')
-    def test_initialize_worker(self, _delete_worker, initialize, create_worker_working_directory,
+    @mock.patch('pulp.server.async.app.get_resource_manager_lock')
+    def test_initialize_worker(self,
+                               mock_get_resource_manager_lock,
+                               _delete_worker, initialize,
+                               create_worker_working_directory,
                                delete_worker_working_directory):
         """
         Assert that initialize_worker() calls Pulp's initialization code and the appropriate worker
-        monitoring code.
+        monitoring code for a non-resource mananger worker.
         """
-        sender = mock.MagicMock()
-        # The args aren't used and don't matter, so we'll just pass some mocks
+        sender = 'reserved_resource_worker-0' + '@' + platform.node()
+        # The instance argument isn't used and don't matter, so we'll just pass a mock
         app.initialize_worker(sender, mock.MagicMock())
 
         initialize.assert_called_once_with()
         _delete_worker.assert_called_once_with(sender, normal_shutdown=True)
         create_worker_working_directory.assert_called_once_with(sender)
         delete_worker_working_directory.assert_called_once_with(sender)
+        mock_get_resource_manager_lock.assert_not_called()
+
+    @mock.patch('pulp.server.async.app.common_utils.delete_worker_working_directory')
+    @mock.patch('pulp.server.async.app.common_utils.create_worker_working_directory')
+    @mock.patch('pulp.server.async.app.initialization.initialize')
+    @mock.patch('pulp.server.async.app.tasks._delete_worker')
+    @mock.patch('pulp.server.async.app.get_resource_manager_lock')
+    def test_initialize_worker_resource_manager(self,
+                                                mock_get_resource_manager_lock,
+                                                _delete_worker, initialize,
+                                                create_worker_working_directory,
+                                                delete_worker_working_directory):
+        """
+        Assert that initialize_worker() calls Pulp's initialization code and the appropriate worker
+        monitoring code for a resource mananger worker.
+        """
+        sender = RESOURCE_MANAGER_WORKER_NAME + '@' + platform.node()
+        # The instance argument isn't used and don't matter, so we'll just pass a mock
+        app.initialize_worker(sender, mock.MagicMock())
+
+        initialize.assert_called_once_with()
+        _delete_worker.assert_called_once_with(sender, normal_shutdown=True)
+        create_worker_working_directory.assert_called_once_with(sender)
+        delete_worker_working_directory.assert_called_once_with(sender)
+        mock_get_resource_manager_lock.assert_called_once_with(sender)
+
+    @mock.patch('pulp.server.async.app.time')
+    @mock.patch('pulp.server.async.app.datetime')
+    @mock.patch('pulp.server.async.app.Worker')
+    @mock.patch('pulp.server.async.app.ResourceManagerLock')
+    def test_get_resource_manager_lock(self, mock_rm_lock, mock_worker, mock_datetime, mock_time):
+        """
+        Assert that get_resource_manager_lock() attempts to save a lock to the database with the
+        correct name, and that it creates a worker entry with that name and the correct timestamp,
+        and that a failure to save the lock will cause it to sleep and retry acquisition.
+        """
+        sender = RESOURCE_MANAGER_WORKER_NAME + '@' + platform.node()
+        mock_rm_lock().save.side_effect = [mongoengine.NotUniqueError(), None]
+        app.get_resource_manager_lock(sender)
+
+        mock_worker.objects(name=sender).update_one.\
+            assert_called_with(set__last_heartbeat=mock_datetime.utcnow(), upsert=True)
+
+        self.assertEquals(2, len(mock_rm_lock().save.mock_calls))
+        mock_time.sleep.assert_called_once_with(CELERY_CHECK_INTERVAL)
+
+    @mock.patch('pulp.server.async.app.sys')
+    @mock.patch('pulp.server.async.app.tasks._delete_worker')
+    def test_custom_sigterm_handler(self, _delete_worker, mock_sys):
+        """
+        Assert that the signal handler installed by the custom_sigterm_handler context manager
+        calls the delete_worker cleanup routine with the correct worker name and then exits.
+        """
+        name = RESOURCE_MANAGER_WORKER_NAME + '@' + platform.node()
+
+        with app.custom_sigterm_handler(name):
+            handler = signal.getsignal(signal.SIGTERM)
+            self.assertNotEquals(handler, signal.SIG_DFL)
+
+            handler(None, None)
+
+            _delete_worker.assert_called_once_with(name, normal_shutdown=True)
+            mock_sys.exit.assert_called_once_with(0)
+
+    @mock.patch('pulp.server.async.app.sys')
+    @mock.patch('pulp.server.async.app.tasks._delete_worker')
+    def test_custom_sigterm_handler_context_manager(self, _delete_worker, mock_sys):
+        """
+        Assert that the custom_sigterm_handler context manager properly sets and restores the
+        SIGTERM signal handler upon entry and exit.
+        """
+        handler = signal.getsignal(signal.SIGTERM)
+        self.assertEquals(handler, signal.SIG_DFL)
+
+        name = RESOURCE_MANAGER_WORKER_NAME + '@' + platform.node()
+
+        with app.custom_sigterm_handler(name):
+            handler = signal.getsignal(signal.SIGTERM)
+            handler(None, None)
+
+        handler = signal.getsignal(signal.SIGTERM)
+        self.assertEquals(handler, signal.SIG_DFL)


### PR DESCRIPTION
Adds a mechanism to enforce that only one resource manager can be executing at a time. Duplicate copies of the resource manager will wait until the original one dies off.

closes #898
https://pulp.plan.io/issues/898
