### PR TITLE
 SELinux permission for celery to change domain object id of files 

### DIFF
--- a/server/selinux/server/pulp-celery.te
+++ b/server/selinux/server/pulp-celery.te
@@ -147,6 +147,10 @@ corenet_tcp_bind_generic_node(celery_t)
 #
 
 selinux_validate_context(celery_t)
+ifdef(`distro_rhel6', `
+    domain_obj_id_change_exemption(celery_t)
+')
+
 
 allow celery_t httpd_sys_rw_content_t:dir relabelto;
 allow celery_t httpd_sys_rw_content_t:file relabelto;


### PR DESCRIPTION
On EL6, calling selinux.restorecon() requires changing the domain object id for the file
whose security context is being restored. This patch provides that permission for celery
on EL6.
    
closes #2387
https://pulp.plan.io/issues/2387
