### PR TITLE
Adds exception handling for when SELinux is disabled on EL7

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -905,7 +905,7 @@ class AtomicDirectoryPublishStep(PluginStep):
             try:
                 selinux.restorecon(timestamp_master_dir.encode('utf-8'), recursive=True)
             except OSError as e:
-                if e.errno != errno.EPERM:
+                if e.errno not in [errno.EPERM, errno.ENODATA]:
                     raise
         except OSError as e:
             if e.errno == errno.EXDEV:


### PR DESCRIPTION
On EL7, restorecon calls out to lgetfilecon which raises an exception when
SELinux security context labels are not available.

https://www.gnu.org/software/gnulib/manual/html_node/lgetfilecon.html