### PR TITLE
Add units which did not pass signature filter to the task report.

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1152,13 +1152,13 @@ def check_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_con
                                                       not predistributor_last_published))
     # Check if content has not changed since last publish and a predistributor is not defined.
     unchanged_content_and_no_predistributor = last_published and not last_updated and \
-                                              not units_removed and not predistributor_id
+        not units_removed and not predistributor_id
     # We want to skip based on predistributor conditions. We also want to skip if repository
     # content has not changed since last publish and no predistributor is defined. We want to not
     # skip if 'force_full' is configured or the distributor config has changed since last publish.
     if (skip_for_predistributor and not last_published) or\
-            (last_published and not force_full and not dist_updated and same_override
-             and (skip_for_predistributor or unchanged_content_and_no_predistributor)):
+            (last_published and not force_full and not dist_updated and same_override and
+                (skip_for_predistributor or unchanged_content_and_no_predistributor)):
 
         publish_result_coll = RepoPublishResult.get_collection()
         publish_start_timestamp = _now_timestamp()

--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -271,7 +271,12 @@ class RepoUnitAssociationManager(object):
             copied_units = importer_instance.import_units(
                 transfer_source_repo, transfer_dest_repo, conduit, call_config,
                 units=transfer_units)
-
+            if isinstance(copied_units, tuple):
+                suc_units_ids = [u.to_id_dict() for u in copied_units[0] if u is not None]
+                unsuc_units_ids = [u.to_id_dict() for u in copied_units[1]]
+                repo_controller.rebuild_content_unit_counts(dest_repo)
+                return {'units_successful': suc_units_ids,
+                        'units_failed_signature_filter': unsuc_units_ids}
             unit_ids = [u.to_id_dict() for u in copied_units if u is not None]
             repo_controller.rebuild_content_unit_counts(dest_repo)
             return {'units_successful': unit_ids}

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -230,6 +230,28 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.assertEqual(1, mock_imp_inst.import_units.call_count)
         self.assertEqual(ret.get('units_successful'), [])
 
+    @mock.patch('pulp.server.controllers.repository.rebuild_content_unit_counts', spec_set=True)
+    @mock.patch('pulp.server.managers.repo.unit_association.UnitAssociationCriteria')
+    @mock.patch('pulp.server.managers.repo.unit_association.plugin_api')
+    @mock.patch('pulp.server.managers.repo.unit_association.model.Importer')
+    def test_associate_from_repo_return_tuple(self, mock_importer, mock_plugin, mock_repo,
+                                              mock_crit, mock_rebuild_count):
+        mock_imp_inst = mock.MagicMock()
+        mock_plugin.get_importer_by_id.return_value = (mock_imp_inst, mock.MagicMock())
+        source_repo = mock.MagicMock(repo_id='source-repo')
+        dest_repo = mock.MagicMock(repo_id='dest-repo')
+
+        with mock.patch('pulp.server.controllers.importer.remove_importer'):
+            importer_controller.set_importer(source_repo, 'mock-importer', {})
+            importer_controller.set_importer(dest_repo, 'mock-importer', {})
+
+        mock_imp_inst.import_units.return_value = (list(), list())
+        ret = self.manager.associate_from_repo('source_repo', 'dest_repo', mock_crit)
+
+        self.assertEqual(1, mock_imp_inst.import_units.call_count)
+        self.assertEqual(ret.get('units_successful'), [])
+        self.assertEqual(ret.get('units_failed_signature_filter'), [])
+
     @mock.patch('pulp.server.managers.repo.unit_association.UnitAssociationCriteria')
     def test_associate_from_repo_missing_source(self, mock_repo, mock_crit):
         importer_controller.set_importer('dest_repo', 'mock-importer', {})


### PR DESCRIPTION
closes #2212
https://pulp.plan.io/issues/2212