### PR TITLE
Update the prefix-stripping method in oid_validator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 This is an alphabetical (by last name) list of the authors of the Pulp project. If you submit a pull request
 to Pulp and your name is not on this list, please add yourself.
 
+Partha Aji (parthaa@gmail.com)
 Daniel Alley (dalley@redhat.com)
 Randy Barlow (rbarlow@redhat.com)
 Shubham Bhawsinka(sbhawsin@redhat.com)

--- a/oid_validation/pulp/oid_validation/oid_validation.py
+++ b/oid_validation/pulp/oid_validation/oid_validation.py
@@ -13,6 +13,7 @@ The OID structure follows the Red Hat model. Download URLs are found at:
 The * represents the product ID and is not used as part of this calculation.
 '''
 
+import os
 from gettext import gettext as _
 from ConfigParser import NoOptionError, SafeConfigParser, NoSectionError
 
@@ -194,9 +195,10 @@ class OidValidator:
 
         valid = False
         for prefix in repo_url_prefixes:
-            if dest.find(prefix) > -1:
-                # Extract the repo portion of the URL
-                repo_dest = dest[dest.find(prefix) + len(prefix):]
+            if dest.startswith(prefix):
+                # rhsm throws a ValueError if there's no leading /. Amusingly, it immediately
+                # strips it off.
+                repo_dest = os.path.join('/', os.path.relpath(dest, prefix))
                 try:
                     valid = cert.check_path(repo_dest)
                 except AttributeError:

--- a/oid_validation/pulp/oid_validation/oid_validation.py
+++ b/oid_validation/pulp/oid_validation/oid_validation.py
@@ -194,16 +194,17 @@ class OidValidator:
 
         valid = False
         for prefix in repo_url_prefixes:
-            # Extract the repo portion of the URL
-            repo_dest = dest[dest.find(prefix) + len(prefix):]
-            try:
-                valid = cert.check_path(repo_dest)
-            except AttributeError:
-                # not an entitlement certificate, so no entitlements
-                log_func('The provided client certificate is not an entitlement certificate.\n')
-            # if we have a valid url check, no need to continue
-            if valid:
-                break
+            if dest.find(prefix) > -1:
+                # Extract the repo portion of the URL
+                repo_dest = dest[dest.find(prefix) + len(prefix):]
+                try:
+                    valid = cert.check_path(repo_dest)
+                except AttributeError:
+                    # not an entitlement certificate, so no entitlements
+                    log_func('The provided client certificate is not an entitlement certificate.\n')
+                # if we have a valid url check, no need to continue
+                if valid:
+                    break
 
         if not valid:
             log_func('Request denied to destination [%s]' % dest)


### PR DESCRIPTION
The prefix stripping method used in the oid_validator failed if the
prefix was _not_ found in the path. This fixes that particular issue,
improves readability, and adds a unit test.

fixes #2065
