### PR TITLE
Replace task controller with facade object that represents the current running task.

### DIFF
--- a/app/pulp/app/models/task.py
+++ b/app/pulp/app/models/task.py
@@ -122,8 +122,8 @@ class Task(Model):
     started_at = models.DateTimeField(null=True)
     finished_at = models.DateTimeField(null=True)
 
-    non_fatal_errors = JSONField()
-    result = JSONField(default=[])
+    non_fatal_errors = JSONField(default=list)
+    result = JSONField(default=list)
 
     parent = models.ForeignKey("Task", null=True, related_name="spawned_tasks")
     worker = models.ForeignKey("Worker", null=True, related_name="tasks")

--- a/plugin/pulp/plugin/__init__.py
+++ b/plugin/pulp/plugin/__init__.py
@@ -5,4 +5,4 @@ from .cataloger import Cataloger
 from .publisher import Publisher
 from .importer import Importer
 from .profiler import Profiler
-from .tasking import TaskController
+from .tasking import Task

--- a/plugin/pulp/plugin/tasking.py
+++ b/plugin/pulp/plugin/tasking.py
@@ -1,38 +1,37 @@
-from pulp.app.models import Task
+from pulp.app import models
 from pulp.exceptions import exception_to_dict
 from pulp.tasking import get_current_task_id
 
 
-class TaskController(object):
+class Task(object):
     """
-    An interface to the currently running task.
+    The task which is currently executing.
 
-    With this object you can record non-fatal exceptions as they occur.
+    Attributes:
+        id (str): The task identifier.
 
-    This object is natively task aware. When called inside of a task it will append the non-fatal
-    exception to the currently running task. When called outside of a task a
-    :class: `pulp.app.models.Task.DoesNotExist` Exception is raised.
-
-    Fatal errors should not use this. Instead they should raise an Exception, preferably one that
-    inherits from :class: `pulp.server.exception.PulpException`.
     """
 
-    @classmethod
-    def append_non_fatal_error(cls, error):
+    def __init__(self):
+        self.id = get_current_task_id()
+
+    def append_non_fatal_error(self, error):
         """
         Append and save a non-fatal error for the currently executing task.
+        Fatal errors should not use this. Instead they should raise an Exception,
+        preferably one that inherits from :class: `pulp.server.exception.PulpException`.
 
         This is saved in a structured way to the :attr: `~pulp.app.models.Task.non_fatal_errors`
         attribute on the :class: `~pulp.app.models.Task` model.
 
-        :param error: The non fatal error to be appended.
-        :type error: Exception
+        Args:
+            error (Exception): The non fatal error to be appended.
 
-        :raises :class: `pulp.app.models.Task.DoesNotExist`: If not currently running inside a
-                                                             task.
+        Raises:
+            pulp.app.models.Task.DoesNotExist: If not currently running inside a task.
+
         """
-        task_id = get_current_task_id()
-        task_obj = Task.objects.get(id=task_id)
+        task = models.Task.objects.get(id=self.id)
         serialized_error = exception_to_dict(error)
-        task_obj.non_fatal_errors.append(serialized_error)
-        task_obj.save()
+        task.non_fatal_errors.append(serialized_error)
+        task.save()


### PR DESCRIPTION
The `TaskController` is basically a *procedural* approach and proposing an *object-oriented* alternative.  Appending non-fatal errors is a natural operation on the currently running task.  Proposing a *facade* object that represents the currently running task that supports these operations.

I also noticed the models.Task.non_fatal_errors is expected to be a json document with its root being a list.  But, the field did not have a default=[].  So I added it.  I think this makes sense?

I feel like the docstring could use a little more but not really sure what that needs to be yet.  After the entire plugin API is complete, we should make another pass over them to ensure it's crystal clear to the plugin writer how the API is to be used.