### PR TITLE
Adds release note about EL6 for 2.11

### DIFF
--- a/docs/user-guide/authentication.rst
+++ b/docs/user-guide/authentication.rst
@@ -22,7 +22,7 @@ using the ``pulp-admin auth user`` commands.
 Once an apache authorization module is configured, pulp will read and trust the
 ``REMOTE_USER`` variable from apache.
 
-.. note:
+.. note::
 
     Enabling apache preauthentication as described below *disables* authorization
     against the built-in user database, so you will not be able to authenticate

--- a/docs/user-guide/installation/index.rst
+++ b/docs/user-guide/installation/index.rst
@@ -74,6 +74,7 @@ Pulp stores its content in ``/var/lib/pulp``. The size requirements of this
 directory vary depending on how much content you wish to download.
 
 .. note::
+
    Making ``/var/lib/pulp`` a symbolic link to a different directory is possible,
    but it is recommended that you use a bind mount instead. As of Pulp 2.8.0, using
    a symbolic link requires you modify an Apache configuration. This configuration

--- a/docs/user-guide/release-notes/2.11.x.rst
+++ b/docs/user-guide/release-notes/2.11.x.rst
@@ -2,6 +2,19 @@
 Pulp 2.11 Release Notes
 =======================
 
+EL6 Support Changes
+===================
+
+The 2.11 releases are the last releases with support for deploying Pulp itself on EL6. This does not
+change the use cases of running ``pulp-agent`` on EL6 or whether Pulp can sync and publish EL6
+repositories, which will still be supported.
+
+In preparation for 2.12+, EL6 users are encouraged to upgrade their Pulp environments to EL7. See
+the `mailing discussion <https://www.redhat.com/archives/pulp-list/2016-November/msg00022.html>`_ or
+the `blog post <http://pulpproject.org/2016/11/17/django14-epel6-retirement/>`_ for background and
+motivation of this decision.
+
+
 Pulp 2.11.0
 ===========
 


### PR DESCRIPTION
2.11 is the last release supporting EL6. This commit adds
a release note for that.