### PR TITLE
Remove redundant 'type' fields.

### DIFF
--- a/app/pulp/app/models/content.py
+++ b/app/pulp/app/models/content.py
@@ -18,19 +18,14 @@ class Content(MasterModel):
     :cvar natural_key_fields: Tuple of natural fields.  Must be: models.Field.
     :type natural_key_fields: tuple
 
-    Fields:
-
-    :cvar type: The content type.
-    :type type: models.TextField
-
     Relations:
 
     :cvar notes: Arbitrary information stored with the content.
     :type notes: fields.GenericRelation
     """
-    natural_key_fields = ()
+    TYPE = 'content'
 
-    type = models.TextField(blank=False, default=None)
+    natural_key_fields = ()
 
     notes = fields.GenericRelation(Notes)
 

--- a/app/pulp/app/models/repository.py
+++ b/app/pulp/app/models/repository.py
@@ -114,9 +114,6 @@ class ContentAdaptor(MasterModel):
     :cvar name: The ContentAdaptor name.
     :type type: models.TextField
 
-    :cvar type: The ContentAdaptor type.
-    :type type: models.TextField
-
     :cvar last_updated: When the adaptor was last updated.
     :type last_updated: fields.DateTimeField
 
@@ -127,7 +124,6 @@ class ContentAdaptor(MasterModel):
 
     """
     name = models.TextField(db_index=True)
-    type = models.TextField(blank=False, default=None)
     last_updated = models.DateTimeField(auto_now=True, blank=True, null=True)
 
     repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
@@ -197,6 +193,7 @@ class Importer(ContentAdaptor):
     :cvar scratchpad: Arbitrary information stashed by the importer.
     :type scratchpad: fields.GenericRelation
     """
+    TYPE = 'importer'
 
     # Download Policies
     IMMEDIATE = 'immediate'
@@ -251,6 +248,8 @@ class Publisher(ContentAdaptor):
     Relations:
 
     """
+    TYPE = 'publisher'
+
     auto_publish = models.BooleanField(default=True)
     relative_path = models.TextField(blank=True)
     last_published = models.DateTimeField(blank=True, null=True)

--- a/app/pulp/app/tests/models/test_consumer.py
+++ b/app/pulp/app/tests/models/test_consumer.py
@@ -14,7 +14,7 @@ class TestConsumer(TestCase):
         consumer.save()
         repository = Repository(name='test')
         repository.save()
-        publisher = Publisher(name='test', type='test', repository=repository)
+        publisher = Publisher(name='test', repository=repository)
         publisher.save()
 
         # bind

--- a/app/pulp/app/tests/models/test_content.py
+++ b/app/pulp/app/tests/models/test_content.py
@@ -94,15 +94,6 @@ class ContentExample(TestCase):
                 self.assertEqual(artifact.file.read(), fp.read())
             artifact.file.close()
 
-    def test_publishing_repository(self):
-        self.associate()
-        self.add_artifacts()
-
-        # publishing
-        for content in (c.cast() for c in self.repository.content.filter(type=TYPE)):
-            for artifact in content.artifacts.all():
-                self.publish(artifact)
-
     def test_find_artifacts_by_path(self):
         n = 0
         self.associate()

--- a/app/pulp/app/tests/models/test_repository.py
+++ b/app/pulp/app/tests/models/test_repository.py
@@ -45,7 +45,6 @@ class RepositoryExample(TestCase):
         repository = Repository.objects.get(name=RepositoryExample.NAME)
         importer = Importer(repository=repository)
         importer.name = 'Upstream'
-        importer.type = 'YUM'
         importer.feed_url = 'http://content-world/everyting/'
         importer.ssl_validation = True
         importer.ssl_ca_certificate = 'MY-CA'
@@ -64,7 +63,6 @@ class RepositoryExample(TestCase):
         for n in range(3):
             publisher = Publisher(repository=repository)
             publisher.name = 'p{}'.format(n)
-            publisher.type = 'YUM'
             publisher.auto_publish = True
             publisher.save()
 


### PR DESCRIPTION
The 'detail_model' field provided by MasterModel *is* the type field.

If we want to rename it from detail_model to 'type', I'm in favor of that.