### PR TITLE
Explicitly set view_name when registering NamedModelViewSets

### DIFF
--- a/app/pulp/app/serializers/fields.py
+++ b/app/pulp/app/serializers/fields.py
@@ -7,6 +7,6 @@ class RepositoryRelatedField(serializers.HyperlinkedRelatedField):
     """
     A serializer field with the correct view_name and lookup_field to link to a repository.
     """
-    view_name = 'repository-detail'
+    view_name = 'repositories-detail'
     lookup_field = 'name'
     queryset = models.Repository.objects.all()

--- a/app/pulp/app/serializers/repository.py
+++ b/app/pulp/app/serializers/repository.py
@@ -8,7 +8,7 @@ class RepositorySerializer(ModelSerializer):
     # _href is normally provided by the base class, but Repository's
     # "name" lookup field means _href must be explicitly declared.
     _href = serializers.HyperlinkedIdentityField(
-        view_name='repository-detail',
+        view_name='repositories-detail',
         lookup_field='name',
     )
     name = serializers.CharField(

--- a/app/pulp/app/viewsets/base.py
+++ b/app/pulp/app/viewsets/base.py
@@ -93,4 +93,5 @@ class NamedModelViewSet(viewsets.ModelViewSet):
             pieces = (cls.endpoint_name,)
 
         urlpattern = '/'.join(pieces)
-        router.register(urlpattern, cls)
+        view_name = '-'.join(pieces)
+        router.register(urlpattern, cls, view_name)


### PR DESCRIPTION
Without this, we had an inconsistency where a ViewSet, e.g. "TasksViewSet"
with endpoint_name "tasks" would still be registered with a base_name of
"task", so the section of the docs that say to use endpoint_name when
generating view_name arguments to serializer reference fields is a liar
without this change.