### PR TITLE
Fixes logic used to skip publishes based on predistributor.

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -119,8 +119,6 @@ class RSyncPublishStep(PublishStep):
                                                     '/ssh_identity_file', 'hostname']
         :rtype: list
         """
-        if self.get_config().flatten()["remote"]['auth_type'] == 'local':
-            return []
         ssh_parts = []
         for arg in self.make_ssh_cmd():
             if " " in arg:
@@ -153,9 +151,6 @@ class RSyncPublishStep(PublishStep):
         :return: str of the combination of user, host, and dir.
         :rtype:  str
         """
-        if self.get_config().flatten()["remote"]['auth_type'] == 'local':
-            return self.get_config().flatten()["remote"]['root']
-
         user = self.get_config().flatten()["remote"]['ssh_user']
         host = self.get_config().flatten()["remote"]['host']
         remote_root = self.get_config().flatten()["remote"]['root']

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1006,7 +1006,9 @@ def check_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_con
                                                            updated__gte=the_timestamp).count()
         units_removed = last_unit_removed is not None and last_unit_removed > last_published
         dist_updated = dist.last_updated > last_published
-    published_after_predistributor = True
+        published_after_predistributor = True
+    else:
+        published_after_predistributor = False
     predistributor_id = call_config.get('predistributor_id')
     if predistributor_id and last_published:
         predistributor = model.Distributor.objects.get_or_404(repo_id=repo_obj.repo_id,


### PR DESCRIPTION
Also removes extraneous code from rsync.

re #1887
https://pulp.plan.io/issues/1887
re #1963
https://pulp.plan.io/issues/1963
re #1759
https://pulp.plan.io/issues/1759