### PR TITLE
Allow nested routing for objects related to repos

### DIFF
--- a/app/pulp/app/serializers/__init__.py
+++ b/app/pulp/app/serializers/__init__.py
@@ -3,10 +3,10 @@
 # - all can import directly from base and fields if needed
 from pulp.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # NOQA
     ModelSerializer, MasterModelSerializer, viewset_for_model)  # NOQA
-from pulp.app.serializers.fields import RepositoryRelatedField  # NOQA
+from pulp.app.serializers.fields import RepositoryNestedIdentityField, RepositoryRelatedField  # NOQA
 from pulp.app.serializers.generic import (ConfigKeyValueRelatedField,  # NOQA
     NotesKeyValueRelatedField)  # NOQA
 from pulp.app.serializers.content import ContentSerializer, ContentRelatedField  # NOQA
-from pulp.app.serializers.consumer import ConsumerSerializer # NOQA
-from pulp.app.serializers.repository import RepositorySerializer  # NOQA
-from pulp.app.serializers.task import TaskSerializer, WorkerSerializer # NOQA
+from pulp.app.serializers.consumer import ConsumerSerializer  # NOQA
+from pulp.app.serializers.repository import ImporterSerializer, RepositorySerializer  # NOQA
+from pulp.app.serializers.task import TaskSerializer, WorkerSerializer  # NOQA

--- a/app/pulp/app/serializers/base.py
+++ b/app/pulp/app/serializers/base.py
@@ -221,7 +221,7 @@ class _DetailFieldMixin:
 class DetailIdentityField(_DetailFieldMixin, serializers.HyperlinkedIdentityField):
     """IdentityField for use in the _href field of Master/Detail Serializers
 
-    When using this field on a Serializer,it will automatically cast objects to their Detail type
+    When using this field on a Serializer, it will automatically cast objects to their Detail type
     base on the Serializer's Model before generating URLs for them.
 
     Subclasses must indicate the Master model they represent by declaring a queryset

--- a/app/pulp/app/serializers/fields.py
+++ b/app/pulp/app/serializers/fields.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.reverse import reverse
 
 from pulp.app import models
 
@@ -10,3 +11,36 @@ class RepositoryRelatedField(serializers.HyperlinkedRelatedField):
     view_name = 'repositories-detail'
     lookup_field = 'name'
     queryset = models.Repository.objects.all()
+
+
+class RepositoryNestedIdentityField(serializers.HyperlinkedIdentityField):
+    """
+    Used to represent an href identity field includes the associated repository name in the url.
+
+    Overrides `get_url` and `get_object` methods. This is necessary because objects that are nested
+    within their related repositories need to be able to generate their identity urls. The base
+    implementation only supports a single url parameter, defined by `lookup_field`. By overriding
+    these methods, we will use the repository name and the object name. In order for this to work,
+    the object's `lookup_field` must be set to `name`.
+    """
+
+    def get_url(self, obj, view_name, request, format):
+        """
+        The parent class's get_url can only use a single kwarg, which is `lookup_field`. This
+        builds a url that includes the associated repository name.
+        """
+        url_kwargs = {
+            'repo_name': obj.repository.name,
+            'name': obj.name
+        }
+        return reverse(view_name, kwargs=url_kwargs, request=request, format=format)
+
+    def get_object(self, view_name, view_args, view_kwargs):
+        """
+        Used to query for an object from its name and associated repository name.
+        """
+        lookup_kwargs = {
+            'repository__name': view_kwargs['repo_name'],
+            'name': view_kwargs['name']
+        }
+        return self.get_queryset().get(**lookup_kwargs)

--- a/app/pulp/app/serializers/repository.py
+++ b/app/pulp/app/serializers/repository.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 
 from pulp.app import models
-from pulp.app.serializers import NotesKeyValueRelatedField, ModelSerializer
+from pulp.app.serializers import (ModelSerializer, NotesKeyValueRelatedField,
+                                  MasterModelSerializer)
 
 
 class RepositorySerializer(ModelSerializer):
@@ -37,3 +38,19 @@ class RepositorySerializer(ModelSerializer):
         fields = ModelSerializer.Meta.fields + ('name', 'description', 'notes',
                                                 'last_content_added', 'last_content_removed')
 
+
+class ImporterSerializer(MasterModelSerializer):
+    """
+    Every importer defined by a plugin should have an Importer serializer that inherits from this
+    class. Please import from `pulp.app.serializers` rather than from this module directly.
+
+    Every subclass must override the `_href` field with a `RepositoryNestedIdentityField` that
+    defines the view_name.
+    """
+    name = serializers.CharField(
+        help_text='A name for this importer, unique within the associated repository.'
+    )
+
+    class Meta:
+        abstract = True
+        fields = MasterModelSerializer.Meta.fields + ('name',)

--- a/app/pulp/app/viewsets/__init__.py
+++ b/app/pulp/app/viewsets/__init__.py
@@ -1,3 +1,3 @@
 from pulp.app.viewsets.base import NamedModelViewSet  # NOQA
 from pulp.app.viewsets.content import ContentViewSet  # NOQA
-from pulp.app.viewsets.repository import RepositoryViewSet  # NOQA
+from pulp.app.viewsets.repository import ImporterViewSet, RepositoryViewSet  # NOQA

--- a/app/pulp/app/viewsets/base.py
+++ b/app/pulp/app/viewsets/base.py
@@ -11,6 +11,7 @@ class NamedModelViewSet(viewsets.ModelViewSet):
     "Normal" Django Models and Master/Detail models are supported by the ``register_with`` method.
     """
     endpoint_name = None
