### PR TITLE
Changes needed to support relative url for ISO repositories

### DIFF
--- a/server/pulp/plugins/conduits/repo_config.py
+++ b/server/pulp/plugins/conduits/repo_config.py
@@ -50,7 +50,7 @@ class RepoConfigConduit(object):
         spec = rel_url_is_repo_id | rel_url_in_list | rel_url_match
 
         if repo_id is not None:
-            spec = Q(repo_id__ne=repo_id) & spec
+            spec = Q(repo_id__ne=repo_id, distributor_type_id=self.distributor_type) & spec
 
         dists = model.Distributor.objects(spec).only('repo_id', 'config')
         return [{'repo_id': dist.repo_id, '_id': dist.id, 'config': dist.config} for dist in dists]

--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -402,7 +402,7 @@ class Publisher(PublishStep):
         :return: path to 'master' publish directory
         :rtype: str
         """
-        repo_relative_path = self.predistributor['config']['relative_url']
+        repo_relative_path = self.predistributor['config'].get('relative_url', self.repo.id)
         return os.path.realpath(os.path.join(self._get_root_publish_dir(), repo_relative_path))
 
     def get_units_directory_dest_path(self):


### PR DESCRIPTION
The Q object used to find conflicts for relative url now restricts the search to distributor's of a
particular type. This is necesary to allow the same relative URLs for RPM and ISO content.

re: #2132
https://pulp.plan.io/issues/2132