### PR TITLE
Update urls syntax for Django 1.10

### DIFF
--- a/server/pulp/server/webservices/compat_urls.py
+++ b/server/pulp/server/webservices/compat_urls.py
@@ -1,0 +1,10 @@
+"""
+This module creates urlpatterns using the old syntax of Django <=  1.6
+"""
+
+from pulp.server.webservices import urls
+
+from django.conf.urls import patterns
+
+
+urlpatterns = patterns('', *urls.urlpatterns)

--- a/server/pulp/server/webservices/settings.py
+++ b/server/pulp/server/webservices/settings.py
@@ -1,6 +1,9 @@
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+
+import django
+
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 SECRET_KEY = 'I_am_a_secret_that_is_never_used_meaningfully_by_pulp'
@@ -25,7 +28,11 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
 )
 
-ROOT_URLCONF = 'pulp.server.webservices.urls'
+if django.VERSION[0] == 1 and django.VERSION[2] <= 6:
+    ROOT_URLCONF = 'pulp.server.webservices.compat_urls'
+else:
+    ROOT_URLCONF = 'pulp.server.webservices.urls'
+
 
 WSGI_APPLICATION = 'pulp.server.webservices.wsgi.application'
 

--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -81,8 +81,7 @@ from pulp.server.webservices.views.status import StatusView
 handler404 = 'pulp.server.webservices.views.util.page_not_found'
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^v2/actions/login/$', LoginView.as_view(), name='login'), # flake8: noqa
     url(r'^v2/consumer_groups/$', ConsumerGroupView.as_view(), name='consumer_group'),
     url(r'^v2/consumers/$', ConsumersView.as_view(), name='consumers'),
@@ -258,4 +257,4 @@ urlpatterns = patterns(
     url(r'^v2/users/search/$', users.UserSearchView.as_view(),
         name='user_search'),
     url(r'^v2/users/(?P<login>[^/]+)/$', users.UserResourceView.as_view(), name='user_resource')
-)
+]


### PR DESCRIPTION
Also adds a compat_urls.py file to support Django versions older than
1.6.

closes #1766