### PR TITLE
Fix distribution storage path migration incorrect re-linking of .treeinfo files.

### DIFF
--- a/server/pulp/plugins/migration/standard_storage_path.py
+++ b/server/pulp/plugins/migration/standard_storage_path.py
@@ -103,7 +103,7 @@ class Batch(object):
                     continue
                 new_path = item.new_path
                 for rel_path in item.files:
-                    if target.endswith(rel_path):
+                    if target == os.path.join(item.storage_path, rel_path):
                         new_path = os.path.join(new_path, rel_path)
                         break
                 os.unlink(abs_path)


### PR DESCRIPTION
https://pulp.plan.io/issues/2056

The platform migration needed to use a stricter comparison when matching the target path to one of the files listed by the unit as contained within the storage_path.

The unit test was pretty hard to understand (even though I wrote it).  Updated the data sets and made the functionality more explicit.