### PR TITLE
Update pulp-manage-db to handle default answer, closes #2467

### DIFF
--- a/server/pulp/server/db/manage.py
+++ b/server/pulp/server/db/manage.py
@@ -294,4 +294,7 @@ def _start_logging():
 
 def _user_input_continue(question):
     reply = str(raw_input(_(question + ' (y/N): '))).lower().strip()
-    return reply[0] == 'y'
+    try:
+        return reply[0] == 'y'
+    except IndexError:
+        return False


### PR DESCRIPTION
Default to no when any input is given for the continue question when running
pulp-manage-db.

I did some testing and the new condition works:

```python
>>> not len(a) == 0 and a[0] == 'y'
False
>>> a='n'; not len(a) == 0 and a[0] == 'y'
False
>>> a=''; not len(a) == 0 and a[0] == 'y'
False
>>> a='y'; not len(a) == 0 and a[0] == 'y'
True
>>> a='    '; not len(a) == 0 and a[0] == 'y'
False
```

Fixes https://pulp.plan.io/issues/2467