### PR TITLE
[Do not merge] Tasking sandbox

### DIFF
--- a/app/pulp/app/settings.py
+++ b/app/pulp/app/settings.py
@@ -183,7 +183,7 @@ _DEFAULT_PULP_SETTINGS = {
         'working_directory': '/var/cache/pulp',
     },
     'broker': {
-        'url': 'qpid://localhost/',
+        'url': 'amqp://localhost/',
         'celery_require_ssl': False,
         'ssl_ca_certificate': '/etc/pki/pulp/qpid/ca.crt',
         'ssl_client_key': '/etc/pki/pulp/qpid/client.crt',

--- a/server/usr/lib/systemd/system/pulp_celerybeat.service
+++ b/server/usr/lib/systemd/system/pulp_celerybeat.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 EnvironmentFile=/etc/default/pulp_celerybeat
 User=apache
 WorkingDirectory=/var/run/pulp/
-ExecStart=/usr/bin/celery beat --app=pulp.tasking.celery_instance.celery --scheduler=pulp.server.async.scheduler.Scheduler
+ExecStart=/usr/bin/celery beat --app=pulp.tasking.celery_instance.celery --scheduler=pulp.tasking.scheduler.Scheduler
 
 [Install]
 WantedBy=multi-user.target

--- a/server/usr/lib/systemd/system/pulp_celerybeat.service
+++ b/server/usr/lib/systemd/system/pulp_celerybeat.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 EnvironmentFile=/etc/default/pulp_celerybeat
 User=apache
 WorkingDirectory=/var/run/pulp/
-ExecStart=/usr/bin/celery beat --app=pulp.tasking.celery_instance.celery --scheduler=pulp.tasking.scheduler.Scheduler
+ExecStart=/usr/bin/celery beat --app=pulp.celery_instance.celery --scheduler=pulp.tasking.scheduler.Scheduler
 
 [Install]
 WantedBy=multi-user.target

--- a/server/usr/lib/systemd/system/pulp_resource_manager.service
+++ b/server/usr/lib/systemd/system/pulp_resource_manager.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 EnvironmentFile=/etc/default/pulp_resource_manager
 User=apache
 WorkingDirectory=/var/run/pulp/
-ExecStart=/usr/bin/celery worker -A pulp.tasking.celery_app -n resource_manager@%%h\
+ExecStart=/usr/bin/celery worker -A pulp.celery_app -n resource_manager@%%h\
           -Q resource_manager -c 1 --events --umask 18 --pidfile=/var/run/pulp/resource_manager.pid\
           --heartbeat-interval=30
 

--- a/server/usr/lib/systemd/system/pulp_workers.service
+++ b/server/usr/lib/systemd/system/pulp_workers.service
@@ -7,8 +7,8 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/var/run/pulp/
-ExecStart=/usr/bin/python -m  pulp.tasking.manage_workers start
-ExecStop=/usr/bin/python -m  pulp.tasking.manage_workers stop
+ExecStart=/usr/bin/python3 -m  pulp.tasking.manage_workers start
+ExecStop=/usr/bin/python3 -m  pulp.tasking.manage_workers stop
 
 [Install]
 WantedBy=multi-user.target

--- a/server/usr/lib/systemd/system/pulp_workers.service
+++ b/server/usr/lib/systemd/system/pulp_workers.service
@@ -7,8 +7,8 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/var/run/pulp/
-ExecStart=/usr/bin/python3 -m  pulp.tasking.manage_workers start
-ExecStop=/usr/bin/python3 -m  pulp.tasking.manage_workers stop
+ExecStart=/usr/bin/python3 -m  pulp.manage_workers start
+ExecStop=/usr/bin/python3 -m  pulp.manage_workers stop
 
 [Install]
 WantedBy=multi-user.target

--- a/tasking/pulp/celery_app.py
+++ b/tasking/pulp/celery_app.py
@@ -11,6 +11,11 @@ import sys
 import time
 from gettext import gettext as _
 
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", 'pulp.app.settings')
+import django
+django.setup()
+
 from celery.signals import celeryd_after_setup
 from django.db.utils import IntegrityError
 
@@ -19,10 +24,10 @@ from pulp.tasking import delete_worker, storage
 from pulp.tasking.constants import TASKING_CONSTANTS
 
 # This import is here so that Celery will find our application instance
-from pulp.tasking.celery_instance import celery  # noqa
+from pulp.celery_instance import celery  # noqa
 
 # This import is here so Celery will discover all tasks
-import pulp.tasking.registry  # noqa
+import pulp.tasking.registry # noqa
 
 
 _logger = logging.getLogger(__name__)

--- a/tasking/pulp/celery_instance.py
+++ b/tasking/pulp/celery_instance.py
@@ -3,13 +3,12 @@ import ssl
 
 from celery import Celery
 
-from pulp.app import settings
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", 'pulp.app.settings')
+
+from django.conf import settings
 
 broker_url = settings.BROKER['url']
 celery = Celery('tasks', broker=broker_url)
-
 
 DEDICATED_QUEUE_EXCHANGE = 'C.dq'
 RESOURCE_MANAGER_QUEUE = 'resource_manager'
@@ -18,7 +17,7 @@ CELERYBEAT_SCHEDULE = {
 
 
 celery.conf.update(CELERYBEAT_SCHEDULE=CELERYBEAT_SCHEDULE)
-celery.conf.update(CELERYBEAT_SCHEDULER='pulp.server.async.scheduler.Scheduler')
+celery.conf.update(CELERYBEAT_SCHEDULER='pulp.tasking.scheduler.Scheduler')
 celery.conf.update(CELERY_WORKER_DIRECT=True)
 celery.conf.update(CELERY_TASK_SERIALIZER='json')
 celery.conf.update(CELERY_ACCEPT_CONTENT=['json'])

--- a/tasking/pulp/manage_workers.py
+++ b/tasking/pulp/manage_workers.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", 'pulp.app.settings')
 
 _ENVIRONMENT_FILE = os.path.join('/', 'etc', 'default', 'pulp_workers')
 _SYSTEMD_UNIT_PATH = os.path.join('/', 'run', 'systemd', 'system')
@@ -20,7 +21,7 @@ After=network.target
 EnvironmentFile=%(environment_file)s
 User=apache
 WorkingDirectory=/var/run/pulp/
-ExecStart=/usr/bin/celery worker -n reserved_resource_worker-%(num)s@%%%%h -A pulp.server.async.app\
+ExecStart=/usr/bin/celery worker -n reserved_resource_worker-%(num)s@%%%%h -A pulp.celery_app\
           -c 1 --events --umask 18 --pidfile=/var/run/pulp/reserved_resource_worker-%(num)s.pid\
           --heartbeat-interval=30 %(max_tasks_argument)s
 KillSignal=SIGQUIT

--- a/tasking/pulp/tasking/base.py
+++ b/tasking/pulp/tasking/base.py
@@ -15,8 +15,8 @@ from pulp.app.models import ReservedResource, Task as TaskStatus, TaskLock, Work
 from pulp.common import TASK_FINAL_STATES, TASK_INCOMPLETE_STATES, TASK_STATES
 from pulp.exceptions import MissingResource, PulpException
 from pulp.tasking import storage
-from pulp.tasking.celery_instance import celery
-from pulp.tasking.celery_instance import DEDICATED_QUEUE_EXCHANGE, RESOURCE_MANAGER_QUEUE
+from pulp.celery_instance import celery
+from pulp.celery_instance import DEDICATED_QUEUE_EXCHANGE, RESOURCE_MANAGER_QUEUE
 from pulp.tasking.constants import TASKING_CONSTANTS
 
 celery_controller = control.Control(app=celery)

--- a/tasking/pulp/tasking/base.py
+++ b/tasking/pulp/tasking/base.py
@@ -8,6 +8,7 @@ from gettext import gettext as _
 from celery import Task as CeleryTask, current_task, task
 from celery.app import control
 from celery.result import AsyncResult
+from django.db import transaction
 from django.db.models import Count
 
 from pulp.app.models import ReservedResource, Task as TaskStatus, TaskLock, Worker
@@ -141,16 +142,19 @@ def delete_worker(name, normal_shutdown=False):
         msg = msg % {'name': name}
         _logger.error(msg)
 
-    worker = Worker.objects.get(name=name)
+    try:
+        worker = Worker.objects.get(name=name)
+    except Worker.DoesNotExist:
+        pass
+    else:
+        # Cancel all of the tasks that were assigned to this worker's queue
+        for task_status in worker.tasks.filter(state__in=TASK_INCOMPLETE_STATES):
+            cancel(task_status.pk)
 
-    # Cancel all of the tasks that were assigned to this worker's queue
-    for task_status in worker.tasks.filter(state__in=TASK_INCOMPLETE_STATES):
-        cancel(task_status.pk)
+        worker.delete()
 
-    worker.delete()
-
-    if name.startswith(TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME):
-        TaskLock.objects.filter(name=name).delete()
+        if name.startswith(TASKING_CONSTANTS.RESOURCE_MANAGER_WORKER_NAME):
+            TaskLock.objects.filter(name=name).delete()
 
 
 @task(base=PulpTask)
@@ -180,7 +184,7 @@ def _release_resource(task_id):
 
         new_task.on_failure(runtime_exception, task_id, (), {}, MyEinfo)
 
-    ReservedResource.objects.get(task__pk=task_id).delete()
+    ReservedResource.objects.filter(task__pk=task_id).delete()
 
 
 class UserFacingTask(PulpTask):
@@ -247,11 +251,14 @@ class UserFacingTask(PulpTask):
         group_id = kwargs.get('group_id', None)
 
         # Set the parent attribute if being dispatched inside of a Task
-        parent_arg = self._get_parent_arg
+        parent_arg = self._get_parent_arg()
 
         # Create a new task status with the task id and tags.
-        TaskStatus.objects.create(pk=inner_task_id, state=TaskStatus.WAITING, tags=tag_list,
-                                  group=group_id, **parent_arg)
+        with transaction.atomic():
+            task_status = TaskStatus.objects.create(pk=async_result.id, state=TaskStatus.WAITING,
+                                                    group=group_id, **parent_arg)
+            for tag in tag_list:
+                task_status.tags.create(name=tag)
 
         # Call the outer task which is a promise to call the real task when it can.
         _queue_reserved_task.apply_async(args=[task_name, inner_task_id, resource_id, args, kwargs],
@@ -285,11 +292,15 @@ class UserFacingTask(PulpTask):
         async_result.tags = tag_list
 
         # Set the parent attribute if being dispatched inside of a Task
-        parent_arg = self._get_parent_arg
+        parent_arg = self._get_parent_arg()
 
         # Create a new task status with the task id and tags.
-        TaskStatus.objects.create(pk=async_result.id, state=TaskStatus.WAITING, tags=tag_list,
-                                  group=group_id, **parent_arg)
+        with transaction.atomic():
+            task_status = TaskStatus.objects.create(pk=async_result.id, state=TaskStatus.WAITING,
+                                                    group=group_id, **parent_arg)
+            for tag in tag_list:
+                task_status.tags.create(name=tag)
+
         return async_result
 
     def __call__(self, *args, **kwargs):

--- a/tasking/pulp/tasking/registry.py
+++ b/tasking/pulp/tasking/registry.py
@@ -1,3 +1,4 @@
 """
 Any Celery task imported here will be known to Pulp
 """
+from pulp.tasking.tasks.repository import delete_publisher

--- a/tasking/pulp/tasking/scheduler.py
+++ b/tasking/pulp/tasking/scheduler.py
@@ -11,7 +11,7 @@ from django.db import IntegrityError
 
 from pulp.app.models.task import TaskLock, Worker
 from pulp.tasking import worker_watcher
-from pulp.tasking.celery_instance import celery as app
+from pulp.celery_instance import celery as app
 from pulp.tasking.constants import TASKING_CONSTANTS as constants
 from pulp.tasking import delete_worker
 

--- a/tasking/pulp/tasking/scheduler.py
+++ b/tasking/pulp/tasking/scheduler.py
@@ -258,7 +258,7 @@ class Scheduler(beat.Scheduler):
                           % {'celerybeat_name': self.celerybeat_name})
             ret = self.call_tick(self, self.celerybeat_name)
         except TaskLock.DoesNotExist:
-            TaskLock.objects.get(name=self.celerybeat_name, timestamp__lte=old_timestamp).delete()
+            TaskLock.objects.filter(name=self.celerybeat_name, timestamp__lte=old_timestamp).delete()
             try:
                 # Insert new lock entry
                 TaskLock.objects.create(name=self.celerybeat_name, lock=TaskLock.CELERY_BEAT)

--- a/tasking/pulp/tasking/tasks/repository.py
+++ b/tasking/pulp/tasking/tasks/repository.py
@@ -1,0 +1,8 @@
+from celery import task
+
+from pulp.app.models import Publisher
+from pulp.tasking import UserFacingTask
+
+@task(base=UserFacingTask)
+def delete_publisher(repo_name, publisher_name):
+     Publisher.objects.filter(name=publisher_name, repository__name=repo_name).delete()


### PR DESCRIPTION
Workaround to avoid app label issue and start playing with tasks.

You would need to switch to RabbitMQ.
`sudo dnf install rabbitmq-server`
To use the default port for broker, stop/disable Qpid and start/enable RabbitMQ:
`sudo systemctl disable qpidd --now`
`sudo systemctl status rabbitmq-server`
Then change broker_url either in settings.py (as in PR), or in server.yaml config.
Start pulp_workers/celerybeat/resource_manager in a usual way via `systemctl` (find modified startup scripts in this PR).
Run `python manage.py shell` and try something out and continue the journey:
```
from pulp.tasking.registry import delete_publisher
delete_publisher.apply_async(...)
```
or
`delete_publisher.apply_async_with_reservation(...)`

Current status:
 - workers/resource_manager/celerybeat run and [almost] work
 - tasks can be dispatched but they are not handled well all the way

This is where I am so far. This is just to share where I am now. Feel free to join anytime ;)