### PR TITLE
Consolidation of repository models.

### DIFF
--- a/docs/dev-guide/3.0-development/data-modeling.rst
+++ b/docs/dev-guide/3.0-development/data-modeling.rst
@@ -4,13 +4,13 @@ Data Modeling
 Introduction
 ^^^^^^^^^^^^
 
-The pulp 3 data modeling effort is not just a translation or porting effort but instead
-an effort to build pulp 3 using pulp 2.  Remodeling will include changes to leverage the
-relational capabilities of postgres but also to improve upon the pulp 2 model.
+The Pulp 3 data modeling effort is not just a translation or porting effort but instead
+an effort to build Pulp 3 using Pulp 2.  Remodeling will include changes to leverage the
+relational capabilities of postgres but also to improve upon the Pulp 2 model.
 
-When creating each pulp 3 model object, consider the following:
+When creating each Pulp 3 model object, consider the following:
 
-- Understand what the pulp 2 model (collection) stores and how the information
+- Understand what the Pulp 2 model (collection) stores and how the information
   is used by pulp.
 
 - Name the model/table appropriately.  A table is implicitly plural.  Naming a
@@ -26,14 +26,14 @@ When creating each pulp 3 model object, consider the following:
   effort, a proper class hierarchy is almost always possible and will be better in the end.
 
 - Question the existence, type, and naming of all fields.  Field names beginning with `_` 
-  should not exist in pulp 3.  The primary key field name is `id` and already defined in the
+  should not exist in Pulp 3.  The primary key field name is `id` and already defined in the
   `Model` base class.  All `display_name` fields need to be renamed to `name`.  Also, avoid
   redundant scope by prefixing field names (or any attribute) with the name of the class.
   For example: `Task.task_type`.
 
 - Question all methods (including @property). We **only** want those methods that encapsulate
-  significant complexity and are widely used.  Most of the methods on pulp 2 models will likely
-  not be necessary or wanted in the pulp 3 models.  Let's keep the model interface as clean
+  significant complexity and are widely used.  Most of the methods on Pulp 2 models will likely
+  not be necessary or wanted in the Pulp 3 models.  Let's keep the model interface as clean
   as possible.
 
 - Most string fields will be `TextField`.  When the field is required and indexed,
@@ -44,7 +44,7 @@ When creating each pulp 3 model object, consider the following:
 - All fields containing *ISO-8601* strings must be converted to `DateTimeField`.
 
 - Think about *natural* keys.  For example, each repository has a unique name (instead of repo_id
-  like in pulp 2) that is known to users and is not the primary key (`id` is).  The `name` is
+  like in Pulp 2) that is known to users and is not the primary key (`id` is).  The `name` is
   the *natural* key.  Don't forget the index. See: https://en.wikipedia.org/wiki/Natural_key
 
 - Define a `natural_key()` method in each model.  This both documents the *natural* key and
@@ -57,7 +57,7 @@ Development Process
 
 - The *refactor* tasks (in Redmine) group related collections.
 
-- The pulp 3 models are grouped into modules within the `models` package.
+- The Pulp 3 models are grouped into modules within the `models` package.
 
 - Foreach model class defined, A *refactor* task needs to be created in Redmine for
   migrating the data.  See existing examples.
@@ -76,14 +76,14 @@ Notes About Models
 .. note:: This article is a stub. You can help by expanding it.
 
 This section captures notes about each model.  Developers should explain differences
-between the pulp 2 and pulp 3.  This is a good place to give examples of how models are intended
+between the Pulp 2 and Pulp 3.  This is a good place to give examples of how models are intended
 to be used or extended by plugins.  Except for how to extend a class, refer to the *howto* unit
 tests instead of including code blocks here.
 
 Consumer
 ^^^^^^^^
 
