### PR TITLE
Add repository models.

### DIFF
--- a/platform/pulp/platform/models/__init__.py
+++ b/platform/pulp/platform/models/__init__.py
@@ -3,4 +3,6 @@ from .base import Model, MasterModel  # NOQA
 from .generic import GenericRelationModel, GenericKeyValueStore, Config, Notes, Scratchpad  # NOQA
 
 from .consumer import Consumer, ConsumerContent  # NOQA
-from .repository import Distributor  # NOQA
+from .repository import (Repository, RepositoryGroup, Importer, Distributor,  # NOQA
+                         RepositoryImporter,  RepositoryDistributor, GroupDistributor,  # NOQA
+                         RepositoryContent)  # NOQA

--- a/platform/pulp/platform/models/base.py
+++ b/platform/pulp/platform/models/base.py
@@ -51,7 +51,7 @@ class MasterModel(Model):
         subclass.
 
     """
-    type = models.CharField(max_length=63)
+    detail_model = models.CharField(max_length=63)
 
     objects = MasterModelManager()
 
@@ -64,8 +64,8 @@ class MasterModel(Model):
         # name. That name is what I'm using here to determine the value of
         # type. Storing type in a column on the MasterModel next to makes it trivial
         # to filter for specific detail model types across model relations.
-        if not self.type:
-            self.type = self._meta.model_name
+        if not self.detail_model:
+            self.detail_model = self._meta.model_name
         return super(MasterModel, self).save(*args, **kwargs)
 
     def cast(self):
@@ -74,16 +74,16 @@ class MasterModel(Model):
         If this model is already an instance of its detail type, it will return itself.
         """
         # If this instance's type matches the current model name, it is already cast. Return it.
-        if self.type == self._meta.model_name:
+        if self.detail_model == self._meta.model_name:
             return self
         else:
             try:
                 # Otherwise, return the cast model attribute for this instance
-                return getattr(self, self.type)
+                return getattr(self, self.detail_model)
             except AttributeError:
                 # Unknown content type. The generic content type is as specific as
                 # we can get here. This is a great place to throw a log message about
-                # encountering an unmodelled type, such as a type from an uninstalled
+                # encountering an un-modelled type, such as a type from an uninstalled
                 # plugin.
                 return self
 

--- a/platform/pulp/platform/models/consumer.py
+++ b/platform/pulp/platform/models/consumer.py
@@ -29,10 +29,10 @@ class Consumer(Model):
     :type distributors: models.ManyToManyField
     """
     name = models.TextField(db_index=True, unique=True)
-    description = models.TextField(blank=True, default='')
+    description = models.TextField(blank=True)
 
     notes = fields.GenericRelation(Notes)
-    distributors = models.ManyToManyField('Distributor')
+    distributors = models.ManyToManyField('RepositoryDistributor')
 
 
 class ConsumerContent(Model):

--- a/platform/pulp/platform/models/repository.py
+++ b/platform/pulp/platform/models/repository.py
@@ -1,10 +1,330 @@
 """
