### PR TITLE
Use yaml.safe_load instead of yaml.load

### DIFF
--- a/app/pulp/app/settings.py
+++ b/app/pulp/app/settings.py
@@ -228,7 +228,7 @@ def load_settings(paths=()):
         try:
             with open(path) as config_file:
                 config = config_file.read()
-                override_settings = yaml.load(config)
+                override_settings = yaml.safe_load(config)
                 settings = merge_settings(settings, override_settings)
         except (OSError, IOError):
             # Consider adding logging of some kind, potentially to /var/log/pulp


### PR DESCRIPTION
Use yaml.safe_load instead of yaml.load, as yaml.load is dangerous

Look at http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML for more
info

closes #[2290](https://pulp.plan.io/issues/2290)