### PR TITLE
Remove invalid header from response

### DIFF
--- a/server/pulp/server/webservices/middleware/exception.py
+++ b/server/pulp/server/webservices/middleware/exception.py
@@ -55,7 +55,6 @@ class ExceptionHandlerMiddleware(object):
                 response_obj = HttpResponseServerError(
                     json.dumps(response), content_type="application/json; charset=utf-8")
 
-            response_obj['Content-Encoding'] = 'utf-8'
             return response_obj
         # Because this defines our own exception handling, if something goes wrong we need to make
         # sure that it gets logged.


### PR DESCRIPTION
This header was removed in this commit:
8bf3c595f283d5072cfdce617c1e1623684132d8, but was acciddentally
reintroduced in this commit:
8ce699acdd65b4d2fd50c7a023bfa2a36b6387bc
The information is already present in the Content-Type headers, so the
offending line can simply be removed.