### PR TITLE
Fixes selinux-policy spec file macro

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -16,7 +16,7 @@
 %if %{pulp_server}
 #SELinux
 %define selinux_variants mls strict targeted
-%define selinux_policyver %(sed -e 's,.*selinux-policy-\\([^/]*\\)/.*,\\1,' /usr/share/selinux/devel/policyhelp 2> /dev/null)
+%define selinux_policyver %(rpm --qf "%{version}-%{release}" -q selinux-policy)
 %define moduletype apps
 %endif
 
@@ -949,12 +949,7 @@ BuildRequires:  selinux-policy-devel
 BuildRequires:  hardlink
 Obsoletes: pulp-selinux-server
 
-%if "%{selinux_policyver}" != ""
 Requires: selinux-policy >= %{selinux_policyver}
-%endif
-%if 0%{?fedora} == 19
-Requires(post): selinux-policy-targeted >= 3.12.1-74
-%endif
 Requires(post): policycoreutils-python
 Requires(post): /usr/sbin/semodule, /sbin/fixfiles, /usr/sbin/semanage
 Requires(postun): /usr/sbin/semodule


### PR DESCRIPTION
Adjusts the selinux_policyver macro in the pulp spec file
to not be an empty string. The new field value includes
both version and release of selinux-policy.

Also removes an unecessary if statement for F19 which is
not longer built.

https://pulp.plan.io/issues/2121
re #2121