### PR TITLE
_release_resource cleans up killed worker tasks

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -270,6 +270,17 @@ def _release_resource(task_id):
     :param task_id: The UUID of the task that requested the reservation
     :type  task_id: basestring
     """
+    running_task_qs = TaskStatus.objects.filter(task_id=task_id, state=constants.CALL_RUNNING_STATE)
+    for running_task in running_task_qs:
+        new_task = Task()
+        msg = _('The task status %(task_id)s exited immediately for some reason. Marking as '
+                'errored. Check the logs for more details')
+        runtime_exception = RuntimeError(msg % {'task_id': task_id})
+
+        class MyEinfo(object):
+            traceback = None
+
+        new_task.on_failure(runtime_exception, task_id, (), {}, MyEinfo)
     ReservedResource.objects(task_id=task_id).delete()
 
 


### PR DESCRIPTION
If a child Celery process is killed, Celery would recover
but the TaskStatus would stay at running forever. This adds
an additional check when the resource lock is removed which
handles cleanup for any worker being killed.

Because the _release_resource is being run, we know the task
itself has exited, yet if the TaskStatus is not at a final state,
the worker certainly errored.

https://pulp.plan.io/issues/1673
fixes #1673