### PR TITLE
Update Vagrant and Ansible to work with Fedora 24

### DIFF
--- a/Vagrantfile.example
+++ b/Vagrantfile.example
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  # to browse that repository a bit to find the latest successful Vagrant image. For example, at the
  # time of this writing, I could set this setting like this for the latest F24 image:
  # config.vm.box = "https://kojipkgs.fedoraproject.org/compose/24/Fedora-24-20160430.0/compose/CloudImages/x86_64/images/Fedora-Cloud-Base-Vagrant-24_Beta-1.4.x86_64.vagrant-libvirt.box"
- config.vm.box = "fedora/23-cloud-base"
+ config.vm.box = "fedora/24-cloud-base"
 
  # Comment out if you don't want Vagrant to add and remove entries from /etc/hosts for each VM.
  # requires the vagrant-hostmanager plugin to be installed

--- a/playpen/ansible/roles/dev/tasks/main.yml
+++ b/playpen/ansible/roles/dev/tasks/main.yml
@@ -12,6 +12,7 @@
   notify: restart sshd
 
 - name: Install Pulp dnf repository
+  when: ansible_distribution == 'Fedora' and ansible_distribution_version|int < 24
   get_url:
       url: https://repos.fedorapeople.org/repos/pulp/pulp/fedora-pulp.repo
       dest: /etc/yum.repos.d/fedora-pulp.repo
@@ -21,7 +22,7 @@
 
 - name: Enable Pulp Nightly repository
   command: dnf config-manager --set-enabled pulp-nightlies
-  when: pulp_nightly_repo_enabled == false
+  when: ansible_distribution == 'Fedora' and ansible_distribution_version|int < 24 and pulp_nightly_repo_enabled == false
 
 # These can go away when https://fedorahosted.org/spin-kickstarts/ticket/59 is fixed
 - stat:


### PR DESCRIPTION
Since all our dependencies are in F24 we don't need to enable external repositories to get a working development environment.