### PR TITLE
Fixes the Pulp tasking system

### DIFF
--- a/tasking/pulp/tasking/celery_instance.py
+++ b/tasking/pulp/tasking/celery_instance.py
@@ -11,7 +11,7 @@ broker_url = settings.BROKER['url']
 celery = Celery('tasks', broker=broker_url)
 
 
-DEDICATED_QUEUE_EXCHANGE = 'C.dq'
+DEDICATED_QUEUE_EXCHANGE = 'C.dq2'
 RESOURCE_MANAGER_QUEUE = 'resource_manager'
 CELERYBEAT_SCHEDULE = {
 }


### PR DESCRIPTION
This PR introduces three fixes:

- Updates the Celery dedicated queue name to be 'C.dq2'.
  This is a Celery backwards incompatible change so
  Pulp3 is only compatible with Celery 4.0.

- Fixes a bug in the worker selection which was dispatching
  work to non-dedicated workers.

- Resolves a traceback where a TaskStatus was being created
  twice during normal reserved task execution.

https://pulp.plan.io/issues/2440
re #2440