### PR TITLE
Add a DownloadCatalog model to track Artifacts

### DIFF
--- a/app/pulp/app/models/__init__.py
+++ b/app/pulp/app/models/__init__.py
@@ -7,6 +7,7 @@ from .content import Content, Artifact  # NOQA
 from .repository import (Repository, RepositoryGroup, Importer, Publisher,  # NOQA
                          RepositoryContent)  # NOQA
 
+from .catalog import DownloadCatalog  # NOQA
 from .task import ReservedResource, Worker, Task, TaskTag, TaskLock, ScheduledCalls  # NOQA
 
 # Moved here to avoid a circular import with Task

--- a/app/pulp/app/models/catalog.py
+++ b/app/pulp/app/models/catalog.py
@@ -1,0 +1,48 @@
+"""
+Django models for artifact catalogs.
+"""
+from django.core import validators
+from django.db import models
+from django.utils.translation import ugettext as _
+
+from pulp.app.models import Model, Artifact, Importer
+
+
+class DownloadCatalog(Model):
+    """
+    Each :class:`DownloadCatalog` maps an :class:`Artifact` to a URL where
+    it is stored remotely and to the :class:`Importer` which contains the
+    network configuration required to access that URL.
+
+    Fields:
+
+    :cvar url: The URL used to download the related artifact.
+    :type url: django.db.models.TextField
+
+    Relations:
+
+    :cvar artifact: The artifact that is expected to be present at ``url``.
+    :type artifact: pulp.platform.models.Artifact
+
+    :cvar importer: The importer that contains the configuration necessary
+                    to access ``url``.
+    :type importer: pulp.platform.models.Importer
+    """
+    # Although there is a Django field for URLs based on CharField, there is
+    # not technically any limit on URL lengths so it's simplier to allow any
+    # length here and let the upstream server deal with the problem of size.
+    url = models.TextField(blank=True, validators=[validators.URLValidator])
+
+    artifact = models.ForeignKey(Artifact, on_delete=models.CASCADE)
+    importer = models.ForeignKey(Importer, on_delete=models.CASCADE)
+
+    def __str__(self):
+        """
+        Human-readable representation of this model.
+
+        This is helpful for interactive prompts and is used in Django's admin
+        interface.
+        """
+
+        return _('{artifact} is retrievable at {url} by {importer}'.format(
+            artifact=self.artifact, url=self.url, importer=self.importer))

--- a/app/pulp/app/models/content.py
+++ b/app/pulp/app/models/content.py
@@ -76,6 +76,10 @@ class Artifact(Model):
     :cvar downloaded: The associated file has been successfully downloaded.
     :type downloaded: BooleanField
 
+    :cvar requested: The associated file has been requested by a client at
+                     least once.
+    :type requested: BooleanField
+
     :cvar relative_path: The artifact's path relative to the associated
                          :class:`Content`. This path is incorporated in
                          the absolute storage path of the file and its
@@ -117,6 +121,7 @@ class Artifact(Model):
 
     file = models.FileField(db_index=True, upload_to=StoragePath(), max_length=255)
     downloaded = models.BooleanField(db_index=True, default=False)
+    requested = models.BooleanField(db_index=True, default=False)
     relative_path = models.TextField(db_index=True, blank=False, default=None)
 
     size = models.IntegerField(blank=True, null=True)


### PR DESCRIPTION
Lazy sync has a LazyCatalogEntry collection Pulp 2. This covers the
LazyCatalogEntry functionality by relating a URL to an ``Artifacts``
and an ``Importer`` that contains the necessary download configuration
to access the URL (basic auth, client certificates, CA certificates,
etc).

closes #2088