### PR TITLE
Allow at sign in user ids

### DIFF
--- a/client_lib/pulp/client/validators.py
+++ b/client_lib/pulp/client/validators.py
@@ -11,7 +11,7 @@ from pulp.common import dateutils
 from pulp.common.plugins import importer_constants
 
 
-ID_REGEX_ALLOW_DOTS = re.compile(r'^[.\-_A-Za-z0-9]+$')
+ID_REGEX_ALLOW_DOTS = re.compile(r'^[.@\-_A-Za-z0-9]+$')
 ID_REGEX = re.compile(r'^[\-_A-Za-z0-9]+$')
 
 
@@ -115,8 +115,8 @@ def id_validator_allow_dots(x):
 
     for input_id in x:
         if ID_REGEX_ALLOW_DOTS.match(input_id) is None:
-            raise ValueError(_('value must contain only letters, numbers, underscores, periods and '
-                               'hyphens'))
+            raise ValueError(_('value must contain only letters, numbers, underscores, periods,'
+                               'hyphens, and @ signs'))
 
 
 def download_policy_validator(x):

--- a/client_lib/test/unit/test_validators.py
+++ b/client_lib/test/unit/test_validators.py
@@ -101,7 +101,6 @@ class TestId(unittest.TestCase):
 
         # Single input
         self.assertRaises(ValueError, validators.id_validator, '**invalid**')
-        self.assertRaises(ValueError, validators.id_validator, 'invalid-@')
         self.assertRaises(ValueError, validators.id_validator, '-_-_- ')
 
         # Multiple input
@@ -122,6 +121,7 @@ class TestIdAllowDots(unittest.TestCase):
         validators.id_validator_allow_dots('TesT.-0')
         validators.id_validator_allow_dots('-_-_-')
         validators.id_validator_allow_dots('-._.-._.-')
+        validators.id_validator_allow_dots('Kodiak@dabomb.com')
 
         # Multiple input
         validators.id_validator_allow_dots(['test123', 'TesT-0', 'test.123'])
@@ -131,7 +131,6 @@ class TestIdAllowDots(unittest.TestCase):
         # Single input
         self.assertRaises(ValueError, validators.id_validator_allow_dots, '**invalid**')
         self.assertRaises(ValueError, validators.id_validator_allow_dots, '**inval.id**')
-        self.assertRaises(ValueError, validators.id_validator_allow_dots, 'invalid-@')
         self.assertRaises(ValueError, validators.id_validator_allow_dots, '-_-_- ')
 
         # Multiple input

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -1105,7 +1105,7 @@ class User(AutoRetryDocument):
     :type _ns: mongoengine.StringField
     """
 
-    login = StringField(required=True, regex=r'^[.\-_A-Za-z0-9]+$')
+    login = StringField(required=True, regex=r'^[.@\-_A-Za-z0-9]+$')
     name = StringField()
     password = StringField()
     roles = ListField(StringField())


### PR DESCRIPTION
Adjust the regex to allow usernames to contain the at sign so that email
addresses can be valid usernames.

https://pulp.plan.io/issues/1728