### PR TITLE
Adds predistributor logic to the publish controller

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -460,4 +460,4 @@ class Publisher(PublishStep):
         :return: predistributor that was configured in rsyn distributor's config
         :rtype: Distributor
         """
-        raise NotImplementedError()
+        return None

--- a/server/pulp/server/db/model/repository.py
+++ b/server/pulp/server/db/model/repository.py
@@ -1,3 +1,4 @@
+from gettext import gettext as _
 import traceback as traceback_module
 
 from pulp.server.db.model.base import Model
@@ -245,7 +246,7 @@ class RepoPublishResult(Model, ReaperMixin):
 
     @classmethod
     def skipped_result(cls, repo_id, distributor_id, distributor_type_id, started, completed,
-                       result_code):
+                       result_code, translated_message):
         """
         Creates a new history entry for a skipped publish.
 
@@ -266,11 +267,15 @@ class RepoPublishResult(Model, ReaperMixin):
 
         @param result_code: one of the RESULT_* constants in this class
         @type  result_code: str
+
+        @param translated_message: translated reason for skipping
+        @type translated_message: str
+
         """
 
         r = cls(repo_id, distributor_id, distributor_type_id, started, completed,
                 cls.RESULT_SKIPPED)
-        message = 'Skipped. Nothing changed since last publish'
+        message = _('Skipped: %(reason)s') % {'reason': translated_message}
         r.summary = r.details = message
 
         return r

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -1106,7 +1106,8 @@ class TestCheckPublish(unittest.TestCase):
         m_dist_qs.return_value.update.assert_called_once_with(set__last_publish=mock_now())
         m_repo_pub_result.skipped_result.assert_called_once_with(
             fake_repo.repo_id, m_dist.distributor_id, m_dist.distributor_type_id, mock_now(),
-            mock_now(), m_repo_pub_result.RESULT_SKIPPED
+            mock_now(), m_repo_pub_result.RESULT_SKIPPED, 'Repository content has not changed '
+                                                          'since last publish.'
         )
         msg = 'publish skipped for repo [repo1] with distributor ID [dist]'
         mock_log.assert_called_once_with(msg)
@@ -1121,7 +1122,7 @@ class TestCheckPublish(unittest.TestCase):
         Test that if force option specified, publish happens even if there were no changes made
         since last publish.
         """
-        mock_call_conf.get.return_value = True
+        mock_call_conf.get.side_effect = [True, None]
         fake_repo = model.Repository(repo_id='repo1')
         mock_transfer = fake_repo.to_transfer_repo()
         mock_objects.return_value.count.return_value = 0


### PR DESCRIPTION
If a distributor has a predistributor_id configured, the publish is skipped when the
predistributor has not published since the last publish by the distributor. This includes
situations where the predistributor has not published at all.

re #1887
https://pulp.plan.io/issues/1887