### PR TITLE
Add a new settings file for Django

### DIFF
--- a/platform/etc/pulp/server.yaml
+++ b/platform/etc/pulp/server.yaml
@@ -1,0 +1,44 @@
+# Pulp server configuration
+#
+# Values shown are the default values used, unless otherwise indicated.
+
+
+# `allowed_hosts`: A list of strings representing the host/domain names that
+# Pulp can serve. This is a security measure to prevent HTTP Host header
+# attacks. A value beginning with a period can be used as a sub-domain wildcard.
+# The default is the host's FQDN.
+#
+# allowed_hosts:
+#   - pulp.example.com
+
+# `databases`: An associative array (dictionary) of databases to use. For the
+# full list of configuration options, refer to the Django database documentation
+# shipped with your version of Django, or online at
+# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+#
+# By default, Pulp will attempt to connect to PostgreSQL on a local Unix
+# socket using the 'pulp' user with a database name of 'pulp'.
+#
+# databases:
+#   default:
+#     CONN_MAX_AGE: 0
+#     ENGINE: django.db.backends.postgresql_psycopg2
+#     NAME: pulp
+#     USER: pulp
+#     PASSWORD:
+#     HOST:
+#     PORT:
+
+# Logging configuration
+#
+# `logging`: Logging configuration for Pulp. By default, Pulp logs to syslog.
+# It is possible to change this by providing a Python logging dictConfig. For
+# more information, see Django's logging documentation.
+#
+# logging:
+#   loggers:
+#     django:
+#       level: INFO
+#     pulp.platform:
+#       level: INFO
+

--- a/platform/pulp/platform/tests/test_settings.py
+++ b/platform/pulp/platform/tests/test_settings.py
@@ -1,0 +1,64 @@
+from unittest import TestCase
+
+import mock
+
+from pulp.platform import settings as pulp_settings
+
+
+class TestMergeSettings(TestCase):
+
+    def test_no_override_config(self):
+        """Assert the default config is returned when no override config exists"""
+        self.assertEqual({'key': 'value'}, pulp_settings.merge_settings({'key': 'value'}, {}))
+
+    def test_no_overlap(self):
+        """Assert that merging two dicts with no shared keys works"""
+        default = {'default_1': 'value', 'default_2': 'value'}
+        override = {'1': 'value', '2': 'value'}
+        expected = {'default_1': 'value', 'default_2': 'value', '1': 'value', '2': 'value'}
+
+        merged = pulp_settings.merge_settings(default, override)
+        self.assertEqual(merged, expected)
+
+    def test_simple(self):
+        """Assert that merging two dicts with shared keys causes the override to be applied"""
+        default = {'key1': 'value', 'key2': 'value'}
+        override = {'key1': 'Circus of values', 'key3': 'value'}
+        expected = {'key1': 'Circus of values', 'key2': 'value', 'key3': 'value'}
+
+        merged = pulp_settings.merge_settings(default, override)
+        self.assertEqual(merged, expected)
+
+    def test_recursive(self):
+        """Assert that merging two dicts with shared keys causes the override to be applied"""
+        default = {'key1': {'subkey': 'value', 'subkey2': 'value'}}
+        override = {'key1': {'subkey': 'VALUE'}}
+        expected = {'key1': {'subkey': 'VALUE', 'subkey2': 'value'}}
+
+        merged = pulp_settings.merge_settings(default, override)
+        self.assertEqual(merged, expected)
+
+
+class TestLoadSettings(TestCase):
+
+    def test_no_settings_files(self):
+        """Assert the default settings are used if no setting files are provided"""
+        settings = pulp_settings.load_settings()
+
+        self.assertEqual(settings, pulp_settings._DEFAULT_PULP_SETTINGS)
+
+    def test_settings_file(self):
+        """Assert loading a file merges the file settings with the default"""
+        override = """
+        allowed_hosts:
+          - subdomains.all.the.way.down.www.example.com
+        """
+        expected = pulp_settings._DEFAULT_PULP_SETTINGS.copy()
+        expected['allowed_hosts'] = ['subdomains.all.the.way.down.www.example.com']
+
+        mocked_open = mock.mock_open(read_data=override)
+        with mock.patch('pulp.platform.settings.open', mocked_open, create=True):
+            settings = pulp_settings.load_settings('somefile')
+
+        self.assertEqual(settings, expected)
+        mocked_open.assert_called_with('somefile')


### PR DESCRIPTION
In order to allow for easy configuration, this patch loads settings from
`/etc/pulp/server.yaml`, merges them with default settings for Pulp, and
then applies them to settings.py (which is in turn merged with the
global default settings).

fixes #2109

Reviewer note: Tests are incoming, but I wanted to see what people thought about a) switching to YAML and b) allowing users to set _any_ Django-supported setting