### PR TITLE
Handle queries containing base64 padding gracefully

### DIFF
--- a/server/pulp/server/lazy/url.py
+++ b/server/pulp/server/lazy/url.py
@@ -360,7 +360,9 @@ class Query(object):
         for pair in encoded.split(';'):
             if not pair:
                 continue
-            k, v = pair.split('=')
+            # The url-safe base64 encoding still contains padding
+            # so we shouldn't split more than once.
+            k, v = pair.split('=', 1)
             decoded[k] = unquote(v)
         return decoded
 

--- a/server/test/unit/server/lazy/test_url.py
+++ b/server/test/unit/server/lazy/test_url.py
@@ -266,6 +266,11 @@ class TestQuery(TestCase):
         decoded = Query.decode(encoded)
         self.assertEqual(decoded, {'name': 'john', 'age': '12'})
 
+    def test_decode_with_padding(self):
+        encoded = 'policy=SuchPad==;signature=MuchZero=='
+        decoded = Query.decode(encoded)
+        self.assertEqual(decoded, {'policy': 'SuchPad==', 'signature': 'MuchZero=='})
+
     def test_encode(self):
         decoded = OrderedDict()
         decoded['name'] = 'john'

--- a/server/test/unit/server/webservices/views/test_repositories.py
+++ b/server/test/unit/server/webservices/views/test_repositories.py
@@ -14,7 +14,7 @@ from pulp.server import exceptions
 from pulp.server.controllers import repository as repo_controller
 from pulp.server.db import model
 from pulp.server.webservices.views import repositories, util, search
-from pulp.server.webservices.views.repositories import(
+from pulp.server.webservices.views.repositories import (
     ContentApplicabilityRegenerationView, HistoryView, RepoAssociate, RepoDistributorResourceView,
     RepoDistributorsView, RepoDistributorsSearchView, RepoImportUpload, RepoImporterResourceView,
     RepoImportersView, RepoPublish, RepoPublishHistory, RepoPublishScheduleResourceView,


### PR DESCRIPTION
The lazy URL parser does not work with url-safe base64-encoded queries containing
padding ('='). It's worth investigating why the standard library parser
isn't used, but this is an easy fix for the immediate future.

closes #2031