-The consumer models are much like that in pulp 2 except the fields related to the removed
+The consumer models are much like that in Pulp 2 except the fields related to the removed
 *nodes* and *agent* functionality are gone.  The `bind` has be replaced with a simple relation
 that is managed by django because no addition fields on the join table are needed.
 
@@ -95,22 +95,24 @@ on a consumer.
 Repository
 ^^^^^^^^^^
 
-The repository models include importers and distributors.  The main difference being the
-consolidation of the importer and distributor and it's configuration.  In the model, a
-`Plugin` is the base for plugin contributed models that can be associated to a repository.
-On importer and distributor base models, the *standard* configuration settings that were
-separate documents in pulp 2 are attributes of the importer and distributor itself.  These models
-follow the *master-detail* pattern.  Plugins needing additional configuration, need to extend the
+First, `Distributor` has been renamed to `Publisher` because it seems more appropriate.
+
+The repository models include importers and publishers.  The main difference being the
+consolidation of the importer and publisher and its configuration.  In the model, a
+`ContentAdaptor` is the base for plugin contributed models that can be associated to a repository.
+On importer and publisher base models, the *standard* configuration settings that were
+separate documents in Pulp 2 are attributes of the importer and publishers itself.  These models
+follow the *master-detail* pattern.  Adaptors needing additional configuration, need to extend the
 base model (master) and add the extra fields on a new (detail) model.
+
+The concept of a repository group distributor has been discarded.  This concept and associated flows
+were flawed in Pulp 2.
 
 Examples:
 
 .. code-block:: python
 
-    Class MyImporter(RepositoryImporter):
+    Class MyImporter(Importer):
 
         field_1 = models.TextField()
         field_2 = models.TextField()
-
-        class Meta:
-            unique_together = ()

--- a/platform/pulp/platform/models/__init__.py
+++ b/platform/pulp/platform/models/__init__.py
@@ -4,8 +4,7 @@ from .generic import GenericRelationModel, GenericKeyValueStore, Config, Notes, 
 
 from .consumer import Consumer, ConsumerContent  # NOQA
 from .content import Content, Artifact  # NOQA
