### PR TITLE
Repository syncs show all units updated even when there are no changes.

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1431,9 +1431,21 @@ class LazyUnitDownloadStep(DownloadEventListener):
                 path=path_entry[CATALOG_ENTRY].path)
             _logger.debug(msg)
             report.data[REQUEST].canceled = True
+
         except (InvalidChecksumType, VerificationException, IOError):
             # It's either missing or incorrect, so download it
             pass
+
+        unit_model = plugin_api.get_unit_model_by_id(report.data[TYPE_ID])
+        unit_qs = unit_model.objects.filter(id=report.data[UNIT_ID])
+
+        # Mark the entire unit as downloaded, if necessary.
+        download_flags = [entry[PATH_DOWNLOADED] for entry in
+                          report.data[UNIT_FILES].values()]
+        if all(download_flags):
+            _logger.debug(_('Marking content located at {path} as downloaded.').format(
+                path=path_entry[CATALOG_ENTRY].path))
+            unit_qs.update_one(set__downloaded=True)
 
     def download_succeeded(self, report):
         """

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -1640,8 +1640,9 @@ class TestLazyUnitDownloadStep(unittest.TestCase):
         self.step.start()
         self.step.downloader.download.assert_called_once_with(self.step.download_requests)
 
+    @patch(MODULE + 'plugin_api.get_unit_model_by_id')
     @patch(MODULE + 'model.DeferredDownload')
-    def test_download_started(self, mock_deferred_download):
+    def test_download_started(self, mock_deferred_download, mock_get_model):
         """Assert if validate_file raises an exception, the download is not skipped."""
         self.step.validate_file = Mock(side_effect=IOError)
 
@@ -1650,16 +1651,22 @@ class TestLazyUnitDownloadStep(unittest.TestCase):
         qs.assert_called_once_with(unit_id='1234', unit_type_id='abc')
         qs.return_value.delete.assert_called_once_with()
 
+    @patch(MODULE + 'plugin_api.get_unit_model_by_id')
     @patch(MODULE + 'model.DeferredDownload')
-    def test_download_started_already_downloaded(self, mock_deferred_download):
+    def test_download_started_already_downloaded(self, mock_deferred_download, mock_get_model):
         """Assert if validate_file doesn't raise an exception, the download is skipped."""
         self.step.validate_file = Mock()
+        model_qs = mock_get_model.return_value
 
         self.step.download_started(self.report)
         self.assertTrue(self.report.data[repo_controller.REQUEST].canceled)
         qs = mock_deferred_download.objects.filter
         qs.assert_called_once_with(unit_id='1234', unit_type_id='abc')
         qs.return_value.delete.assert_called_once_with()
+        self.assertEqual(
+            {'set__downloaded': True},
+            model_qs.objects.filter.return_value.update_one.call_args_list[0][1]
+        )
 
     @patch(MODULE + 'os.path.relpath', Mock(return_value='filename'))
     @patch(MODULE + 'plugin_api.get_unit_model_by_id')


### PR DESCRIPTION
closes #2328
https://pulp.plan.io/issues/2328