### PR TITLE
Fix unit query by criteria when unit filter contains ids.

### DIFF
--- a/server/pulp/server/managers/repo/unit_association_query.py
+++ b/server/pulp/server/managers/repo/unit_association_query.py
@@ -353,11 +353,16 @@ class RepoUnitAssociationQueryManager(object):
         collection = types_db.type_units_collection(unit_type_id)
         serializer = units.get_model_serializer_for_type(unit_type_id)
 
-        spec = criteria.unit_filters.copy()
-        if spec and serializer:
-                spec = serializer.translate_filters(serializer.model, spec)
+        unit_filter = criteria.unit_filters.copy()
+        if unit_filter and serializer:
+                unit_filter = serializer.translate_filters(serializer.model, unit_filter)
 
-        spec['_id'] = {'$in': associated_unit_ids}
+        spec = {
+            '$and': [
+                {'_id': {'$in': associated_unit_ids}},
+                unit_filter
+            ]
+        }
 
         fields = criteria.unit_fields
 

--- a/server/test/unit/server/managers/repo/test_unit_association_query.py
+++ b/server/test/unit/server/managers/repo/test_unit_association_query.py
@@ -388,6 +388,20 @@ class UnitAssociationQueryTests(base.PulpServerTests):
         for u in units:
             self.assertEqual(u['metadata']['md_2'], 0)
 
+    def test_get_units_by_type_unit_id_filter(self):
+        unit_id = 'dog'
+        unit_filter = {
+            '_id': {'$in': [unit_id]}
+        }
+
+        # Test
+        criteria = UnitAssociationCriteria(unit_filters=unit_filter)
+        units = self.manager.get_units_by_type('repo-2', 'delta', criteria)
+
+        # Verify
+        self.assertEqual(len(units), 1)
+        self.assertEqual(units[0]['unit_id'], unit_id)
+
     def test_get_units_by_type_filter_wildcard(self):
         # Test
         criteria = UnitAssociationCriteria(unit_filters={'key_1': {'$regex': 'aa.*'}})


### PR DESCRIPTION
https://pulp.plan.io/issues/1894

The unit query needed to be the list of associated unit ids **AND** anything specified in the unit filter.