### PR TITLE
Removes intersphinx, updates urls, adds doc guide

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS           =
+SPHINXOPTS           = -W -n
 SPHINXBUILD          = sphinx-build
 PAPER                =
 BUILDDIR             = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath('./_extensions'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx', 'rest_api', 'sphinx.ext.extlinks']
+extensions = ['rest_api', 'sphinx.ext.extlinks']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -247,21 +247,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
-
-# NOTE: these need to be updated periodically to point to the most recent
-# current release of the plugin. They are all set to "latest" right now but
-# that will change as new plugin versions are released using the new RTD
-# builders. See
-# http://pulp.readthedocs.org/en/latest/dev-guide/contributing/building.html
-# for more info.
-
-intersphinx_mapping = {'pylang': ('http://docs.python.org/2.7/', None),
-                       'python': ("http://pulp-python.readthedocs.org/en/latest/", None),
-                       'docker': ("http://pulp-docker.readthedocs.org/en/latest/", None),
-                       'puppet': ("http://pulp-puppet.readthedocs.org/en/latest/", None),
-                       'ostree': ("http://pulp-ostree.readthedocs.org/en/latest/", None),
-                       'platform': ("http://pulp.readthedocs.org/en/latest/", None),
-                       'rpm':    ("http://pulp-rpm.readthedocs.org/en/latest/", None)}
 
 extlinks = {'redmine': ('https://pulp.plan.io/issues/%s', '#'),
             'fixedbugs': ('https://pulp.plan.io/projects/pulp/issues?c%%5B%%5D=tracker&c%%5B%%5D='

--- a/docs/dev-guide/contributing/dev_setup.rst
+++ b/docs/dev-guide/contributing/dev_setup.rst
@@ -93,7 +93,7 @@ Pulp if you aren't sure which method you prefer. Vagrant is available in Fedora.
 Whenever you connect to your Vagrant environment, you will be greeted by a message of the day
 that gives you some helpful hints. All of the code is mounted in
 /home/vagrant/devel. Your development environment has been configured for
-`virtualenvwrapper <http://virtualenvwrapper.readthedocs.org/en/latest/>`_. If you would like to
+`virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/>`_. If you would like to
 activate a virtualenv, you can simply type ``workon <repo_dir>`` to work on any particular Pulp
 repo. For example, ``workon pulp`` will activate the Pulp platform virtualenv and cd into the code
 directory for you. You can type ``workon pulp_rpm`` for pulp_rpm, ``workon pulp_python`` for

--- a/docs/dev-guide/contributing/documenting.rst
+++ b/docs/dev-guide/contributing/documenting.rst
@@ -18,7 +18,6 @@ platform guide and instead focus on these two topics:
    and interesting operations. For example, create a repository, sync it, and
    publish it. Show more advanced stories as "recipes".
 
-
 Command Line User Guide
 -----------------------
 
@@ -40,52 +39,36 @@ must be run as root should be shown using ``sudo``.
 Docs Layout
 -----------
 
-Relative to the root of pulp, the user guide is stored at ``dev/sphinx/user-guide/``
-and the dev guide is stored at ``docs/sphinx/dev-guide/``.
+Platform and plugins each have their own Sphinx project which allow docs to be
+built without checking out additional repositories. The Sphinx project for
+platform and each plugin are located in the ``docs`` directory in the top level
+of the repository. For example, the platform Sphinx project
+`is located here <https://github.com/pulp/pulp/tree/master/docs>`_.
 
+Doc Hosting
+-----------
 
-Read the Docs
--------------
+Pulp's documentation is hosted on `OpenShift <https://www.openshift.com/>`_.
+and is available at `https://docs.pulpproject.org/ <https://docs.pulpproject.org/>`_.
 
-Pulp's documentation is hosted on `Read the Docs <http://readthedocs.org>`_.
-Links to all current documentation can be found at
-`http://www.pulpproject.org/docs <http://www.pulpproject.org/docs>`_.
-
-
-RTD Versions
+Doc Versions
 ------------
 
-When viewing docs on Read the Docs, there are multiple versions linked in the
-bottom-left corner of the page. Past releases each have a link named "pulp-x.y"
-and are built from the most recent commit on the corresponding "pulp-x.y"
-release branch. Documentation shown on Read the Docs must be merged onto the
-appropriate branch for it to be displayed. The "latest" version corresponds
-to the most recently released version of Pulp.
+The current, stable GA release are hosted at https://docs.pulpproject.org/
 
-Docs automatically get built when a commit happens to a corresponding branch.
-However, it seems that builds may not happen automatically when only a merge
-takes place.
+GA releases for version X.Y are hosted at https://docs.pulpproject.org/en/X.Y/
 
-   .. note::
+A given X.Y version could have either a Beta or an RC but not both, so
+those are hosted at the same place https://docs.pulpproject.org/en/X.Y/testing/
 
-      You can manually start a build on Read the Docs for a specific version
-      using the `user guide build page <https://readthedocs.org/builds/pulp-user-guide/>`_
-      or the `dev guide build page <https://readthedocs.org/builds/pulp-dev-guide/>`_.
+Nightly docs for a given X.Y release are hosted at https://docs.pulpproject.org/en/X.Y/nightly/
 
-There may be a "staging" version at times. This build is used by the team to
-share documentation that has not yet been reviewed.
+Old doc versions not available on https://docs.pulpproject.org/ are available via source.
 
 Editing the Docs
------------------
+----------------
 
-The Pulp docs support `intersphinx <http://sphinx-doc.org/ext/intersphinx.html>`_
-and `extlinks <http://sphinx-doc.org/ext/extlinks.html>`_.
-
-To refer to a document in a plugin or platform, you can do something like so::
-
-     :ref:`installation <platform:server_installation>`
-
-This will create a link to the correct reference in the platform docs.
+The Pulp docs support `extlinks <http://sphinx-doc.org/ext/extlinks.html>`_.
 
 Use the ``:redmine:`` directive to easily create links to Pulp issues. For
 example::
@@ -110,16 +93,34 @@ have its link text set using the syntax::
 
 Which creates this link: :fixedbugs:`these great bugs were fixed <2.6.0>`
 
-Building the Docs
------------------
+Build Docs Locally
+------------------
 
-Anyone can build the docs in their own dev environment, which is useful for
-proofing changes to the docs before committing them. For either the user guide
-or the dev guide, navigate to the base docs folder and run ``make html``. Once
-run, the html is available in ``_build/html``.
+Building docs locally is easy::
 
-The html is built with the vanilla sphinx theme, so the look and feel is
-different than Read the Docs look and feel.
+    1. Navigate to the Sphinx project folder
+    2. ``make html``
+    3. Browse the docs the folder ``docs/_build/html``.
+
+The Vagrant environment comes pre-loaded with all the dependencies you need
+to build the docs.
+
+If the Python environment you build the docs in has the ``sphinx_rtd_theme``
+Python package, the docs will have the same look and feel as
+`https://docs.pulpproject.org/ <https://docs.pulpproject.org/>`_. If not,
+you will get the default Sphinx theme. Either should be sufficient for
+proofing content changes.
 
 You do not need to clean the docs before rebuilding. If you do need to
 clean the docs, you should run ``make clean`` from the documentation root.
+
+Build Docs for docs.pulpproject.org
+-----------------------------------
+
+Nightly docs are built automatically each night. If builds fail,
+e-mail is sent to the docs maintainers who are expected to resolve issues.
+
+GA, RC, and Beta docs are triggered manually as part of the release process.
+
+See all of the `Jenkins doc builders <https://pulp-jenkins.rhev-ci-vms.eng.
+rdu2.redhat.com/view/Docs%20Builders/>`_.

--- a/docs/user-guide/installation/v1_upgrade.rst
+++ b/docs/user-guide/installation/v1_upgrade.rst
@@ -5,7 +5,8 @@ Pulp v1 Upgrade
 
 Pulp no longer supports directly upgrading from Pulp 1.1 to the latest release. If you wish to
 upgrade from Pulp 1.1 to the latest release of Pulp, you must first
-`upgrade from 1.1 to 2.1 <https://pulp-user-guide.readthedocs.org/en/pulp-2.1/v1_upgrade.html>`_.
+`upgrade from 1.1 to 2.1 <https://github.com/pulp/pulp/blob/pulp-2.1/docs/sphinx/user-guide/
+v1_upgrade.rst>`_.
 
 Once you have successfully upgraded to 2.1, you may use the ordinary upgrade system to move from 2.1
 to the latest release of Pulp.

--- a/docs/user-guide/release-notes/2.1.x.rst
+++ b/docs/user-guide/release-notes/2.1.x.rst
@@ -117,8 +117,8 @@ We have improved the Content Applicability API significantly in this release. A
 #. Return format is updated to a more compact format keyed by Consumer ID and Content Type ID and it now returns
    only applicable units.
 
-The API is documented in detail 
-`in the applicability API documentation <http://pulp-dev-guide.readthedocs.org/en/devguide-2.1/integration/rest-api/consumer/applicability.html>`_.
+The API is documented in detail `in the applicability API documentation <https://
+docs.pulpproject.org/dev-guide/integration/rest-api/consumer/applicability.html>`_.
 
 Distributor Plugin API Change
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user-guide/release-notes/2.4.x.rst
+++ b/docs/user-guide/release-notes/2.4.x.rst
@@ -440,11 +440,10 @@ Call Reports
 
 Every API that returns a Call Report with an HTTP 202 ACCEPTED response code has changed. For the
 sake of brevity, we will not list every API that returns 202 here. The structure of the Call Report
-has been changed significantly. The
-`2.3 Call Report <https://pulp-dev-guide.readthedocs.org/en/pulp-2.3/conventions/sync-v-async.html#call-report>`_
-had many more fields than the
-`2.4 Call Report <https://pulp-dev-guide.readthedocs.org/en/2.4-release/conventions/sync-v-async.html#call-report>`_
-does.
+has been changed significantly. The `2.3 Call Report <https://github.com/pulp/pulp/blob/
+pulp-2.3/docs/sphinx/dev-guide/integration/rest-api/dispatch/task.rst#polling-task-progress>`_
+had many more fields than the `2.4 Call Report <https://github.com/pulp/pulp/blob/2.4-release/
+docs/sphinx/dev-guide/integration/rest-api/dispatch/task.rst#task-report>`_ does.
 
 * The spawned_tasks list within the Call Report object does not contain the full list of all
   tasks that will be scheduled for a given call. Each spawned task is responsible for spawning
@@ -459,7 +458,7 @@ does.
 Scheduled Calls
 ^^^^^^^^^^^^^^^
 
-The `Scheduled Call data structure <https://pulp-dev-guide.readthedocs.org/en/latest/conventions/scheduled.html#scheduled-tasks>`_
+The `Scheduled Call data structure <https://docs.pulpproject.org/dev-guide/conventions/scheduled.html>`_
  has changed substantially.
 
 * ``last_run`` is now ``last_run_at``.
@@ -481,8 +480,8 @@ Here are other APIs that have changed, arranged by path:
 
 ``/v2/catalog/<source_id>/``
 
-    This is a new API. See the `developer documentation <http://pulp-dev-guide.readthedocs.org/en/pulp-2.4/integration/rest-api/content/catalog.html>`_
-    for more detail.
+    This is a new API. See the `developer documentation <https://docs.pulpproject.org/dev-guide/
+    integration/rest-api/content/catalog.html>`_ for more detail.
 
 ``/v2/consumers/<consumer_id>/actions/content/regenerate_applicability/``
     The original applicability generation API did not allow a consumer to request regeneration of its
@@ -496,7 +495,7 @@ Here are other APIs that have changed, arranged by path:
 ``/v2/queued_calls/``
 
     This API has been removed in 2.4, as queued and running tasks are accessed through the same
-    `Tasks API <https://pulp-dev-guide.readthedocs.org/en/2.4-release/integration/rest-api/dispatch/task.html#task-report>`_.
+    `Tasks API <https://docs.pulpproject.org/dev-guide/integration/rest-api/tasks.html#task-report>`_.
 
 ``/v2/repositories/``
     Documentation for POST states that each distributor object should contain a
@@ -515,7 +514,7 @@ Here are other APIs that have changed, arranged by path:
 ``/v2/queued_calls/<call_request_id>/``
 
     This API has been removed in 2.4, as queued and running tasks are accessed through the same
-    `Tasks API <https://pulp-dev-guide.readthedocs.org/en/2.4-release/integration/rest-api/dispatch/task.html#task-report>`_.
+    `Tasks API <https://docs.pulpproject.org/dev-guide/integration/rest-api/tasks.html#task-report>`_.
 
 ``/v2/task_groups/``
 
@@ -544,10 +543,10 @@ Here are other APIs that have changed, arranged by path:
       ``spawned_tasks``.
 
     Feel free to compare the
-    `2.3 Call Report API <https://pulp-dev-guide.readthedocs.org/en/pulp-2.3/integration/rest-api/dispatch/task.html#polling-task-progress>`_
-    and the
-    `2.4 Task Report API <https://pulp-dev-guide.readthedocs.org/en/2.4-release/integration/rest-api/dispatch/task.html#task-report>`_
-    on your own.
+    `2.3 Call Report API <https://github.com/pulp/pulp/blob/pulp-2.3/docs/sphinx/dev-guide/
+    integration/rest-api/dispatch/task.rst#polling-task-progress>`_ and the
+    `2.4 Task Report API <https://github.com/pulp/pulp/blob/2.4-release/docs/sphinx/dev-guide/
+    integration/rest-api/dispatch/task.rst#task-report>`_ on your own.
 
 ``/v2/tasks/search/``
 

--- a/docs/user-guide/release-notes/2.5.x.rst
+++ b/docs/user-guide/release-notes/2.5.x.rst
@@ -85,7 +85,7 @@ New Features
   repositories. In Pulp 2.5.0 this optional plugin is considered "tech preview"
   and did not undergo the same level of testing as other plugins. Please
   refer to the
-  `pulp_docker documentation <http://pulp-docker.readthedocs.org/en/latest/>`_
+  `pulp_docker documentation <https://docs.pulpproject.org/plugins/pulp_docker/>`_
   for usage information.
 
 - Pulp now supports SSL on its connection to MongoDB. It is strongly recommended that you


### PR DESCRIPTION
This removes intersphinx and removes all content which used
intersphinx.

URLs are also updated to use docs.pulpproject.org instead of
readthedocs.io

Finally, the docs guide is updated to match the current state
of things for contributors.

Also, one really tiny formatting fix I saw while I was editing.

https://pulp.plan.io/issues/2034
fixes #2034