### PR TITLE
platform provides python2-pulp-* packages

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -652,7 +652,7 @@ Pulp nodes consumer client extensions.
 %package -n python-pulp-streamer
 Summary: The pulp lazy streamer
 Group: Development/Languages
-
+Provides: python2-pulp-streamer
 Requires: httpd
 Requires: pulp-server
 Requires: python-mongoengine
@@ -720,6 +720,7 @@ fi
 Summary: Pulp common python packages
 Group: Development/Languages
 Obsoletes: pulp-common
+Provides: python2-pulp-common
 Requires: python-isodate >= 0.5.0-1.pulp
 Requires: python-iniparse
 # RHEL5 ONLY
@@ -745,6 +746,7 @@ A collection of components that are common between the pulp server and client.
 %package -n python-pulp-devel
 Summary: Pulp devel python packages
 Group: Development/Languages
+Provides: python2-pulp-devel
 %if 0%{?rhel} == 6
 Requires: python-unittest2
 %endif
@@ -766,6 +768,7 @@ A collection of tools used for developing & testing Pulp plugins
 %package -n python-pulp-bindings
 Summary: Pulp REST bindings for python
 Group: Development/Languages
+Provides: python2-pulp-bindings
 Requires: python-%{name}-common = %{pulp_version}
 %if %{pulp_client_oauth}
 Requires: python-oauth2 >= 1.5.170-2.pulp
@@ -787,6 +790,7 @@ The Pulp REST API bindings for python.
 %package -n python-pulp-client-lib
 Summary: Pulp client extensions framework
 Group: Development/Languages
+Provides: python2-pulp-client-lib
 Requires: m2crypto
 Requires: python-%{name}-common = %{pulp_version}
 Requires: python-okaara >= 1.0.32
@@ -814,6 +818,7 @@ A framework for loading Pulp client extensions.
 %package -n python-pulp-agent-lib
 Summary: Pulp agent handler framework
 Group: Development/Languages
+Provides: python2-pulp-agent-lib
 Requires: python-%{name}-common = %{pulp_version}
 
 %description -n python-pulp-agent-lib
@@ -1006,6 +1011,7 @@ exit 0
 %package -n python-pulp-repoauth
 Summary: Framework for cert-based repo authentication
 Group: Development/Languages
+Provides: python2-pulp-repoauth
 Requires: httpd
 Requires: mod_ssl
 Requires: mod_wsgi >= 3.4-1.pulp
@@ -1027,6 +1033,7 @@ Cert-based repo authentication for Pulp
 %package -n python-pulp-oid_validation
 Summary: Cert-based repo authentication for Pulp
 Group: Development/Languages
+Provides: python2-pulp-oid-validation
 Requires: python-rhsm
 Requires: python-pulp-repoauth = %{pulp_version}
 

--- a/server/test/unit/plugins/migration/test_standard_storage_path.py
+++ b/server/test/unit/plugins/migration/test_standard_storage_path.py
@@ -117,8 +117,8 @@ class TestBatch(TestCase):
             call('/content/new/e/f6', '/pub/zoo/wolf/f6'),
         ]
         for link_call, unlink_call in zip(expected_link_calls, expected_unlink_calls):
-            self.assertIn(link_call, symlink.call_args_list)
-            self.assertIn(unlink_call, unlink.call_args_list)
+            self.assertTrue(link_call in symlink.call_args_list)
+            self.assertTrue(unlink_call in unlink.call_args_list)
 
     def test_migrate(self):
         plan = Mock()
@@ -136,7 +136,7 @@ class TestBatch(TestCase):
         # validate
         for i in items:
             expected_call = call(i.unit_id, i.storage_path, i.new_path)
-            self.assertIn(expected_call, plan.migrate.call_args_list)
+            self.assertTrue(expected_call in plan.migrate.call_args_list)
 
     @patch(MODULE + '.Batch.reset')
     @patch(MODULE + '.Batch._relink')


### PR DESCRIPTION
Testing has been broken for a while on f24, and it's because of a difference between the f24 spec file in fedora downstream and our upstream spec. I'm still digging into what the "best" solution might be, but this gets tests running on f24 for 2.10 right now, by providing "python2-" prefixed versions of all the python-pulp-* packages in platform.