### PR TITLE
celery_t can now exec rsync_exec_t

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -158,6 +158,13 @@ optional_policy(`
 
 ######################################
 #
+# The rsync distributors need to be able to execute rsync.
+#
+
+rsync_exec(celery_t)
+
+######################################
+#
 # ostree needs to be able to execute gpg, but both ostree and the gpg_exec directive are
 # unavailable on el6.
 #


### PR DESCRIPTION
The rsync distributors needs to execute the rsync binary.
The call to rsync_exec allows the celery_t security context
to make that call.

https://pulp.plan.io/issues/2196
closes #2196