### PR TITLE
Moves the get_current_task_id function

### DIFF
--- a/platform/pulp/platform/models/progress.py
+++ b/platform/pulp/platform/models/progress.py
@@ -7,7 +7,7 @@ import logging
 from django.db import models
 
 from pulp.platform.models import Model, Task
-from pulp.server.async.tasks import get_current_task_id
+from pulp.platform.tasks.task_system import get_current_task_id
 
 
 _logger = logging.getLogger(__name__)

--- a/platform/pulp/platform/tasks/task_system.py
+++ b/platform/pulp/platform/tasks/task_system.py
@@ -1,0 +1,14 @@
+from celery import current_task
+
+
+def get_current_task_id():
+    """"
+    Get the current task id from celery. If this is called outside of a running
+    celery task it will return None
+
+    :return: The ID of the currently running celery task or None if not in a task
+    :rtype: str
+    """
+    if current_task and current_task.request and current_task.request.id:
+        return current_task.request.id
+    return None


### PR DESCRIPTION
This creates the pulp.platform.tasks.task_system package
and moves the get_current_task_id function into it.