### PR TITLE
Allow to copy units to custom location

### DIFF
--- a/server/pulp/server/content/storage.py
+++ b/server/pulp/server/content/storage.py
@@ -104,7 +104,7 @@ class FileStorage(ContentStorage):
             digest[0:2],
             digest[2:])
 
-    def put(self, unit, path, location=None):
+    def put(self, unit, path, location=None, destination=None):
         """
         Put the content defined by the content unit into storage.
         The file at the specified *path* is transferred into storage.
@@ -116,8 +116,11 @@ class FileStorage(ContentStorage):
         :param location: The (optional) location within the path
             where the content is to be stored.
         :type location: str
+        :param destination: The (optional) location where the content is to be stored.
+        :type  destination: str
         """
-        destination = unit.storage_path
+        if destination is None:
+            destination = unit.storage_path
         if location:
             destination = os.path.join(destination, location.lstrip('/'))
         mkdir(os.path.dirname(destination))

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -852,7 +852,7 @@ class FileContentUnit(ContentUnit):
                 raise ValueError(_('must be relative path'))
         self._storage_path = path
 
-    def import_content(self, path, location=None):
+    def import_content(self, path, location=None, destination=None):
         """
         Import a content file into platform storage.
         The (optional) *location* may be used to specify a path within the unit
@@ -866,6 +866,8 @@ class FileContentUnit(ContentUnit):
         :param location: The (optional) location within the unit storage path
             where the content is to be stored.
         :type location: str
+        :param destination: The (optional) location where the content is to be stored.
+        :type  destination: str
 
         :raises ImportError: if the unit has not been saved.
         :raises PulpCodedException: PLP0037 if *path* is not an existing file.
@@ -876,7 +878,7 @@ class FileContentUnit(ContentUnit):
         if not os.path.isfile(path):
             raise exceptions.PulpCodedException(error_code=error_codes.PLP0037, path=path)
         with FileStorage() as storage:
-            storage.put(self, path, location)
+            storage.put(self, path, location, destination)
 
     def save_and_import_content(self, path, location=None):
         """

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -476,7 +476,7 @@ class TestFileContentUnit(unittest.TestCase):
         file_storage.assert_called_once_with()
         storage.__enter__.assert_called_once_with()
         storage.__exit__.assert_called_once_with(None, None, None)
-        storage.put.assert_called_once_with(unit, path, None)
+        storage.put.assert_called_once_with(unit, path, None, None)
 
     @patch('os.path.isfile')
     @patch('pulp.server.db.model.FileStorage')
@@ -498,7 +498,7 @@ class TestFileContentUnit(unittest.TestCase):
         file_storage.assert_called_once_with()
         storage.__enter__.assert_called_once_with()
         storage.__exit__.assert_called_once_with(None, None, None)
-        storage.put.assert_called_once_with(unit, path, location)
+        storage.put.assert_called_once_with(unit, path, location, None)
 
     def test_import_content_unit_not_saved(self):
         try:


### PR DESCRIPTION
To be able to copy units to temporary files.

re #1823
https://pulp.plan.io/issues/1823