### PR TITLE
Add a support policy section to the documentation

### DIFF
--- a/docs/user-guide/installation/f23-.rst
+++ b/docs/user-guide/installation/f23-.rst
@@ -2,6 +2,7 @@ CentOS, RHEL, and Fedora 23-
 ============================
 
 This page contains installation instructions for CentOS, RHEL, and Fedora 23 and below.
+The :ref:`platform-support-policy` defines platforms are currently supported.
 
 
 Repositories

--- a/docs/user-guide/installation/index.rst
+++ b/docs/user-guide/installation/index.rst
@@ -20,26 +20,7 @@ Client
 Additional steps are needed for upgrading Pulp 1.1 installations. More information can be found
 in the :doc:`v1_upgrade` section of this guide.
 
-
-Supported Operating Systems
----------------------------
-Server
-
-* RHEL Server 6 & 7
-* Fedora
-* CentOS Server 6 & 7
-
-Consumer
-
-* RHEL 5, 6, & 7
-* Fedora
-* CentOS 5, 6 & 7
-
-Admin Client
-
-* RHEL 6 & 7
-* Fedora
-* CentOS 6 & 7
+The :ref:`platform-support-policy` defines platforms are currently supported.
 
 
 Prerequisites

--- a/docs/user-guide/introduction.rst
+++ b/docs/user-guide/introduction.rst
@@ -48,3 +48,35 @@ you are interested. You can find all of our documentation at `our docs page <htt
 
 Many examples require the use of a type, and for those we will use "rpm". However,
 examples in this guide will only cover features that are common across content types.
+
+.. _platform-support-policy:
+
+Platform Support Policy
+-----------------------
+
+CentOS/Red Hat Enterprise Linux (RHEL)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Pulp team aims to provide RPM builds for the last two major releases of RHEL. For
+example, if the latest version is RHEL 8, builds should be available for RHEL 8 and
+RHEL 7. However, due to the long life cycle of these platforms and the relatively rapid
+development cycle of both Pulp and its dependencies, we may need to stop supporting
+the older platform before the next major release of RHEL. If this does occur, announcements
+will be made well in advance.
+
+.. note::
+  It is likely that support for Red Hat Enterprise Linux 6 will be removed prior to
+  the release of Red Hat Enterprise Linux 8. This is due to the difficulty of
+  supporting both Python 2.6 and Python 3 at the same time.
+
+Currently we support Red Hat Enterprise Linux 6 and 7 as well as CentOS 6 and 7.
+
+
+Fedora
+^^^^^^
+
+Pulp follows the `Fedora release life cycle
+<https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle#Maintenance_Schedule>`_.
+This means that when a release of Fedora reaches its End of Life, Pulp will no longer
+support that platform in any way, including providing updates for any security
+vulnerabilities.


### PR DESCRIPTION
I've placed this change in the introduction because I didn't see a better section and it seemed like a place most people would look, but I'm interested in other suggestions. 

I also considered adding something in there about the versions of Pulp itself we support (something like there's currently no LTS and the latest stable build is typically the only build to receive z streams). Does anyone have thoughts on that one way or the other?