### PR TITLE
Add consumer models.

### DIFF
--- a/platform/pulp/platform/models/__init__.py
+++ b/platform/pulp/platform/models/__init__.py
@@ -1,3 +1,6 @@
 # https://docs.djangoproject.com/en/1.8/topics/db/models/#organizing-models-in-a-package
 from .base import Model, MasterModel  # NOQA
 from .generic import GenericRelationModel, GenericKeyValueStore, Config, Notes, Scratchpad  # NOQA
+
+from .consumer import Consumer, ConsumerContent  # NOQA
+from .repository import Distributor  # NOQA

--- a/platform/pulp/platform/models/consumer.py
+++ b/platform/pulp/platform/models/consumer.py
@@ -1,0 +1,50 @@
+"""
+Django models related to content consumers.
+"""
+
+from django.contrib.contenttypes import fields
+from django.db import models
+
+from pulp.platform.models import Model, Notes
+
+
+class Consumer(Model):
+    """
+    A content consumer.
+
+    Fields:
+
+    :cvar name: The consumer common name.
+    :type name: models.TextField
+
+    :cvar: description: An optional description.
+    :type: models.TextField
+
+    Relations:
+
+    :cvar notes: Arbitrary information about the consumer.
+    :type notes: fields.GenericRelation
+
+    :cvar distributors: Associated distributors.
+    :type distributors: models.ManyToManyField
+    """
+    name = models.TextField(db_index=True, unique=True)
+    description = models.TextField(blank=True, default='')
+
+    notes = fields.GenericRelation(Notes)
+    distributors = models.ManyToManyField('Distributor')
+
+
+class ConsumerContent(Model):
+    """
+    Collection of content currently installed on a consumer.
+
+    Relations:
+
+    :cvar consumer: The consumer on which the content is installed.
+    :type consumer: models.ForeignKey
+    """
+    consumer = models.ForeignKey(Consumer, on_delete=models.CASCADE)
+
+    class Meta:
+        abstract = True

--- a/platform/pulp/platform/models/repository.py
+++ b/platform/pulp/platform/models/repository.py
@@ -1,0 +1,10 @@
+"""
+Django models related to repositories.
+"""
+
+from pulp.platform.models import Model
+
+
+class Distributor(Model):
+    # placeholder
+    pass


### PR DESCRIPTION
https://pulp.plan.io/issues/2085

The following fields were not carried forward to 3.0.

Consumer:
- **capability**  *supported Agent but never used*
- **rsa_pub**  *supported Agent*

Binding:
- **binding_config**  *supported Nodes*
- **notify_agent**  *supported Agent*
- **consumer_actions** *supported Agent*
- **deleted** *supported Agent*

The applicability models are not included in anticipation that a strong relational model will support calculation on demand.  If this proves to be incorrect, we can add them later.

On consumer, I initially wrote `bind()` and `unbind()` convenience methods.  Then, after further consideration, I removed them because each of them contained a single line of code that the caller could also do.  Also, It seemed inappropriate for a model method to operation on another model.  Thoughts?
