### PR TITLE
Update the git commit message section

### DIFF
--- a/docs/dev-guide/contributing/branching.rst
+++ b/docs/dev-guide/contributing/branching.rst
@@ -111,9 +111,42 @@ branch that will need to contain your work.
 Commit Messages
 ---------------
 
-The primary commit in a bug fix should have a log message that starts with
-'<bug_id> - ', for example ``123456 - fixes a silly bug``.
+Commit messages in Pulp should contain a human readable explanation of what
+was fixed in the commit. They should also follow the standard git message
+format of starting with a subject line or title (usually wrapped at about 50
+chars) and optionally, a longer message (usually wrapped at 72 characters)
+broken up into paragraphs. For more on what constitutes a good commit message,
+we recommend `Tim Pope's blog post on the subject
+<http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_.
 
+It's also recommended that every commit message in Pulp reference an issue in
+`Pulp's Redmine issue tracker <https://pulp.plan.io>`_. To do this you should
+use both a keyword and a link to the issue.
+
+To reference the issue (but not change its state), use ``re`` or ``ref``::
+
+    re #123
+    ref #123
+
+To update the issue's state to MODIFIED and set the %done to 100, use
+``fixes`` or ``closes``::
+
+    fixes #123
+    closes #123
+
+You can also reference multiple issues in a commit::
+
+    fixes #123, #124
+
+Putting this altogether, the following is an example of a good commit message::
+
+    Update node install and quickstart
+
+    The nodes install and quickstart was leaving out an important step on
+    the child node to configure the server.conf on the child node.
+
+    closes #1392
+    https://pulp.plan.io/issues/1392
 
 Cherry-picking and Rebasing
 ---------------------------

--- a/docs/dev-guide/contributing/merging.rst
+++ b/docs/dev-guide/contributing/merging.rst
@@ -155,6 +155,5 @@ strategy "ours".
 
 In either case, git's history records that your fix has been applied to each
 branch. Make sure the human-readable description of your fix accurately
-describes its scope. For example, a good commit message would be "Fixed memory
-use issue in ABC system, which was removed in pulp 2.8", or "Fixed a python 2.4
-compatibility issue that is no longer applicable as of pulp 2.8".
+describes its scope. For more on how to write a good commit message, see the
+Commit Messages section of our `branching page </dev-guide/branching>`_.


### PR DESCRIPTION
Update the git commit message section in the docs to include a note about the keywords for referencing a Redmine issue and add some info about what constitutes a good commit message.

closes #103, #1321
https://pulp.plan.io/issues/103
https://pulp.plan.io/issues/1321