### PR TITLE
Add PyYAML to the dependency list for platform

### DIFF
--- a/platform/setup.py
+++ b/platform/setup.py
@@ -2,9 +2,10 @@ from setuptools import setup, find_packages
 
 requirements = [
     'Django>=1.8,<1.9',
+    'django-extensions',
     'djangorestframework',
     'psycopg2',
-    'django-extensions',
+    'PyYAML',
     'setuptools',
 ]
 


### PR DESCRIPTION
Pulp's platform package depends on PyYAML, so it should declare it in
the setup.py.

fixes #2231