### PR TITLE
Prompt user of running workers/tasks on migration

### DIFF
--- a/docs/user-guide/release-notes/2.11.x.rst
+++ b/docs/user-guide/release-notes/2.11.x.rst
@@ -10,3 +10,5 @@ New Features
 
 * For RPM content, a full sync will be forced if the sync configuration has been changed or content
   has been removed since the last sync.
+
+* When pulp-manage-db is run, prompt the user to continue if there are Pulp services still running.

--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -192,6 +192,9 @@ class Scheduler(beat.Scheduler):
         self._schedule = None
         self._loaded_from_db_count = 0
 
+        # Setting the celerybeat name
+        self.celerybeat_name = constants.SCHEDULER_WORKER_NAME + "@" + platform.node()
+
         # Force the use of the Pulp celery_instance when this custom Scheduler is used.
         kwargs['app'] = app
 
@@ -241,8 +244,6 @@ class Scheduler(beat.Scheduler):
         :return:    number of seconds before the next tick should run
         :rtype:     float
         """
-        # Setting the celerybeat name
-        celerybeat_name = constants.SCHEDULER_WORKER_NAME + "@" + platform.node()
 
         # this is not an event that gets sent anywhere. We process it
         # immediately.
@@ -250,7 +251,7 @@ class Scheduler(beat.Scheduler):
             'timestamp': time.time(),
             'local_received': time.time(),
             'type': 'scheduler-event',
-            'hostname': celerybeat_name
+            'hostname': self.celerybeat_name
         }
 
         worker_watcher.handle_worker_heartbeat(scheduler_event)
@@ -258,14 +259,14 @@ class Scheduler(beat.Scheduler):
         old_timestamp = datetime.utcnow() - timedelta(seconds=constants.CELERYBEAT_LOCK_MAX_AGE)
 
         # Updating the current lock if lock is on this instance of celerybeat
-        result = CeleryBeatLock.objects(celerybeat_name=celerybeat_name).\
+        result = CeleryBeatLock.objects(celerybeat_name=self.celerybeat_name).\
             update(set__timestamp=datetime.utcnow())
 
         # If current instance has lock and updated lock_timestamp, call super
         if result == 1:
             _logger.debug(_('Lock updated by %(celerybeat_name)s')
-                          % {'celerybeat_name': celerybeat_name})
-            ret = self.call_tick(self, celerybeat_name)
+                          % {'celerybeat_name': self.celerybeat_name})
+            ret = self.call_tick(self, self.celerybeat_name)
         else:
             # check for old enough time_stamp and remove if such lock is present
             CeleryBeatLock.objects(timestamp__lte=old_timestamp).delete()
@@ -273,13 +274,13 @@ class Scheduler(beat.Scheduler):
                 lock_timestamp = datetime.utcnow()
 
                 # Insert new lock entry
-                new_lock = CeleryBeatLock(celerybeat_name=celerybeat_name,
+                new_lock = CeleryBeatLock(celerybeat_name=self.celerybeat_name,
                                           timestamp=lock_timestamp)
                 new_lock.save()
                 _logger.info(_("New lock acquired by %(celerybeat_name)s") %
-                             {'celerybeat_name': celerybeat_name})
+                             {'celerybeat_name': self.celerybeat_name})
                 # After acquiring new lock call super to dispatch tasks
-                ret = self.call_tick(self, celerybeat_name)
+                ret = self.call_tick(self, self.celerybeat_name)
 
             except mongoengine.NotUniqueError:
                 # Setting a default wait time for celerybeat instances with no lock
@@ -368,3 +369,7 @@ class Scheduler(beat.Scheduler):
         entries to the database, and they will be picked up automatically.
         """
         raise NotImplementedError
+
+    def close(self):
+        _delete_worker(self.celerybeat_name, normal_shutdown=True)
+        super(Scheduler, self).close()

--- a/server/pulp/server/db/manage.py
+++ b/server/pulp/server/db/manage.py
@@ -1,6 +1,7 @@
 """
 This module's main() function becomes the pulp-manage-db.py script.
 """
+from datetime import datetime
 from gettext import gettext as _
 from optparse import OptionParser
 import logging
@@ -8,6 +9,7 @@ import os
 import sys
 import traceback
 
+from pulp.common import constants
 from pulp.plugins.loader.api import load_content_types
 from pulp.plugins.loader.manager import PluginManager
 from pulp.server import logs
@@ -15,9 +17,11 @@ from pulp.server.db import connection
 from pulp.server.db.migrate import models
 from pulp.server.db import model
 from pulp.server.db.migrations.lib import managers
-from pulp.server.managers import factory
+from pulp.server.db.fields import UTCDateTimeField
+from pulp.server.managers import factory, status
 from pulp.server.managers.auth.role.cud import RoleManager, SUPER_USER_ROLE
 
+from pymongo.errors import ServerSelectionTimeoutError
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pulp.server.webservices.settings'
 
@@ -191,6 +195,15 @@ def main():
         options = parse_args()
         _start_logging()
         connection.initialize(max_timeout=1)
+
+        # Prompt the user if there are workers that have not timed out
+        if filter(lambda worker: (UTCDateTimeField().to_python(datetime.now()) -
+                                  worker['last_heartbeat']).total_seconds() <
+                  constants.CELERY_TIMEOUT_SECONDS, status.get_workers()):
+            if not _user_input_continue('There are still running workers, continuing could '
+                                        'corrupt your Pulp installation. Are you sure you wish '
+                                        'to continue?'):
+                return os.EX_OK
         return _auto_manage_db(options)
     except UnperformedMigrationException:
         return 1
@@ -199,6 +212,9 @@ def main():
         _logger.critical(''.join(traceback.format_exception(*sys.exc_info())))
         return os.EX_DATAERR
     except models.MigrationRemovedError:
+        return os.EX_SOFTWARE
+    except ServerSelectionTimeoutError:
+        _logger.info(_('Cannot connect to database, please validate that the database is up.'))
         return os.EX_SOFTWARE
     except Exception, e:
         _logger.critical(str(e))
@@ -274,3 +290,10 @@ def _start_logging():
     console_handler = logging.StreamHandler()
     console_handler.setLevel(logging.INFO)
     _logger.root.addHandler(console_handler)
+
+
+def _user_input_continue(question):
+    reply = str(raw_input(_(question + ' (y/N): '))).lower().strip()
+    if reply[0] == 'y':
+        return True
+    return False

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -116,9 +116,9 @@ class TestSchedulerTick(unittest.TestCase):
     @mock.patch('pulp.server.async.scheduler.CeleryBeatLock')
     def test_calls_handle_heartbeat(self, mock_celerybeatlock, mock_worker_watcher, time, node,
                                     mock_tick):
+        node.return_value = 'some_host'
         sched_instance = scheduler.Scheduler()
         time.time.return_value = 1449261335.275528
-        node.return_value = 'some_host'
 
         sched_instance.tick()
 


### PR DESCRIPTION
Add close() method to celery scheduler for clean exit.
Catch ServerSelectionTimeoutError when mongo is down.

closes #2186
https://pulp.plan.io/issues/2186