-Django models related to repositories.
+Repository related Django models.
 """
+from django.db import models
+from django.contrib.contenttypes import fields
+from django.utils import timezone
 
-from pulp.platform.models import Model
+from pulp.platform.models import Model, Notes, Scratchpad, MasterModel
 
 
-class Distributor(Model):
+class Content(Model):
     # placeholder
-    pass
+    type = models.TextField()
+    created = models.DateTimeField(auto_now_add=True)
+
+
+class Repository(Model):
+    """
+    Collection of content.
+
+    Fields:
+
+    :cvar name: The repository name.
+    :type name: models.TextField
+
+    :cvar: description: An optional description.
+    :type: models.TextField
+
+    :cvar last_content_added: When content was last added.
+    :type last_content_added: models.DateTimeField
+
+    :cvar last_content_removed: When content was last removed.
+    :type last_content_removed: models.DateTimeField
+
+    Relations:
+
+    :cvar scratchpad: Arbitrary information stashed on the repository.
+    :type scratchpad: fields.GenericRelation
+
+    :cvar notes: Arbitrary repository properties.
+    :type notes: fields.GenericRelation
+
+    :cvar content: Associated content.
+    :type content: models.ManyToManyField
+    """
+    name = models.TextField(db_index=True, unique=True)
+    description = models.TextField(blank=True)
+
+    last_content_added = models.DateTimeField(blank=True, null=True)
+    last_content_removed = models.DateTimeField(blank=True, null=True)
+
+    scratchpad = fields.GenericRelation(Scratchpad)
+    notes = fields.GenericRelation(Notes)
+
+    content = models.ManyToManyField('Content', through='RepositoryContent')
+
+    @property
+    def content_summary(self):
+        """
+        The contained content summary.
+
+        :return: A dict of {<type>: <count>}
+        :rtype:  dict
+        """
+        mapping = self.content.values('type').annotate(count=models.Count('type'))
+        return {m['type']: m['count'] for m in mapping}
+
+
+class RepositoryGroup(Model):
+    """
+    A group of repositories.
+
+    Fields:
+
+    :cvar name: The group name.
+    :type name: models.TextField
+
+    :cvar: description: An optional description.
+    :type: models.TextField
+
+    Relations:
+    :cvar notes: Arbitrary group properties.
+    :type notes: fields.GenericRelation
+
+    :cvar members: Repositories associated with the group.
+    :type members: models.ManyToManyField
+    """
+    name = models.TextField(db_index=True, unique=True)
+    description = models.TextField(blank=True)
+
+    members = models.ManyToManyField('Repository')
+    scratchpad = fields.GenericRelation(Scratchpad)
+    notes = fields.GenericRelation(Notes)
+
+
+class Plugin(MasterModel):
+    """
+    An Abstract model for plugins.
+
+    Fields:
+
+    :cvar name: The plugin name.
+    :type type: models.TextField
+
+    :cvar type: The plugin type.
+    :type type: models.TextField
+
+    :cvar last_updated: When the plugin was last updated.
+    :type last_updated: fields.DateTimeField
+
+    Relations:
+
+    """
+    name = models.TextField(db_index=True)
+    type = models.TextField(blank=False, default=None)
+    last_updated = models.DateTimeField(auto_now=True, blank=True, null=True)
+
+    class Meta:
+        abstract = True
+
+
+class Importer(Plugin):
+    """
+    A abstract content importer.
+
+    Fields:
+
+    :cvar feed_url: The URL of an external content source.
+    :type feed_url: models.TextField
+
+    :cvar validate: Validate the imported context.
+    :type validate: models.BooleanField
+
+    :cvar ssl_ca_certificate: A PEM encoded CA certificate used to validate the server
+                              certificate presented by the external source.
+    :type ssl_ca_certificate: models.TextField
+
+    :cvar ssl_client_certificate: A PEM encoded client certificate used for authentication.
+    :type ssl_client_certificate: models.TextField
+
+    :cvar ssl_client_key: A PEM encoded private key used for authentication.
+    :type ssl_client_key: models.TextField
+
+    :cvar ssl_validation: Indicates whether SSL peer validation must be performed.
+    :type ssl_validation: models.BooleanField
+
+    :cvar proxy_url: The optional proxy URL. Format: scheme://user:password@host:port
+    :type proxy_url: models.ForeignKey
+
+    :cvar basic_auth_user: The user used in HTTP basic authentication.
+    :type basic_auth_user: models.TextField
+
+    :cvar basic_auth_password: The password used in HTTP basic authentication.
+    :type basic_auth_password: models.TextField
+
+    :cvar max_download_bandwidth: The max amount of bandwidth used per download (Bps).
+    :type max_download_bandwidth: models.IntegerField
+
+    :cvar max_concurrent_downloads: The number of concurrent downloads permitted.
+    :type max_concurrent_downloads: models.IntegerField
+
+    :cvar download_policy: The policy for downloading content.
+    :type download_policy: models.TextField
+
+    :cvar last_sync: When the last successful synchronization occurred.
+    :type last_sync: models.DateTimeField
+
+    Relations:
+
+    :cvar scratchpad: Arbitrary information stashed by the importer.
+    :type scratchpad: fields.GenericRelation
+    """
+
+    # Download Policies
+    IMMEDIATE = 'immediate'
+    ON_DEMAND = 'on_demand'
+    BACKGROUND = 'background'
+    DOWNLOAD_POLICIES = (
+        (IMMEDIATE, 'Download Immediately'),
+        (ON_DEMAND, 'Download On Demand'),
+        (BACKGROUND, 'Download In Background'))
+
+    feed_url = models.TextField()
+    validate = models.BooleanField(default=True)
+
+    ssl_ca_certificate = models.TextField(blank=True)
+    ssl_client_certificate = models.TextField(blank=True)
+    ssl_client_key = models.TextField(blank=True)
+    ssl_validation = models.BooleanField(default=True)
+
+    proxy_url = models.TextField(blank=True)
+
+    basic_auth_user = models.TextField(blank=True)
+    basic_auth_password = models.TextField(blank=True)
+
+    max_download_bandwidth = models.IntegerField(null=True)
+    max_concurrent_downloads = models.IntegerField(null=True)
+
+    download_policy = models.TextField(choices=DOWNLOAD_POLICIES)
+    last_sync = models.DateTimeField(blank=True, null=True)
+
+    scratchpad = fields.GenericRelation(Scratchpad)
+
+    class Meta:
+        abstract = True
+        unique_together = ('name', 'repository')
+
+
+class RepositoryImporter(Importer):
+    """
+    A content importer that is associated with a repository..
+
+    Fields:
+
+    Relations:
+
+    :cvar repository: The associated repository.
+    :type repository: models.ForeignKey
+    """
+
+    repository = models.ForeignKey(
+        Repository, related_name='importers', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('name', 'repository')
+
+
+class Distributor(Plugin):
+    """
+    An abstract content distributor.
+
+    Fields:
+
+    :cvar relative_path: The (relative) path component of the published url.
+    :type relative_path: models.TextField
+
+    :cvar last_published: When the last successful publish occurred.
+    :type last_published: models.DateTimeField
+
+    Relations:
+
+    """
+    relative_path = models.TextField(blank=True)
+    last_published = models.DateTimeField(blank=True, null=True)
+
+    class Meta:
+        abstract = True
+
+
+class RepositoryDistributor(Distributor):
+    """
+    A content distributor that is associated with a repository.
+
+    Fields:
+
+    :cvar auto_publish: Indicates that the distributor may publish automatically
+        when the associated repository's content has changed.
+    :type auto_publish: models.BooleanField
+
+    Relations:
+
+    :cvar repository: The associated repository.
+    :type repository: models.ForeignKey
+
+    """
+    auto_publish = models.BooleanField(default=True)
+
+    repository = models.ForeignKey(
+        Repository, related_name='distributors', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('name', 'repository')
+
+
+class GroupDistributor(Distributor):
+    """
+    A content distributor that is associated with a repository group.
+
+    Fields:
+
+    Relations:
+
+    :cvar group: The associated repository group.
+    :type group: models.ForeignKey
+
+    """
+    group = models.ForeignKey(
+        RepositoryGroup, related_name='distributors', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('name', 'group')
+
+
+class RepositoryContent(Model):
+    """
+    Association between a repository and its contained content.
+
+    Fields:
+
+    :cvar created: When the association was created.
+    :type created: fields.DateTimeField
+
+    Relations:
+
+    :cvar content: The associated content.
+    :type content: models.ForeignKey
+
+    :cvar repository: The associated repository.
+    :type repository: models.ForeignKey
+    """
+    created = models.DateTimeField(auto_now_add=True)
+
+    content = models.ForeignKey('Content', on_delete=models.CASCADE)
+    repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
+
+    def save(self, *args, **kwargs):
+        """
+        Save the association.
+        """
+        self.repository.last_content_added = timezone.now()
+        self.repository.save()
+        super(RepositoryContent, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """
+        Delete the association.
+        """
+        self.repository.last_content_removed = timezone.now()
+        self.repository.save()
+        super(RepositoryContent, self).delete(*args, **kwargs)

--- a/platform/pulp/platform/tests/models/test_repository.py
+++ b/platform/pulp/platform/tests/models/test_repository.py
@@ -1,0 +1,114 @@
+"""
+These tests are intended to be a HOW TO for working with the repository motel.
+"""
+
+from django.test import TestCase
+
+from pulp.platform.models import Repository, RepositoryImporter, RepositoryDistributor
+
+
+class TestRepository(TestCase):
+
+    NAME = 'zoo'
+
+    def _create_repository(self):
+        """
+        Create a repository with sample notes and scratchpad.
+        """
+        repository = Repository(name=TestRepository.NAME)
+        repository.notes.mapping['organization'] = 'Engineering'
+        repository.notes.mapping.update({'age': 10})
+        repository.scratchpad.mapping['hello'] = 'world'
+        repository.save()
+
+    def _delete_repository(self):
+        """
+        Delete the repository.
+        """
+        repository = Repository.objects.filter(name=TestRepository.NAME)
+        repository.delete()
+
+    def _add_importer(self):
+        """
+        Add an importer with feed URL and some standard settings.
+        """
+        repository = Repository.objects.get(name=TestRepository.NAME)
+        importer = RepositoryImporter(repository=repository)
+        importer.name = 'Upstream'
+        importer.type = 'YUM'
+        importer.feed_url = 'http://content-world/everyting/'
+        importer.ssl_validation = True
+        importer.ssl_ca_certificate = 'MY-CA'
+        importer.ssl_client_certificate = 'MY-CERTIFICATE'
+        importer.ssl_client_key = 'MY-KEY'
+        importer.proxy_url = 'http://elmer:fudd@warnerbrothers.com'
+        importer.basic_auth_user = 'Elmer'
+        importer.basic_auth_password = 'Fudd'
+        importer.save()
+
+    def _add_distributor(self):
+        """
+        Add a distributor with some standard settings.
+        """
+        repository = Repository.objects.get(name=TestRepository.NAME)
+        distributor = RepositoryDistributor(repository=repository)
+        distributor.name = 'Public'
+        distributor.type = 'YUM'
+        distributor.auto_publish = True
+        distributor.save()
+
+    def setUp(self):
+        self._create_repository()
+
+    def tearDown(self):
+        self._delete_repository()
+
+    def test_add_importer(self):
+        self._add_importer()
+
+    def test_add_distributor(self):
+        self._add_distributor()
+
+    def test_inspect_repository(self):
+        """
+        Inspect a repository.
+        """
+        repository = Repository.objects.get(name=TestRepository.NAME)
+
+        # Read notes and scratchpad
+        self.assertEqual(repository.notes.mapping['organization'], 'Engineering')
+        self.assertEqual(repository.scratchpad.mapping['hello'], 'world')
+        self.assertEqual(repository.scratchpad.mapping.get('xx', 'good'), 'good')
+
+        # This is what happens when a key is not in the notes and [] is used.
+        with self.assertRaises(KeyError):
+            _ = repository.notes.mapping['xx']
+
+    def test_inspect_importer(self):
+        self._add_importer()
+        repository = Repository.objects.get(name=TestRepository.NAME)
+        importer = repository.importers.first()
+
+        self.assertEqual(importer.feed_url, 'http://content-world/everyting/')
+
+        # SSL
+        self.assertTrue(importer.ssl_validation)
+        self.assertEqual(importer.ssl_ca_certificate, 'MY-CA')
+        self.assertEqual(importer.ssl_client_certificate, 'MY-CERTIFICATE')
+        self.assertEqual(importer.ssl_client_key, 'MY-KEY')
+
+        # Basic auth settings
+        self.assertEqual(importer.basic_auth_user, 'Elmer')
+        self.assertEqual(importer.basic_auth_password, 'Fudd')
+
+    def test_update_note(self):
+        """
+        Update the notes.
+        """
+        repository = Repository.objects.get(name=TestRepository.NAME)
+        repository.notes.mapping['name'] = 'Elvis'
+        repository.notes.mapping.update({'age': 98})
+
+        repository = Repository.objects.get(name=TestRepository.NAME)
+        self.assertEqual(repository.notes.mapping['name'], 'Elvis')
+        self.assertEqual(repository.notes.mapping['age'], '98')


### PR DESCRIPTION
https://pulp.plan.io/issues/2089

Not sold on `RepositoryContent.save()` and `RepositoryContent.delete()` managing the `last_content_added` and `last_content_removed`.  As a rule, we don't have one model update another.  *Maybe* it's okay in cases like this where the model is an *association* (join tables)?  Perhaps managing the `last_content_*` should be in the control layer?

Ignore the `Content` model (for now).

Anyone know if `RepositoryGroup.scratchpad` is need?  Used?
