### PR TITLE
The Artifact `published_path` field is now `relative_path`

### DIFF
--- a/platform/pulp/platform/models/content.py
+++ b/platform/pulp/platform/models/content.py
@@ -76,8 +76,13 @@ class Artifact(Model):
     :cvar downloaded: The associated file has been successfully downloaded.
     :type downloaded: BooleanField
 
-    :cvar published_path: The relative published path.
-    :type published_path: models.FileField
+    :cvar relative_path: The artifact's path relative to the associated
+                         :class:`Content`. This path is incorporated in
+                         the absolute storage path of the file and its
+                         published path relative to the root publishing
+                         directory. At a minimum the path will contain the
+                         file name but may also include sub-directories.
+    :type relative_path: models.TextField
 
     :cvar size: The size of the file in bytes.
     :type size: models.IntegerField
@@ -112,7 +117,7 @@ class Artifact(Model):
 
     file = models.FileField(db_index=True, upload_to=StoragePath(), max_length=255)
     downloaded = models.BooleanField(db_index=True, default=False)
-    published_path = models.TextField(db_index=True, blank=False, default=None)
+    relative_path = models.TextField(db_index=True, blank=False, default=None)
 
     size = models.IntegerField(blank=True, null=True)
 
@@ -126,7 +131,7 @@ class Artifact(Model):
     content = models.ForeignKey(Content, related_name='artifacts', on_delete=models.CASCADE)
 
     class Meta:
-        unique_together = ('content', 'published_path')
+        unique_together = ('content', 'relative_path')
 
     def delete(self, *args, **kwargs):
         if self.downloaded:

--- a/platform/pulp/platform/models/storage.py
+++ b/platform/pulp/platform/models/storage.py
@@ -47,7 +47,7 @@ class StoragePath(object):
         :return: An absolute path.
         :rtype: str
         """
-        return os.path.join(StoragePath.base_path(artifact), artifact.published_path)
+        return os.path.join(StoragePath.base_path(artifact), artifact.relative_path)
 
 
 class FileSystem(Storage):

--- a/platform/pulp/platform/tests/models/test_content.py
+++ b/platform/pulp/platform/tests/models/test_content.py
@@ -42,12 +42,12 @@ class ContentExample(TestCase):
     def publish(self, artifact):
         """
         Fake publish.
-        The artifact.published_path will be the file relative path.
+        The artifact.relative_path will be the file relative path.
             Example: "3/test_content.py"
         The artifact.file.name will be the absolute path to where it is stored.
             Example: "/tmp/pulp-viCVvC/units/test/e3/b0c4429b93855/9/test_content.py"
         """
-        self.assertEqual(os.path.basename(artifact.published_path), os.path.basename(__file__))
+        self.assertEqual(os.path.basename(artifact.relative_path), os.path.basename(__file__))
         self.assertEqual(os.path.basename(artifact.file.name), os.path.basename(__file__))
 
     def add_artifacts(self):
@@ -61,7 +61,7 @@ class ContentExample(TestCase):
         for n in range(10):
             artifact = Artifact(content=self.content)
             # Set the artifact name as n/<name> to make them unique.
-            artifact.published_path = '{0}/{1}'.format(n, os.path.basename(__file__))
+            artifact.relative_path = '{0}/{1}'.format(n, os.path.basename(__file__))
             # Set the file content (to be stored).
             with open(__file__) as fp:
                 artifact.file = File(fp)
@@ -73,7 +73,7 @@ class ContentExample(TestCase):
         """
         Example of publishing.
         for each content unit, we'll iterate all of the artifacts (files) and publish them.
-        The artifact.published_path already contains relative path information needed for
+        The artifact.relative_path already contains relative path information needed for
         publishing which makes this easy.
         """
         self.add_artifacts()


### PR DESCRIPTION
This updates the Artifact model's `published_path` field to be
`relative_path` which I think is clearer. This also updates the
documenation for the field.