### PR TITLE
Add dev setup instructions for SSHFS

### DIFF
--- a/docs/dev-guide/contributing/dev_setup.rst
+++ b/docs/dev-guide/contributing/dev_setup.rst
@@ -206,6 +206,31 @@ follow.
     Fortunately, the code you are working on will be shared from your host via NFS so your work
     should have data safety.
 
+#. You can use SSHFS rather than NFS. The downside is SSHFS does not perform quite as well as NFS,
+   but the upside is you do not need to configure or run NFS, nor do you need to allow Vagrant to
+   edit your /etc/exports file. At the time of this writing, the ``vagrant-sshfs`` package is not
+   yet in Fedora, although the package is in the process of being reviewed. The author provides a
+   COPR repository you can enable to install the RPM::
+
+    $ sudo dnf copr enable dustymabe/vagrant-sshfs
+    $ sudo dnf install vagrant-sshfs
+
+   You need to modify your Vagrantfile to use SSHFS::
+
+    # -*- mode: ruby -*-
+    # vi: set ft=ruby :
+
+
+    Vagrant.configure(2) do |config|
+        config.vm.define "dev" do |dev|
+            VAGRANT_SYNCED_FOLDERS.each do |host_path, guest_path|
+                # Use SSHFS instead of NFS. The ``-o nonempty`` option is passed to allow
+                # mounts on non-empty directories.
+                dev.vm.synced_folder host_path, guest_path, type: "sshfs", sshfs_opts_append: "-o nonempty"
+            end
+        end
+    end
+
 
 Vagrant w/ PyCharm
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
SSHFS is an alternative to NFS when sharing directories between the host
and guest. This documents the approach in the "Advanced" section since
the package is not yet in Fedora and requires a COPR.