### PR TITLE
Set ALLOWED_HOSTS to allow all hosts by default

### DIFF
--- a/app/pulp/app/settings.py
+++ b/app/pulp/app/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
 import os
-import socket
 import sys
 
 import yaml
@@ -28,7 +27,7 @@ SECRET_KEY = '*u&ouzf)09#*dnm8t9jxahz-y=uwe0g&yn9ir-(lj@l*$cc%qo'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 MEDIA_ROOT = '/var/lib/pulp/content/'
 DEFAULT_FILE_STORAGE = 'pulp.app.models.storage.FileSystem'
@@ -146,7 +145,6 @@ STATIC_URL = '/static/'
 # A set of default settings to use if the configuration file in
 # /etc/pulp/ is missing or if it does not have values for every setting
 _DEFAULT_PULP_SETTINGS = {
-    'allowed_hosts': [socket.getfqdn()],
     # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
     'databases': {
         'default': {


### PR DESCRIPTION
We can revisit this if we want, but for the moment having this set
to `get_fqdn` breaks testing. In particular, it's impossible to use
RequestFactory to generate requests that can be used to test API
Serializers.