-from .repository import (Repository, RepositoryGroup, Importer, Distributor,  # NOQA
-                         RepositoryImporter,  RepositoryDistributor, GroupDistributor,  # NOQA
+from .repository import (Repository, RepositoryGroup, Importer, Publisher,  # NOQA
                          RepositoryContent)  # NOQA
 
 from .task import ReservedResource, Worker, Task, TaskTag, TaskLock, ScheduledCalls  # NOQA

--- a/platform/pulp/platform/models/consumer.py
+++ b/platform/pulp/platform/models/consumer.py
@@ -25,14 +25,14 @@ class Consumer(Model):
     :cvar notes: Arbitrary information about the consumer.
     :type notes: fields.GenericRelation
 
-    :cvar distributors: Associated distributors.
-    :type distributors: models.ManyToManyField
+    :cvar publishers: Associated publishers.
+    :type publishers: models.ManyToManyField
     """
     name = models.TextField(db_index=True, unique=True)
     description = models.TextField(blank=True)
 
     notes = fields.GenericRelation(Notes)
-    distributors = models.ManyToManyField('RepositoryDistributor')
+    publishers = models.ManyToManyField('Publisher', related_name='consumers')
 
     def natural_key(self):
         """

--- a/platform/pulp/platform/tests/models/test_consumer.py
+++ b/platform/pulp/platform/tests/models/test_consumer.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from pulp.platform.models import Consumer
+from pulp.platform.models import Consumer, Publisher, Repository
 
 
 class TestConsumer(TestCase):
@@ -8,3 +8,23 @@ class TestConsumer(TestCase):
     def test_natural_key(self):
         consumer = Consumer(name='test')
         self.assertEqual(consumer.natural_key(), (consumer.name,))
+
+    def test_bind(self):
+        consumer = Consumer(name='test')
+        consumer.save()
+        repository = Repository(name='test')
+        repository.save()
+        publisher = Publisher(name='test', type='test', repository=repository)
+        publisher.save()
+
+        # bind
+        consumer.publishers.add(publisher)
+        consumer.save()
+
+        # inspect publishers
+        fetched = consumer.publishers.all()[0]
+        self.assertEqual(fetched.id, publisher.id)
+
+        # inspect consumers
+        fetched = publisher.consumers.all()[0]
+        self.assertEqual(fetched.id, consumer.id)

--- a/platform/pulp/platform/tests/models/test_repository.py
+++ b/platform/pulp/platform/tests/models/test_repository.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
-from pulp.platform.models import (Repository, RepositoryGroup, RepositoryImporter,
-                                  RepositoryDistributor, GroupDistributor)
+from pulp.platform.models import Repository, RepositoryGroup, Importer, Publisher
 
 
 class TestRepository(TestCase):
@@ -16,30 +15,6 @@ class TestRepositoryGroup(TestCase):
     def test_natural_key(self):
         group = RepositoryGroup(name='test')
         self.assertEqual(group.natural_key(), (group.name,))
-
-
-class TestRepositoryImporter(TestCase):
-
-    def test_natural_key(self):
-        repository = Repository()
-        importer = RepositoryImporter(name='test', repository=repository)
-        self.assertEqual(importer.natural_key(), (repository.id, importer.name))
-
-
-class TestRepositoryDistributor(TestCase):
-
-    def test_natural_key(self):
-        group = RepositoryGroup()
-        distributor = GroupDistributor(name='test', group=group)
-        self.assertEqual(distributor.natural_key(), (group.id, distributor.name))
-
-
-class TestGroupDistributor(TestCase):
-
-    def test_natural_key(self):
-        repository = Repository()
-        distributor = RepositoryDistributor(name='test', repository=repository)
-        self.assertEqual(distributor.natural_key(), (repository.id, distributor.name))
 
 
 class RepositoryExample(TestCase):
@@ -68,7 +43,7 @@ class RepositoryExample(TestCase):
         Add an importer with feed URL and some standard settings.
         """
         repository = Repository.objects.get(name=RepositoryExample.NAME)
-        importer = RepositoryImporter(repository=repository)
+        importer = Importer(repository=repository)
         importer.name = 'Upstream'
         importer.type = 'YUM'
         importer.feed_url = 'http://content-world/everyting/'
@@ -81,16 +56,17 @@ class RepositoryExample(TestCase):
         importer.basic_auth_password = 'Fudd'
         importer.save()
 
-    def add_distributor(self):
+    def add_publishers(self):
         """
-        Add a distributor with some standard settings.
+        Add a publisher with some standard settings.
         """
         repository = Repository.objects.get(name=RepositoryExample.NAME)
-        distributor = RepositoryDistributor(repository=repository)
-        distributor.name = 'Public'
-        distributor.type = 'YUM'
-        distributor.auto_publish = True
-        distributor.save()
+        for n in range(3):
+            publisher = Publisher(repository=repository)
+            publisher.name = 'p{}'.format(n)
+            publisher.type = 'YUM'
+            publisher.auto_publish = True
+            publisher.save()
 
     def setUp(self):
         self.create_repository()
@@ -101,8 +77,8 @@ class RepositoryExample(TestCase):
     def test_add_importer(self):
         self.add_importer()
 
-    def test_add_distributor(self):
-        self.add_distributor()
+    def test_add_publisher(self):
+        self.add_publishers()
 
     def test_inspect_repository(self):
         """


### PR DESCRIPTION
Flattened importer and distributor models.
Renamed `Distributor` to `Publisher`.
Renamed `Plugin` to`ContentAdaptor`.  Never seemed quite right and took a stab at something better.

The natural key for an importer and publisher is `name` which requires it to be unique.  This puts *some* extra burden on the API user but I don't think it's unreasonable.

Updated the tests until we decide what direction we're going with on testing.