### PR TITLE
Put only model imports into callables in pulp.tasking

### DIFF
--- a/tasking/pulp/tasking/celery_app.py
+++ b/tasking/pulp/tasking/celery_app.py
@@ -20,7 +20,7 @@ from django.db.utils import IntegrityError
 from pulp.tasking.celery_instance import celery  # noqa
 from pulp.tasking.constants import TASKING_CONSTANTS
 from pulp.tasking.services import storage
-
+from pulp.tasking.services.worker_watcher import delete_worker
 
 celery.autodiscover_tasks()
 
@@ -69,8 +69,6 @@ def initialize_worker(sender, instance, **kwargs):
     :param kwargs:   Other params (unused)
     :type  kwargs:   dict
     """
-    from pulp.tasking.services.worker_watcher import delete_worker
-
     # Delete any potential old state
     delete_worker(sender, normal_shutdown=True)
 

--- a/tasking/pulp/tasking/services/worker_watcher.py
+++ b/tasking/pulp/tasking/services/worker_watcher.py
@@ -17,7 +17,6 @@ from datetime import datetime
 from gettext import gettext as _
 import logging
 
-from pulp.app.models import Worker, TaskLock
 from pulp.common import TASK_INCOMPLETE_STATES
 from pulp.tasking.constants import TASKING_CONSTANTS
 from pulp.tasking.util import cancel
@@ -72,6 +71,8 @@ def handle_worker_heartbeat(event):
     :param event: A celery event to handle.
     :type event: dict
     """
+    from pulp.app.models import Worker
+
     event_info = _parse_and_log_event(event)
     existing_worker, created = Worker.objects.get_or_create(name=event_info['worker_name'])
     if created:
@@ -121,6 +122,8 @@ def delete_worker(name, normal_shutdown=False):
                             False.
     :type normal_shutdown:  bool
     """
+    from pulp.app.models import Worker, TaskLock
+
     if not normal_shutdown:
         msg = _('The worker named %(name)s is missing. Canceling the tasks in its queue.')
         msg = msg % {'name': name}

--- a/tasking/pulp/tasking/util.py
+++ b/tasking/pulp/tasking/util.py
@@ -5,7 +5,6 @@ import logging
 from celery import current_app, current_task
 from celery.app import control
 
-from pulp.app.models import Task
 from pulp.common import TASK_FINAL_STATES
 from pulp.exceptions import MissingResource, PulpException
 
@@ -26,6 +25,8 @@ def cancel(task_id):
 
     :raises MissingResource: if a task with given task_id does not exist
     """
+    from pulp.app.models import Task
+
     try:
         task_status = Task.objects.get(pk=task_id)
     except Task.DoesNotExist:


### PR DESCRIPTION
re #2440
https://pulp.plan.io/issues/2440

This is just a proposal for what we discussed some time ago, @bmbouter, @mhrivnak .
Just for style consistency the suggestion is to put only model imports inside callables. 
This `delete_worker` import is the last  one violating this approach.

If you disagree, feel free to close this PR.