### PR TITLE
Fixes relabel.sh to handle empty string being passed in.

### DIFF
--- a/server/selinux/server/relabel.sh
+++ b/server/selinux/server/relabel.sh
@@ -6,6 +6,12 @@ function version_less_than () {
     [[ $(echo -e $1'\n'$2|sort -V|head -n 1) != $2 ]]
 }
 
+# Set the previous version to 0.0 if one is not passed in
+if [ -z $1 ]
+then
+    set -- "0.0"
+fi
+
 # If upgrading from before 2.4.0
 if version_less_than $1 '2.4.0'
 then


### PR DESCRIPTION
The new version comparison mechanism no longer handled an empty string being passed in.
As a result none of the restorecon statements were getting run at the end of pulp-selinux
installation.

closes #2436
https://pulp.plan.io/issues/2436