### PR TITLE
add content models.

### DIFF
--- a/platform/pulp/platform/models/__init__.py
+++ b/platform/pulp/platform/models/__init__.py
@@ -3,6 +3,7 @@ from .base import Model, MasterModel  # NOQA
 from .generic import GenericRelationModel, GenericKeyValueStore, Config, Notes, Scratchpad  # NOQA
 
 from .consumer import Consumer, ConsumerContent  # NOQA
+from .content import Content, Artifact  # NOQA
 from .repository import (Repository, RepositoryGroup, Importer, Distributor,  # NOQA
                          RepositoryImporter,  RepositoryDistributor, GroupDistributor,  # NOQA
                          RepositoryContent)  # NOQA

--- a/platform/pulp/platform/models/content.py
+++ b/platform/pulp/platform/models/content.py
@@ -1,0 +1,134 @@
+"""
+Content related Django models.
+"""
+import hashlib
+
+from django.contrib.contenttypes import fields
+from django.db import models
+
+
+from pulp.platform.models import Model, MasterModel, Notes
+from pulp.platform.models.storage import StoragePath
+
+
+class Content(MasterModel):
+    """
+    A piece of managed content.
+
+    :cvar natural_key_fields: Tuple of natural fields.  Must be: models.Field.
+    :type natural_key_fields: tuple
+
+    Fields:
+
+    :cvar type: The content type.
+    :type type: models.TextField
+
+    Relations:
+
+    :cvar notes: Arbitrary information stored with the content.
+    :type notes: fields.GenericRelation
+    """
+    natural_key_fields = ()
+
+    type = models.TextField(blank=False, default=None)
+
+    notes = fields.GenericRelation(Notes)
+
+    def natural_key(self):
+        """
+        Get the model's natural key based on natural_key_fields.
+
+        :return: The natural key.
+        :rtype: tuple
+        """
+        return (getattr(self, f.name) for f in self.natural_key_fields)
+
+    def natural_key_digest(self):
+        """
+        Get the SHA-256 digest of the natural key.
+        The digest is updated with each field name followed by its value.
+        The field names are only necessary to preserve backward compatibility
+        with digests generated in pulp 2.
+
+        :return: The hex digest.
+        :rtype: str
+        """
+        h = hashlib.sha256()
+        for name in sorted(f.name for f in self.natural_key_fields):
+            h.update(name)
+            value = getattr(self, name)
+            if not isinstance(value, basestring):
+                h.update(str(value))
+            else:
+                h.update(value)
+        return h.hexdigest()
+
+
+class Artifact(Model):
+    """
+    A file associated with a piece of content.
+
+    Fields:
+
+    :cvar file: The stored file.
+    :type file: models.FileField
+
+    :cvar downloaded: The associated file has been successfully downloaded.
+    :type downloaded: BooleanField
+
+    :cvar published_path: The relative published path.
+    :type published_path: models.FileField
+
+    :cvar size: The size of the file in bytes.
+    :type size: models.IntegerField
+
+    :cvar md5: The MD5 checksum of the file.
+    :type md5: models.CharField
+
+    :cvar sha1: The SHA-1 checksum of the file.
+    :type sha1: models.CharField
+
+    :cvar sha224: The SHA-224 checksum of the file.
+    :type sha224: models.CharField
+
+    :cvar sha256: The SHA-256 checksum of the file.
+    :type sha256: models.CharField
+
+    :cvar sha384: The SHA-384 checksum of the file.
+    :type sha384: models.CharField
+
+    :cvar sha512: The SHA-512 checksum of the file.
+    :type sha512: models.CharField
+
+    Relations:
+
+    :cvar content: The associated content.
+    :type content: Content
+    """
+
+    # Note: The FileField does not support unique indexes and has
+    # other undesirable behavior and complexities.  Using a custom
+    # field should be investigated.
+
+    file = models.FileField(db_index=True, upload_to=StoragePath(), max_length=255)
+    downloaded = models.BooleanField(db_index=True, default=False)
+    published_path = models.TextField(db_index=True, blank=False, default=None)
+
+    size = models.IntegerField(blank=True, null=True)
+
+    md5 = models.CharField(max_length=32, blank=True, null=True)
+    sha1 = models.CharField(max_length=40, blank=True, null=True)
+    sha224 = models.CharField(max_length=56, blank=True, null=True)
+    sha256 = models.CharField(max_length=64, blank=True, null=True)
+    sha384 = models.CharField(max_length=96, blank=True, null=True)
+    sha512 = models.CharField(max_length=128, blank=True, null=True)
+
+    content = models.ForeignKey(Content, related_name='artifacts', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('content', 'published_path')
+
+    def delete(self, *args, **kwargs):
+        if self.downloaded:
+            self.file.delete()
+        super(Artifact, self).delete(*args, **kwargs)

--- a/platform/pulp/platform/models/repository.py
+++ b/platform/pulp/platform/models/repository.py
@@ -8,12 +8,6 @@ from django.utils import timezone
 from pulp.platform.models import Model, Notes, Scratchpad, MasterModel
 
 
-class Content(Model):
-    # placeholder
-    type = models.TextField()
-    created = models.DateTimeField(auto_now_add=True)
-
-
 class Repository(Model):
     """
     Collection of content.

--- a/platform/pulp/platform/models/storage.py
+++ b/platform/pulp/platform/models/storage.py
@@ -1,0 +1,255 @@
+import os
+import errno
+import shutil
+
+from datetime import datetime
+
+from django.conf import settings
+from django.core.files import File
+from django.core.files.storage import Storage
+from django.utils.deconstruct import deconstructible
+
+
+@deconstructible
+class StoragePath(object):
+    """
+    Content storage path.
+    """
+
+    @staticmethod
+    def base_path(artifact):
+        """
+        Get the base path used to store a file associated with the specified artifact.
+        All artifact files *must* be stored relative to this location.
+
+        :param artifact: An content artifact.
+        :type  artifact: pulp.platform.models.content.Artifact
+        :return: An absolute (base) path.
+        :rtype: str
+        """
+        digest = artifact.content.natural_key_digest()
+        return os.path.join(
+            settings.MEDIA_ROOT,
+            'units',
+            artifact.content.type,
+            digest[0:2],
+            digest[2:])
+
+    def __call__(self, artifact, name):
+        """
+        Get the absolute path used to store a file associated
+        with the specified artifact.
+
+        :param artifact: An content artifact.
+        :type  artifact: pulp.platform.models.content.Artifact
+        :param name: Unused but matches the FileField API.
+        :param name: str
+        :return: An absolute path.
+        :rtype: str
+        """
+        return os.path.join(StoragePath.base_path(artifact), artifact.published_path)
+
+
+class FileSystem(Storage):
+    """
+    Provides simplified filesystem storage.
+    The django filesystem storage is overly complex and makes incompatible assumptions
+    and has incompatible behaviors with regard to how final storage paths are calculated.
+    """
+
+    @staticmethod
+    def mkdir(path):
+        """
+        Make the directory (and parent directories) at the specified path.
+        No exception is raised if the directory already exists.
+
+        :param path: The absolute directory path.
+        :type  path: str
+        """
+        try:
+            os.makedirs(path)
+        except OSError as e:
+            if e.errno == errno.EEXIST and os.path.isdir(path):
+                # ignored.
+                pass
+            else:
+                raise
+
+    @staticmethod
+    def unlink(path):
+        """
+        Delete the link at the specified path.
+        No exception is raised if the link does not exist.
+
+        :param path: A path to unlink.
+        :type  path: str
+        """
+        try:
+            os.unlink(path)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                raise
+
+    @staticmethod
+    def _open(path, mode='rb'):
+        """
+        Open the file at the specified path.
+        Required by the Storage API.
+
+        :param path: An absolute path to a file.
+        :type  path: str
+        :param mode: The open mode.  Default: 'rb'.
+        :type  mode: str
+        :return: An open file object.
+        :rtype: File
+        """
+        return File(open(path, mode))
+
+    @staticmethod
+    def _save(path, content):
+        """
+        Copy the content of a file to the specified path.
+        The directory tree is created as needed.
+        Required by the Storage API.
+
+        :param path: The (target) path to which the file is copied.
+        :type  path: str
+        :param content: The (source) file object.
+        :type  content: File
+        :return: The final storage path.
+        :rtype: str
+        """
+        FileSystem.mkdir(os.path.dirname(path))
+        shutil.copy(content.name, path)
+        return path
+
+    def get_available_name(self, name, max_length=None):
+        """
+        Get the available absolute path based on the name requested.
+        Required by the Storage API.
+
+        :param name: The file name.
+        :type  name: str
+        :param max_length: The max length of the returned path.
+        :type  max_length: str
+        :return: The name.
+        :rtype: str
+        :raise: ValueError on max_length exceeded.
+        """
+        if max_length:
+            if len(name) > max_length:
+                raise ValueError('max_length exceeded')
+        return name
+
+    def delete(self, path):
+        """
+        Delete the file at the specified path.
+        Required by the Storage API.
+
+        :param path: An absolute file path.
+        :type  path: str
+        """
+        FileSystem.unlink(path)
+
+    def exists(self, path):
+        """
+        Get whether the file actually exists at the specified path.
+        Required by the Storage API.
+
+        :param path: An absolute file path.
+        :type  path: str
+        :return: True if exists.
+        :rtype: bool
+        """
+        return os.path.exists(path)
+
+    def listdir(self, path):
+        """
+        List the content of the directory at the specified path.
+        Required by the Storage API.
+
+        :param path: An absolute directory path.
+        :type  path: str
+        :return: A tuple of two lists: (directories, files).
+        :rtype: tuple
+        """
+        files = []
+        directories = []
+        for entry in os.listdir(path):
+            if os.path.isdir(os.path.join(path, entry)):
+                directories.append(entry)
+            else:
+                files.append(entry)
+        return (directories, files)
+
+    def path(self, name):
+        """
+        Get the absolute path to a file with the specified name.
+        Required by the Storage API.
+
+        :param name: A File.name.
+        :type  name: str
+        :return: An absolute path.
+        :rtype: str
+        """
+        return name
+
+    def size(self, path):
+        """
+        Get the size of the file at the specified path.
+        Required by the Storage API.
+
+        :param path: An absolute file path.
+        :type  path: str
+        :return: The size in bytes.
+        :rtype: int
+        """
+        return os.path.getsize(path)
+
+    def url(self, path):
+        """
+        Get a URL for the file at the specified path.
+        Required by the Storage API.
+
+        :param path: An absolute file path.
+        :type  path: str
+        :return: An appropriate URL.
+        :rtype: str
+        """
+        return 'file://{}'.format(path)
+
+    def accessed_time(self, path):
+        """
+        Get the last accessed time of the file at specified path.
+        Required by the Storage API.
+
+        :param path: An absolute file path.
+        :type  path: str
+        :return: last access time.
+        :rtype: datetime
+        """
+        return datetime.fromtimestamp(os.path.getatime(path))
+
+    def created_time(self, path):
+        """
+        Get the created time of the file at specified path.
+        Required by the Storage API.
+
+        :param path: An absolute file path.
+        :type  path: str
+        :return: Created time.
+        :rtype: datetime
+        """
+        return datetime.fromtimestamp(os.path.getctime(path))
+
+    def modified_time(self, path):
+        """
+        Get the last modified time of the file at specified path.
+        Required by the Storage API.
+
+        :param path: An absolute file path.
+        :type  path: str
+        :return: Last modified time.
+        :rtype: datetime
+        """
+        return datetime.fromtimestamp(os.path.getmtime(path))

--- a/platform/pulp/platform/settings.py
+++ b/platform/pulp/platform/settings.py
@@ -26,7 +26,8 @@ DEBUG = True
 
 ALLOWED_HOSTS = []
 
-MEDIA_ROOT = 'content'
+MEDIA_ROOT = '/var/lib/pulp/content/'
+DEFAULT_FILE_STORAGE = 'pulp.platform.models.storage.FileSystem'
 
 # Application definition
 

--- a/platform/pulp/platform/tests/models/test_content.py
+++ b/platform/pulp/platform/tests/models/test_content.py
@@ -1,0 +1,111 @@
+import os
+import tempfile
+import shutil
+
+from django.conf import settings
+from django.test import TestCase
+from django.core.files import File
+
+from pulp.platform.models import Repository, RepositoryContent, Content, Artifact
+
+
+NAME = 'test'
+TYPE = 'test'
+
+
+class ContentExample(TestCase):
+    
+    REPO_NAME = 'test'
+
+    def setUp(self):
+        settings.MEDIA_ROOT = tempfile.mkdtemp(prefix='pulp-')
+        self.repository = self.add_repository()
+        self.content = self.add_content()
+
+    def tearDown(self):
+        shutil.rmtree(settings.MEDIA_ROOT)
+
+    def add_repository(self):
+        repository = Repository(name=NAME)
+        repository.save()
+        return repository
+
+    def associate(self):
+        association = RepositoryContent(repository=self.repository, content=self.content)
+        association.save()
+
+    def add_content(self):
+        content = Content(type=TYPE)
+        content.save()
+        return content
+
+    def publish(self, artifact):
+        """
+        Fake publish.
+        The artifact.published_path will be the file relative path.
+            Example: "3/test_content.py"
+        The artifact.file.name will be the absolute path to where it is stored.
+            Example: "/tmp/pulp-viCVvC/units/test/e3/b0c4429b93855/9/test_content.py"
+        """
+        self.assertEqual(os.path.basename(artifact.published_path), os.path.basename(__file__))
+        self.assertEqual(os.path.basename(artifact.file.name), os.path.basename(__file__))
+
+    def add_artifacts(self):
+        """
+        Example of an importer adding files.  Using __file__, let pretend we have
+        downloaded __file__ and want to add it to the content unit.  To make the
+        files unique and to simulate file with meaningful relative paths, let's
+        prefix the {n}/ directory to the file name.
+        """
+        paths = []
+        for n in range(10):
+            artifact = Artifact(content=self.content)
+            # Set the artifact name as n/<name> to make them unique.
+            artifact.published_path = '{0}/{1}'.format(n, os.path.basename(__file__))
+            # Set the file content (to be stored).
+            with open(__file__) as fp:
+                artifact.file = File(fp)
+            artifact.save()
+            paths.append(artifact.file.name)
+        return paths
+
+    def test_publishing(self):
+        """
+        Example of publishing.
+        for each content unit, we'll iterate all of the artifacts (files) and publish them.
+        The artifact.published_path already contains relative path information needed for
+        publishing which makes this easy.
+        """
+        self.add_artifacts()
+
+        # publishing
+        for artifact in self.content.artifacts.all():
+            self.publish(artifact)
+
+    def test_reading(self):
+        self.add_artifacts()
+
+        # reading
+        for artifact in self.content.artifacts.all():
+            artifact.file.open()
+            with open(__file__) as fp:
+                self.assertEqual(artifact.file.read(), fp.read())
+            artifact.file.close()
+
+    def test_publishing_repository(self):
+        self.associate()
+        self.add_artifacts()
+
+        # publishing
+        for content in (c.cast() for c in self.repository.content.filter(type=TYPE)):
+            for artifact in content.artifacts.all():
+                self.publish(artifact)
+
+    def test_find_artifacts_by_path(self):
+        n = 0
+        self.associate()
+        paths = self.add_artifacts()
+        for content in (c.cast() for c in self.repository.content.filter(type=TYPE)):
+            for artifact in content.artifacts.filter(file=paths[0]):
+                n += 1
+        self.assertGreater(n, 0)


### PR DESCRIPTION
https://pulp.plan.io/issues/2098

Okay folks, a few updated semantics to discuss.

The *Unit* part of `ContentUnit` although firmly entrenched in the pulp glossary, is a little awkward.  The term *unit* is synonymous with *item*, *thing*, *object* (and others) which makes it a bit redundant.  Consider it in another context - like a class named `RepositoryUnit` or `TaskObject`.  I believe that a class name of: `Content` and table name of `content` seems more appropriate. 

*"Repositories contain content."*

Another new concept is `Artifacts`.  *"Content has associated artifacts"*.  Each artifact represents a file.  I originally named this `ContentFile` but this quickly lead to odd semantics such as:

```
file = ContentFile(content=content)
file.content        # This is a reference to Content, not the content of the file.
file.file           #  Hmm.. . so, a file contains a file .. odd.
```

The term `artifact` resolves this.

```
artifact = Artifact(content=content)
artifact.content  # yep the associated Content.
artifact.file     # yep, artifacts reference files.
```

See the `test_content.py` for more usage examples.

I tried to use the default `FileSystemStorage` with `FileField` but has some unsuitable behavior.
- some concurrency issues with *if exists* checks.
- Insists on storage paths being relative to `MEDIA_ROOT`
- Mangles storage paths to prevent file name collisions.

The `Storage` interface is straight forward so I just implemented what we needed.  Docstrings and tests to follow.

Also worth noting is the lack of `FileContent` and `SharedContent`.  The separation of Content and Artifacts makes the distinction of `FileContent` unnecessary.  As for `SharedContent`, We only have 1 use case for this (ostree) and I believe this should be handled by plugins.  Not in the platform.

An update to the `models.README.md` to follow.
