### PR TITLE
Remove references to copr

### DIFF
--- a/docs/dev-guide/contributing/dev_setup.rst
+++ b/docs/dev-guide/contributing/dev_setup.rst
@@ -286,11 +286,12 @@ Dependencies
 The easiest way to download the other dependencies is to install Pulp through yum or dnf, which
 pulls in the latest dependencies according to the spec file.
 
-#. Enable the appropriate repository from https://copr.fedorainfracloud.org/groups/g/pulp/coprs/
+#. Download the appropriate repository from https://repos.fedorapeople.org/repos/pulp/pulp/
 
    Example for Fedora::
 
-       $ sudo dnf copr enable @pulp/2.y
+       $ cd /etc/yum.repos.d/
+       $ sudo wget https://repos.fedorapeople.org/repos/pulp/pulp/fedora-pulp.repo
 
 #. Edit the repo and enable the most recent testing repository.
 

--- a/docs/user-guide/installation/f23-.rst
+++ b/docs/user-guide/installation/f23-.rst
@@ -10,9 +10,10 @@ Repositories
 Pulp
 ^^^^
 
-Enable appropriate COPR repository, according to the instructions found on the COPR site:
+Download the appropriate repo definition file from the Pulp repository:
 
-https://copr.fedorainfracloud.org/groups/g/pulp/coprs/
+ * Fedora: https://repos.fedorapeople.org/repos/pulp/pulp/fedora-pulp.repo
+ * RHEL 6+: https://repos.fedorapeople.org/repos/pulp/pulp/rhel-pulp.repo
 
 
 EPEL for RHEL & CentOS

--- a/docs/user-guide/installation/f24+.rst
+++ b/docs/user-guide/installation/f24+.rst
@@ -4,11 +4,6 @@ Fedora 24+
 Beginning with Fedora 24, Pulp is included in the Fedora project and no special repositories are
 needed to install there.
 
-You can stay up to date with newer Pulp releases, however, by subscribing to one of our COPR
-repositories:
-
-https://copr.fedorainfracloud.org/groups/g/pulp/coprs/
-
 
 Database Server
 ---------------


### PR DESCRIPTION
I sadly admit defeat. This removes references to COPR added in
yesterday's PR, but leaves in the changes that remove references
to using groupinstall.

this change partially reverts e00a852ef94f2d8d8737956ef130eb03b576091a

re #1993
https://pulp.plan.io/issues/1993