### PR TITLE
Changes how pulp-selinux RPM decides when to run restorecon statements

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -967,8 +967,8 @@ SELinux policy for Pulp's components
 %pre selinux
 # Record old version so we can limit which restorecon statement are executed later
 test -e %{_localstatedir}/lib/rpm-state/%{name} || mkdir -p %{_localstatedir}/lib/rpm-state/%{name}
-oldversion=$(semodule -l | grep pulp-server)
-echo ${oldversion:12} > %{_localstatedir}/lib/rpm-state/%{name}/old-version
+oldversion=$(rpm -qa pulp-selinux)
+echo ${oldversion:13} > %{_localstatedir}/lib/rpm-state/%{name}/old-version
 
 exit 0
 %post selinux

--- a/server/selinux/server/relabel.sh
+++ b/server/selinux/server/relabel.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
+function version_less_than () {
+# Determines if the version passed in as the first argument is less than the version in the second
+# argument.
+    [[ $(echo -e $1'\n'$2|sort -V|head -n 1) != $2 ]]
+}
+
 # If upgrading from before 2.4.0
-if [[ $1 < '2.4.0' ]]
+if version_less_than $1 '2.4.0'
 then
     /sbin/restorecon -i -R /etc/httpd/conf.d/pulp.conf
     /sbin/restorecon -i -R /etc/pulp
@@ -12,18 +18,18 @@ then
     /sbin/restorecon -i -R /var/log/pulp
 fi
 # If upgrading from before 2.5.0
-if [[ $1 < '2.5.0' ]]
+if version_less_than $1 '2.5.0'
 then
     /sbin/restorecon -i /usr/bin/celery
 fi
 # If upgrading from before 2.7.0
-if [[ $1 < '2.7.0' ]]
+if version_less_than $1 '2.7.0'
 then
     /sbin/restorecon -i -R /var/cache/pulp
     /sbin/restorecon -i -R /var/run/pulp
 fi
 # If upgrading from before 2.8.0
-if [[ $1 < '2.8.0' ]]
+if version_less_than $1 '2.8.0'
 then
     /sbin/restorecon -i -R /usr/share/pulp/wsgi
     /sbin/restorecon -i /usr/bin/pulp_streamer


### PR DESCRIPTION
RHEL 7.3 was experiencing an bug that was preventing the pulp-selinux RPM from using semodule -l to
figure out the installed version of pulp-selinux policies during upgrades.

The other change is in relabel.sh. This change fixed version comparison to account for the fact that
2.10.0 is greater than 2.2.0.

closes #2434
https://pulp.plan.io/issues/2424