### PR TITLE
Task.result is allowed to be null

### DIFF
--- a/app/pulp/app/models/task.py
+++ b/app/pulp/app/models/task.py
@@ -123,7 +123,7 @@ class Task(Model):
     finished_at = models.DateTimeField(null=True)
 
     non_fatal_errors = JSONField(default=list)
-    result = JSONField(default=list)
+    result = JSONField(null=True)
 
     parent = models.ForeignKey("Task", null=True, related_name="spawned_tasks")
     worker = models.ForeignKey("Worker", null=True, related_name="tasks")


### PR DESCRIPTION
It was given a default value recently, but that turned out to not be the best
option. There is no value in forcing this to be a list. Some tasks will return
other types, and some will only return None.