### PR TITLE
The pulp_streamer now uses the plugin-wide proxy config

### DIFF
--- a/streamer/pulp/streamer/server.py
+++ b/streamer/pulp/streamer/server.py
@@ -210,6 +210,14 @@ class Streamer(resource.Resource):
         # Configure the primary downloader for alternate content sources
         plugin_importer, config, db_importer = repo_controller.get_importer_by_id(
             catalog_entry.importer_id)
+        # There is an unfortunate mess of configuration classes and attributes, and
+        # multiple "models" floating around. The MongoEngine class that corresponds
+        # to the database entry only contains the repository config. The ``config``
+        # variable above contains the repository configuration _and_ the plugin-wide
+        # configuration, so here we override the db_importer.config because it doesn't
+        # have the whole config. In the future the importer object should seemlessly
+        # load and apply the plugin-wide configuration.
+        db_importer.config = config.flatten()
         primary_downloader = plugin_importer.get_downloader_for_db_importer(
             db_importer, catalog_entry.url, working_dir='/tmp')
         pulp_request = request.getHeader(PULP_STREAM_REQUEST_HEADER)


### PR DESCRIPTION
An importer has a configuration file in /etc/pulp/server/plugins.conf.d/
that can, among other things, configure the proxy used for the plugin.
Previously, the streamer was only using the importer configuration that
is present on the ``Importer`` module.

Although the most sensible thing to do is have the importer
configuration available on the Importer model object, this would require
a great deal of cleanup since importer/distributor models and
configuration are a mess of old and new, with the configuration spread
all over the place. This should be cleaned up as part plugin API work we
do for Pulp.

closes #2038