### PR TITLE
Remove URL nesting from ViewSet registration

### DIFF
--- a/app/pulp/app/serializers/__init__.py
+++ b/app/pulp/app/serializers/__init__.py
@@ -3,8 +3,7 @@
 # - all can import directly from base and fields if needed
 from pulp.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # NOQA
     ModelSerializer, MasterModelSerializer, viewset_for_model)  # NOQA
-from pulp.app.serializers.fields import (ContentRelatedField, RepositoryNestedIdentityField,  # NOQA
-    RepositoryRelatedField)  # NOQA
+from pulp.app.serializers.fields import (ContentRelatedField, RepositoryRelatedField)  # NOQA
 from pulp.app.serializers.generic import (ConfigKeyValueRelatedField,  # NOQA
     NotesKeyValueRelatedField, ScratchpadKeyValueRelatedField)  # NOQA
 from pulp.app.serializers.consumer import ConsumerSerializer  # NOQA

--- a/app/pulp/app/serializers/fields.py
+++ b/app/pulp/app/serializers/fields.py
@@ -1,5 +1,4 @@
 from rest_framework import serializers
-from rest_framework.reverse import reverse
 
 from pulp.app import models
 from pulp.app.serializers import DetailRelatedField
@@ -19,36 +18,3 @@ class RepositoryRelatedField(serializers.HyperlinkedRelatedField):
     view_name = 'repositories-detail'
     lookup_field = 'name'
     queryset = models.Repository.objects.all()
-
-
-class RepositoryNestedIdentityField(serializers.HyperlinkedIdentityField):
-    """
-    Used to represent an href identity field includes the associated repository name in the url.
-
-    Overrides `get_url` and `get_object` methods. This is necessary because objects that are nested
-    within their related repositories need to be able to generate their identity urls. The base
-    implementation only supports a single url parameter, defined by `lookup_field`. By overriding
-    these methods, we will use the repository name and the object name. In order for this to work,
-    the object's `lookup_field` must be set to `name`.
-    """
-
-    def get_url(self, obj, view_name, request, format):
-        """
-        The parent class's get_url can only use a single kwarg, which is `lookup_field`. This
-        builds a url that includes the associated repository name.
-        """
-        url_kwargs = {
-            'repo_name': obj.repository.name,
-            'name': obj.name
-        }
-        return reverse(view_name, kwargs=url_kwargs, request=request, format=format)
-
-    def get_object(self, view_name, view_args, view_kwargs):
-        """
-        Used to query for an object from its name and associated repository name.
-        """
-        lookup_kwargs = {
-            'repository__name': view_kwargs['repo_name'],
-            'name': view_kwargs['name']
-        }
-        return self.get_queryset().get(**lookup_kwargs)

--- a/app/pulp/app/serializers/repository.py
+++ b/app/pulp/app/serializers/repository.py
@@ -71,17 +71,16 @@ class ImporterSerializer(MasterModelSerializer):
     """
     Every importer defined by a plugin should have an Importer serializer that inherits from this
     class. Please import from `pulp.app.serializers` rather than from this module directly.
-
-    Every subclass must override the `_href` field with a `RepositoryNestedIdentityField` that
-    defines the view_name.
     """
     name = serializers.CharField(
         help_text=_('A name for this importer, unique within the associated repository.')
     )
 
+    repository = RepositoryRelatedField()
+
     class Meta:
         abstract = True
-        fields = MasterModelSerializer.Meta.fields + ('name',)
+        fields = MasterModelSerializer.Meta.fields + ('name', 'repository')
 
 
 class PublisherSerializer(MasterModelSerializer):

--- a/app/pulp/app/viewsets/repository.py
+++ b/app/pulp/app/viewsets/repository.py
@@ -46,8 +46,10 @@ class RepositoryViewSet(NamedModelViewSet):
 
     @decorators.detail_route()
     def importers(self, request, name):
-        # Creates a repositories/<repo>/importers/ endpoint.
-        # This will link to all importers that are associated within the repository.
+        """
+        Creates a nested `importers/` endpoint that returns each importer associated with this
+        repository.
+        """
         repo = self.get_object()
         importers = Importer.objects.filter(repository__name=repo.name)
         paginator = UUIDPagination()
@@ -57,14 +59,9 @@ class RepositoryViewSet(NamedModelViewSet):
 
 
 class ImporterViewSet(NamedModelViewSet):
-    # Indicates that importer urls should be routed through their associated repository.
-    nested_parent = RepositoryViewSet
-    # Name the parameter to generate the link. This is important because `name` in this url refers
-    # to `Importer.name`, not `Repository.name`
-    nested_parent_lookup_name = 'repo_name'
-    endpoint_name = 'importers'
-    serializer_class = ImporterSerializer
     queryset = Importer.objects.all()
+    serializer_class = ImporterSerializer
+    endpoint_name = 'importers'
 
 
 class PublisherViewSet(NamedModelViewSet):


### PR DESCRIPTION
This commit undoes some of the changes in
ff3a0a6404ed17620a0cd63be50c01e62a39b6a0. It removes the nested
routing, but keeps the `ImporerViewSet` and the `importers/` endpoint
in the RepositoryViewSet. 