+    nested_parent = None
 
     @classmethod
     def is_master_viewset(cls):
@@ -48,18 +49,43 @@ class NamedModelViewSet(viewsets.ModelViewSet):
             <master_viewset.endpoint_name>-<detail_viewset.endpoint_name>'
 
         """
+        if cls.is_master_viewset():
+            # If this is a master viewset, it doesn't need to be registered with the API
+            # router (its detail subclasses will be registered instead).
+            return
+
+        pieces = cls.relative_url_pieces()
+        # View name does not include nested parent
+        view_name = '-'.join(pieces)
+        if cls.nested_parent:
+            # If a nested parent is defined, the relative url is built on top of the parent
+            # ViewSet's detail view url.
+            lookup = cls.urlpattern_param(cls.nested_parent_lookup_name)
+            pieces = cls.nested_parent.relative_url_pieces() + (lookup,) + pieces
+
+        urlpattern = '/'.join(pieces)
+        router.register(urlpattern, cls, view_name)
+
+    @staticmethod
+    def urlpattern_param(lookup_name):
+        """
+        Generates a named url pattern using a lookup_name.
+        https://docs.djangoproject.com/en/1.10/topics/http/urls/#naming-url-patterns
+        """
+        return "(?P<{name}>[^/.]+)".format(name=lookup_name)
+
+    @classmethod
+    def relative_url_pieces(cls):
+        """
+        Retrieves the pieces of the relative url for this ViewSet.
+        """
         # if we have a master model, include its endpoint name in endpoint pieces
         # by looking at its ancestry and finding the "master" endpoint name
         if cls.queryset is None:
             # If this viewset has no queryset, we can't begin to introspect its
             # endpoint. It is most likely a superclass to be used by Detail
             # Model ViewSet subclasses.
-            return
-
-        if cls.is_master_viewset():
-            # If this is a master viewset, it doesn't need to be registered with the API
-            # router (its detail subclasses will be registered instead).
-            return
+            return ()
 
         if cls.queryset.model._meta.master_model is not None:
             # Model is a Detail model. Go through its ancestry (via MRO) to find its
@@ -87,11 +113,9 @@ class NamedModelViewSet(viewsets.ModelViewSet):
                        'correctly subclass the Master ViewSet, and do both have endpoint_name '
                        'set to different values?').format(cls.__name__)
                 warnings.warn(msg, RuntimeWarning)
-                return
+                return ()
         else:
             # "Normal" model, can just use endpoint_name directly.
             pieces = (cls.endpoint_name,)
 
-        urlpattern = '/'.join(pieces)
-        view_name = '-'.join(pieces)
-        router.register(urlpattern, cls, view_name)
+        return pieces


### PR DESCRIPTION
This work allows objects that are related to repositories to have urls
that are nested within their related repository. For example, an
`rpm` importer named `zoo-importer` related to the `zoo` repository
will live in `repositories/zoo/importers/rpm/zoo-importer/`