### PR TITLE
The predistributor's history is no longer considered if force_full is…

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1022,14 +1022,19 @@ def check_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_con
             repo_id=repo_obj.repo_id,
             distributor_id=dist_id).update(set__last_override_config=config_override)
 
-    # Skip if a predistributor is configured and the predistributor has not published since the
-    # last publish. Skip if content has not changed since last publish and force_full has not been
-    # requested and no predistributor is defined.
+    # Check if a predistributor is configured and the predistributor has not published since the
+    # last publish.
     skip_for_predistributor = (predistributor_id and (published_after_predistributor or
                                                       not predistributor_last_published))
-    if skip_for_predistributor or \
-            (last_published and not force_full and not last_updated and not units_removed and
-             not dist_updated and same_override and not predistributor_id):
+    # Check if content has not changed since last publish and a predistributor is not defined.
+    unchanged_content_and_no_predistributor = last_published and not last_updated and \
+                                              not units_removed and not predistributor_id
+    # We want to skip based on predistributor conditions. We also want to skip if repository
+    # content has not changed since last publish and no predistributor is defined. We want to not
+    # skip if 'force_full' is configured or the distributor config has changed since last publish.
+    if (skip_for_predistributor and not last_published) or\
+            (last_published and not force_full and not dist_updated and same_override
+             and (skip_for_predistributor or unchanged_content_and_no_predistributor)):
 
         publish_result_coll = RepoPublishResult.get_collection()
         publish_start_timestamp = _now_timestamp()


### PR DESCRIPTION
… passed in. The predistributor's history is also ignored any time posdistributor's configuration changes.

closes #2202
https://pulp.plan.io/issues/2202