### PR TITLE
Restore selinux context after published files are moved.

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -367,6 +367,7 @@ Requires: python-isodate >= 0.5.0-1.pulp
 Requires: python-qpid
 Requires: python-nectar >= 1.5.0
 Requires: python-semantic_version >= 2.2.0
+Requires: libselinux-python
 Requires: httpd
 Requires: mod_ssl
 Requires: openssl

--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -11,6 +11,7 @@ import time
 import traceback
 import uuid
 import errno
+import selinux
 import signal
 
 from pulp.common import error_codes
@@ -901,6 +902,7 @@ class AtomicDirectoryPublishStep(PluginStep):
 
         try:
             os.rename(self.source_dir, timestamp_master_dir)
+            selinux.restorecon(timestamp_master_dir.encode('utf-8'), recursive=True)
         except OSError as e:
             if e.errno == errno.EXDEV:
                 copytree(self.source_dir, timestamp_master_dir, symlinks=True)

--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -16,6 +16,7 @@ files_tmp_file(pulp_tmp_t)
 
 require {
         type celery_t;
+        type httpd_sys_rw_content_t;
         type pulp_var_run_t;
         type pulp_tmp_t;
         type pulp_var_cache_t;
@@ -24,11 +25,11 @@ require {
         type tmp_t;
         class sock_file { create link unlink write };
         class unix_stream_socket connectto;
-        class dir { getattr search write remove_name create add_name rmdir };
-        class file { lock rename write setattr getattr read create unlink open };
+        class dir { getattr search write remove_name create add_name rmdir relabelto relabelfrom };
+        class file { lock rename write setattr getattr read create unlink open relabelto relabelfrom };
         class process { setsched signal signull };
         class tcp_socket { connect create getattr getopt read setopt shutdown write };
-        class lnk_file { create read getattr unlink};
+        class lnk_file { create read getattr unlink relabelto relabelfrom };
         class netlink_route_socket { bind create getattr nlmsg_read write read };
         class udp_socket { ioctl create getattr connect write read };
         class unix_dgram_socket { create connect };
@@ -139,6 +140,19 @@ auth_use_nsswitch(celery_t)
 corenet_tcp_connect_all_ports(celery_t)
 corenet_tcp_bind_all_ports(celery_t)
 corenet_tcp_bind_generic_node(celery_t)
+
+######################################
+#
+# Pulp workers need to do selinux relabeling as part of publishing.
+#
+
+allow celery_t httpd_sys_rw_content_t:dir relabelto;
+allow celery_t httpd_sys_rw_content_t:file relabelto;
+allow celery_t httpd_sys_rw_content_t:lnk_file relabelto;
+allow celery_t pulp_var_cache_t:dir relabelfrom;
+allow celery_t pulp_var_cache_t:file relabelfrom;
+allow celery_t pulp_var_cache_t:lnk_file relabelfrom;
+
 
 ######################################
 #

--- a/server/test/unit/plugins/util/test_publish_step.py
+++ b/server/test/unit/plugins/util/test_publish_step.py
@@ -690,7 +690,8 @@ class TestAtomicDirectoryPublishStep(unittest.TestCase):
         step = publish_step.AtomicDirectoryPublishStep('foo', 'bar', 'baz')
         self.assertEquals(step.step_id, reporting_constants.PUBLISH_STEP_DIRECTORY)
 
-    def test_process_main(self):
+    @patch('selinux.restorecon')
+    def test_process_main(self, restorecon):
         source_dir = os.path.join(self.working_directory, 'source')
         master_dir = os.path.join(self.working_directory, 'master')
         publish_dir = os.path.join(self.working_directory, 'publish', 'bar')
@@ -707,11 +708,14 @@ class TestAtomicDirectoryPublishStep(unittest.TestCase):
         os.makedirs(old_dir)
         step.process_main()
 
+        restorecon.assert_called_once_with(
+            os.path.join(master_dir, step.parent.timestamp), recursive=True)
         target_file = os.path.join(publish_dir, 'foo', 'bar.html')
         self.assertEquals(True, os.path.exists(target_file))
         self.assertEquals(1, len(os.listdir(master_dir)))
 
-    def test_process_main_multiple_targets(self):
+    @patch('selinux.restorecon')
+    def test_process_main_multiple_targets(self, restorecon):
         source_dir = os.path.join(self.working_directory, 'source')
         master_dir = os.path.join(self.working_directory, 'master')
         publish_dir = os.path.join(self.working_directory, 'publish', 'bar')
@@ -730,11 +734,14 @@ class TestAtomicDirectoryPublishStep(unittest.TestCase):
 
         step.process_main()
 
+        restorecon.assert_called_once_with(
+            os.path.join(master_dir, step.parent.timestamp), recursive=True)
         target_file = os.path.join(publish_dir, 'foo', 'bar.html')
         self.assertEquals(True, os.path.exists(target_file))
         self.assertEquals(True, os.path.exists(target_qux))
 
-    def test_process_main_only_publish_directory_contents(self):
+    @patch('selinux.restorecon')
+    def test_process_main_only_publish_directory_contents(self, restorecon):
         source_dir = os.path.join(self.working_directory, 'source')
         master_dir = os.path.join(self.working_directory, 'master')
         publish_dir = os.path.join(self.working_directory, 'publish', 'bar')
@@ -756,6 +763,8 @@ class TestAtomicDirectoryPublishStep(unittest.TestCase):
         os.makedirs(old_dir)
         step.process_main()
 
+        restorecon.assert_called_once_with(
+            os.path.join(master_dir, step.parent.timestamp), recursive=True)
         target_file = os.path.join(publish_dir, 'bar.html')
         self.assertTrue(os.path.exists(target_file))
         self.assertTrue(os.path.exists(existing_file))


### PR DESCRIPTION
https://pulp.plan.io/issues/2277

Call `selinux.restorecon()` after moving published files.  The path passed to `restorecon()` cannot be unicode.

The `Requires: libselinux-python` needs to be added to the .spec file but I have no idea which one is actually being used.