### PR TITLE
Speeds up the unit file path migrations

### DIFF
--- a/docs/user-guide/release-notes/2.10.x.rst
+++ b/docs/user-guide/release-notes/2.10.x.rst
@@ -18,3 +18,19 @@ New Features
 
 * RPM, ISO, and Docker repositories can be published using the new rsync distributors. These
   distributors afford Pulp users to rsync repositories to remote servers.
+
+Upgrade
+-------
+
+Action required: If you are upgrading from 2.8.2 or earlier direct to 2.10.0 or later, you will find
+that many empty directories are present in /var/lib/pulp/content/. Several migrations that moved
+unit files to new locations were optimized for performance, specifically when operating on NFS, and
+that required removal of a directory pruning stage that was taking some users many hours. Instead,
+you can now perform that removal separately from the migration system. Or pulp will happily run with
+the empty directories in place if you do not wish to spend time running the removal.
+
+To execute the removal, which may take a long time over NFS, run this command::
+
+  $ sudo -u apache find /var/lib/pulp/content/ -type d -empty \
+    -not -path "/var/lib/pulp/content/units/*" -delete
+

--- a/server/test/unit/plugins/migration/test_standard_storage_path.py
+++ b/server/test/unit/plugins/migration/test_standard_storage_path.py
@@ -341,36 +341,6 @@ class TestMigration(TestCase):
         # validation
         self.assertEqual(path, os.path.join(storage_dir.return_value, 'published'))
 
-    @patch('os.rmdir')
-    @patch('os.walk')
-    @patch('os.listdir')
-    @patch(MODULE + '.Migration.content_dir')
-    def test_prune(self, content_dir, listdir, walk, rmdir):
-        def list_dir(path):
-            if path.endswith('_'):
-                return []
-            else:
-                return [1, 2]
-        listdir.side_effect = list_dir
-        walk.return_value = [
-            ('r', ['d1', 'd2'], ['f1', 'f2']),
-            ('d1_', [], []),
-            ('d2', ['d3'], []),
-            ('d4_', [], [])
-        ]
-
-        # test
-        Migration._prune()
-
-        # validation
-        walk.assert_called_once_with(content_dir.return_value, topdown=False)
-        self.assertEqual(
-            rmdir.call_args_list,
-            [
-                call('d1_'),
-                call('d4_')
-            ])
-
     def test_add(self):
         plan = Mock()
 


### PR DESCRIPTION
Removes the empty directory purge phase of the 2.8 migrations, which was taking
some users many hours when done over NFS.

Introduces multi-threaded concurrency for the bulk of the migration's work.

https://pulp.plan.io/issues/2118
fixes #2118