### PR TITLE
Small fixes for tasking

### DIFF
--- a/app/pulp/app/settings.py
+++ b/app/pulp/app/settings.py
@@ -184,7 +184,7 @@ _DEFAULT_PULP_SETTINGS = {
         'working_directory': '/var/cache/pulp',
     },
     'broker': {
-        'url': 'qpid://localhost/',
+        'url': 'amqp://guest@localhost//',
         'celery_require_ssl': False,
         'ssl_ca_certificate': '/etc/pki/pulp/qpid/ca.crt',
         'ssl_client_key': '/etc/pki/pulp/qpid/client.crt',

--- a/tasking/pulp/__init__.py
+++ b/tasking/pulp/__init__.py
@@ -1,0 +1,2 @@
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
- adds a missing __init__.py
- switches default to RabbitMQ temporarily until the
  Qpid transport is Python 3.4 compatible