### PR TITLE
Deprecate Pulp nodes

### DIFF
--- a/docs/user-guide/nodes.rst
+++ b/docs/user-guide/nodes.rst
@@ -3,6 +3,14 @@
 Nodes
 =====
 
+.. warning::
+
+  As of Pulp 2.12, Pulp Nodes is deprecated and will be removed in Pulp 3.0.
+  Instead, users can set up a separate Pulp instance and sync content to this
+  instance using Pulp's built-in publish+sync functionality. For more
+  information, see `our blog post on the subject of deprecating Nodes
+  <http://pulpproject.org/2016/12/07/deprecating-nodes/>`_.
+
 Overview
 --------
 

--- a/docs/user-guide/release-notes/2.12.x.rst
+++ b/docs/user-guide/release-notes/2.12.x.rst
@@ -9,3 +9,11 @@ New Features
 ------------
 
  * Task profiling can now be enabled. This will use cProfiling on an individual task and write the profile to a directory for a given task. While this can impact performance, this can enable users to get some insight into what a task is doing or use the output to give to a developer for debugging.
+
+Deprecation
+-----------
+
+* Pulp Nodes is now deprecated and will be removed in Pulp 3.0. Users can use a
+  Pulp instance and sync repositories to this instance from their main Pulp
+  instance instead. For more information, see `our blog post on the subject of
+  deprecating Nodes <http://pulpproject.org/2016/12/06/deprecating-nodes/>`_.

--- a/nodes/child/pulp_node/handlers/handler.py
+++ b/nodes/child/pulp_node/handlers/handler.py
@@ -1,11 +1,13 @@
 from logging import getLogger
+import warnings
 
 from pulp.agent.lib.handler import ContentHandler
 from pulp.agent.lib.report import ContentReport
 
 from pulp_node import constants
 from pulp_node import resources
-from pulp_node.error import GetBindingsError
+from pulp_node.error import GetBindingsError, NodeDeprecationWarning, \
+    TASK_DEPRECATION_WARNING
 from pulp_node.handlers.model import RepositoryBinding
 from pulp_node.handlers.reports import HandlerProgress, SummaryReport
 from pulp_node.handlers.strategies import find_strategy, Request
@@ -64,6 +66,8 @@ class NodeHandler(ContentHandler):
         :return: An update report.
         :rtype: ContentReport
         """
+        warnings.warn(TASK_DEPRECATION_WARNING, NodeDeprecationWarning)
+
         handler_report = ContentReport()
         summary_report = SummaryReport()
         progress_report = HandlerProgress(conduit)
@@ -135,6 +139,8 @@ class RepositoryHandler(ContentHandler):
         :return: An update report.
         :rtype: ContentReport
         """
+        warnings.warn(TASK_DEPRECATION_WARNING, NodeDeprecationWarning)
+
         summary_report = SummaryReport()
         progress_report = HandlerProgress(conduit)
         repo_ids = [key['repo_id'] for key in units if key]

--- a/nodes/child/pulp_node/handlers/model.py
+++ b/nodes/child/pulp_node/handlers/model.py
@@ -10,6 +10,7 @@ the responsibility of the nodes importers.
 
 import httplib
 from logging import getLogger
+import warnings
 
 from pulp.bindings.exceptions import NotFoundException
 from pulp.common.bundle import Bundle
@@ -17,7 +18,8 @@ from pulp.common.plugins import importer_constants
 
 from pulp_node import constants
 from pulp_node import resources
-from pulp_node.error import PurgeOrphansError, RepoSyncRestError, GetBindingsError
+from pulp_node.error import GetBindingsError, NodeDeprecationWarning, \
+    PurgeOrphansError, RepoSyncRestError, TASK_DEPRECATION_WARNING
 from pulp_node.poller import TaskPoller
 
 
@@ -47,6 +49,8 @@ class Entity(object):
         """
         Purge orphaned units within the inventory.
         """
+        warnings.warn(TASK_DEPRECATION_WARNING, NodeDeprecationWarning)
+
         bindings = resources.pulp_bindings()
         http = bindings.content_orphan.remove_all()
         if http.response_code != httplib.ACCEPTED:
@@ -267,6 +271,8 @@ class Repository(Entity):
         :type options: dict
         :return: The task result.
         """
+        warnings.warn(TASK_DEPRECATION_WARNING, NodeDeprecationWarning)
+
         bindings = resources.pulp_bindings()
         poller = TaskPoller(bindings)
         max_download = options.get(

--- a/nodes/child/pulp_node/importers/http/importer.py
+++ b/nodes/child/pulp_node/importers/http/importer.py
@@ -14,6 +14,7 @@
 from logging import getLogger
 from gettext import gettext as _
 from threading import Event
+import warnings
 
 from nectar.downloaders.threaded import HTTPThreadedDownloader as Downloader
 
@@ -22,7 +23,8 @@ from pulp.plugins.importer import Importer
 from pulp.plugins.util.nectar_config import importer_config_to_nectar_config
 
 from pulp_node import constants
-from pulp_node.error import CaughtException
+from pulp_node.error import CaughtException, NodeDeprecationWarning, \
+    TASK_DEPRECATION_WARNING
 from pulp_node.reports import RepositoryProgress
 from pulp_node.importers.reports import SummaryReport, ProgressListener
 from pulp_node.importers.strategies import find_strategy, Request
@@ -116,6 +118,8 @@ class NodesHttpImporter(Importer):
         :return: A report describing the result.
         :rtype: pulp.server.plugins.model.SyncReport
         """
+        warnings.warn(TASK_DEPRECATION_WARNING, NodeDeprecationWarning)
+
         summary_report = SummaryReport()
         downloader = None
 

--- a/nodes/common/pulp_node/error.py
+++ b/nodes/common/pulp_node/error.py
@@ -1,5 +1,13 @@
 from gettext import gettext as _
 
+CLI_DEPRECATION_WARNING = \
+    _('Warning: this Nodes command is deprecated as the Nodes functionality will be '
+      'removed from Pulp 3.0.')
+
+TASK_DEPRECATION_WARNING = \
+    _('Warning: this Nodes task is deprecated as the Nodes functionality will be '
+      'removed from Pulp 3.0.')
+
 
 class NodeError(Exception):
 
@@ -220,3 +228,7 @@ class ErrorList(list):
         """
         for e in self:
             e.details.update(details)
+
+
+class NodeDeprecationWarning(Warning):
+    pass

--- a/nodes/extensions/admin/pulp_node/extensions/admin/commands.py
+++ b/nodes/extensions/admin/pulp_node/extensions/admin/commands.py
@@ -12,6 +12,7 @@ from pulp.client.commands.options import OPTION_REPO_ID, OPTION_CONSUMER_ID
 from pulp.client.commands.repo.cudl import ListRepositoriesCommand
 
 from pulp_node import constants
+from pulp_node.error import CLI_DEPRECATION_WARNING
 from pulp_node.extension import (missing_resources, node_activated, repository_enabled,
                                  ensure_node_section)
 from pulp_node.extensions.admin import sync_schedules
@@ -174,6 +175,10 @@ class NodeListCommand(ConsumerListCommand):
             repo_ids.append(repo_id)
         consumer[key] = formatted
 
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeListCommand, self).run(**kwargs)
+
 
 class NodeListRepositoriesCommand(ListRepositoriesCommand):
 
@@ -195,6 +200,10 @@ class NodeListRepositoriesCommand(ListRepositoriesCommand):
                     enabled.append(repository)
         return enabled
 
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeListRepositoriesCommand, self).run(**kwargs)
+
 
 # --- publishing -------------------------------------------------------------
 
@@ -205,6 +214,7 @@ class NodeRepoPublishCommand(PollingCommand):
         self.add_option(OPTION_REPO_ID)
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
         repo_id = kwargs[OPTION_REPO_ID.keyword]
 
         if not repository_enabled(self.context, repo_id):
@@ -243,6 +253,7 @@ class NodeActivateCommand(PulpCliCommand):
         self.context = context
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
 
         consumer_id = kwargs[OPTION_CONSUMER_ID.keyword]
         strategy = kwargs[STRATEGY_OPTION.keyword]
@@ -279,6 +290,7 @@ class NodeDeactivateCommand(PulpCliCommand):
         self.context = context
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
 
         consumer_id = kwargs[NODE_ID_OPTION.keyword]
         delta = {'notes': {constants.NODE_NOTE_KEY: None, constants.STRATEGY_NOTE_KEY: None}}
@@ -312,6 +324,7 @@ class NodeRepoEnableCommand(PulpCliCommand):
         self.context = context
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
 
         convert_boolean_arguments([AUTO_PUBLISH_OPTION.keyword], kwargs)
 
@@ -353,6 +366,7 @@ class NodeRepoDisableCommand(PulpCliCommand):
         self.context = context
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
 
         repo_id = kwargs[OPTION_REPO_ID.keyword]
 
@@ -400,6 +414,7 @@ class NodeBindCommand(BindingCommand):
         self.context = context
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
 
         repo_id = kwargs[OPTION_REPO_ID.keyword]
         node_id = kwargs[NODE_ID_OPTION.keyword]
@@ -442,6 +457,7 @@ class NodeUnbindCommand(BindingCommand):
         self.context = context
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
 
         repo_id = kwargs[OPTION_REPO_ID.keyword]
         node_id = kwargs[NODE_ID_OPTION.keyword]
@@ -473,6 +489,7 @@ class NodeUpdateCommand(PollingCommand):
         self.tracker = ProgressTracker(self.context.prompt)
 
     def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
         node_id = kwargs[NODE_ID_OPTION.keyword]
         max_bandwidth = kwargs[MAX_BANDWIDTH_OPTION.keyword]
         max_concurrency = kwargs[MAX_CONCURRENCY_OPTION.keyword]

--- a/nodes/extensions/admin/pulp_node/extensions/admin/sync_schedules.py
+++ b/nodes/extensions/admin/pulp_node/extensions/admin/sync_schedules.py
@@ -5,6 +5,7 @@ from pulp.client.commands.schedule import (
     UpdateScheduleCommand, NextRunCommand, ScheduleStrategy)
 
 from pulp_node import constants
+from pulp_node.error import CLI_DEPRECATION_WARNING
 from pulp_node.extensions.admin.options import (NODE_ID_OPTION, MAX_BANDWIDTH_OPTION,
                                                 MAX_CONCURRENCY_OPTION)
 
@@ -25,6 +26,10 @@ class NodeListScheduleCommand(ListScheduleCommand):
         super(self.__class__, self).__init__(context, strategy, description=DESC_LIST)
         self.add_option(NODE_ID_OPTION)
 
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeListScheduleCommand, self).run(**kwargs)
+
 
 class NodeCreateScheduleCommand(CreateScheduleCommand):
     def __init__(self, context):
@@ -34,12 +39,20 @@ class NodeCreateScheduleCommand(CreateScheduleCommand):
         self.add_option(MAX_BANDWIDTH_OPTION)
         self.add_option(MAX_CONCURRENCY_OPTION)
 
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeCreateScheduleCommand, self).run(**kwargs)
+
 
 class NodeDeleteScheduleCommand(DeleteScheduleCommand):
     def __init__(self, context):
         strategy = NodeSyncScheduleStrategy(context)
         super(self.__class__, self).__init__(context, strategy, description=DESC_DELETE)
         self.add_option(NODE_ID_OPTION)
+
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeDeleteScheduleCommand, self).run(**kwargs)
 
 
 class NodeUpdateScheduleCommand(UpdateScheduleCommand):
@@ -48,12 +61,20 @@ class NodeUpdateScheduleCommand(UpdateScheduleCommand):
         super(self.__class__, self).__init__(context, strategy, description=DESC_UPDATE)
         self.add_option(NODE_ID_OPTION)
 
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeUpdateScheduleCommand, self).run(**kwargs)
+
 
 class NodeNextRunCommand(NextRunCommand):
     def __init__(self, context):
         strategy = NodeSyncScheduleStrategy(context)
         super(self.__class__, self).__init__(context, strategy, description=DESC_NEXT_RUN)
         self.add_option(NODE_ID_OPTION)
+
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeNextRunCommand, self).run(**kwargs)
 
 
 class NodeSyncScheduleStrategy(ScheduleStrategy):
@@ -94,3 +115,7 @@ class NodeSyncScheduleStrategy(ScheduleStrategy):
     def update_schedule(self, schedule_id, **kwargs):
         node_id = kwargs.pop(NODE_ID_OPTION.keyword)
         return self.api.update_schedule(SYNC_OPERATION, node_id, schedule_id, **kwargs)
+
+    def run(self, **kwargs):
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+        super(NodeSyncScheduleStrategy, self).run(**kwargs)

--- a/nodes/extensions/consumer/pulp_node/extensions/consumer/commands.py
+++ b/nodes/extensions/consumer/pulp_node/extensions/consumer/commands.py
@@ -10,6 +10,7 @@ from pulp.client.commands.options import OPTION_REPO_ID
 from pulp.client.consumer_utils import load_consumer_id
 
 from pulp_node import constants
+from pulp_node.error import CLI_DEPRECATION_WARNING
 from pulp_node.extension import ensure_node_section, node_activated, repository_enabled
 from pulp_node.extension import missing_resources
 
@@ -89,6 +90,8 @@ class NodeActivateCommand(PulpCliCommand):
 
     def run(self, **kwargs):
 
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+
         consumer_id = load_consumer_id(self.context)
         strategy = kwargs[STRATEGY_OPTION.keyword]
         delta = {'notes': {constants.NODE_NOTE_KEY: True, constants.STRATEGY_NOTE_KEY: strategy}}
@@ -121,6 +124,8 @@ class NodeDeactivateCommand(PulpCliCommand):
         self.context = context
 
     def run(self, **kwargs):
+
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
 
         consumer_id = load_consumer_id(self.context)
         delta = {'notes': {constants.NODE_NOTE_KEY: None, constants.STRATEGY_NOTE_KEY: None}}
@@ -170,6 +175,8 @@ class NodeBindCommand(BindingCommand):
 
     def run(self, **kwargs):
 
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
+
         repo_id = kwargs[OPTION_REPO_ID.keyword]
         node_id = load_consumer_id(self.context)
         dist_id = constants.HTTP_DISTRIBUTOR
@@ -211,6 +218,7 @@ class NodeUnbindCommand(BindingCommand):
 
     def run(self, **kwargs):
 
+        self.context.prompt.render_warning_message(CLI_DEPRECATION_WARNING)
         repo_id = kwargs[OPTION_REPO_ID.keyword]
         node_id = load_consumer_id(self.context)
         dist_id = constants.HTTP_DISTRIBUTOR

--- a/nodes/parent/pulp_node/distributors/http/distributor.py
+++ b/nodes/parent/pulp_node/distributors/http/distributor.py
@@ -3,6 +3,7 @@
 from gettext import gettext as _
 from logging import getLogger
 import os
+import warnings
 
 from pulp.plugins.distributor import Distributor
 from pulp.server.db import model
@@ -13,6 +14,7 @@ from pulp_node import constants
 from pulp_node import pathlib
 from pulp_node.conduit import NodesConduit
 from pulp_node.distributors.http.publisher import HttpPublisher
+from pulp_node.error import TASK_DEPRECATION_WARNING, NodeDeprecationWarning
 
 
 _logger = getLogger(__name__)
@@ -101,6 +103,8 @@ class NodesHttpDistributor(Distributor):
         :return: report describing the publish run
         :rtype:  pulp.plugins.model.PublishReport
         """
+        warnings.warn(TASK_DEPRECATION_WARNING, NodeDeprecationWarning)
+
         nodes_conduit = NodesConduit()
         units = nodes_conduit.get_units(repo.id)
         with self.publisher(repo, config) as publisher:
@@ -164,6 +168,8 @@ class NodesHttpDistributor(Distributor):
         :param config:  plugin config
         :type  config:  pulp.plugins.config.PluginCallConfiguration
         """
+        warnings.warn(TASK_DEPRECATION_WARNING, NodeDeprecationWarning)
+
         _logger.debug(_('removing published node data for repo %s' % repo.id))
         repo_publish_path = self._get_publish_dir(repo.id, config)
         os.system('rm -rf %s' % repo_publish_path)

--- a/nodes/test/nodes_tests/test_admin_extensions.py
+++ b/nodes/test/nodes_tests/test_admin_extensions.py
@@ -112,8 +112,8 @@ class TestListCommands(ClientTests):
         # Verify
         mock_binding.assert_called_with(bindings=False, details=False)
         lines = self.recorder.lines
-        self.assertEqual(len(lines), 4)
-        self.assertTrue('Child Nodes' in lines[1])
+        self.assertEqual(len(lines), 6)
+        self.assertTrue('Child Nodes' in lines[3])
 
     @patch(CONSUMER_LIST_API, return_value=Response(200, CONSUMERS_AND_NODES))
     def test_list_nodes(self, mock_binding):
@@ -123,8 +123,8 @@ class TestListCommands(ClientTests):
         # Verify
         mock_binding.assert_called_with(bindings=False, details=False)
         lines = self.recorder.lines
-        self.assertEqual(len(lines), 9)
-        self.assertTrue(commands.NODE_LIST_TITLE in lines[1])
+        self.assertEqual(len(lines), 11)
+        self.assertTrue(commands.NODE_LIST_TITLE in lines[3])
 
     @patch(CONSUMER_LIST_API, return_value=Response(200, NODES_WITH_BINDINGS))
     def test_list_nodes_with_bindings(self, mock_binding):
@@ -134,8 +134,8 @@ class TestListCommands(ClientTests):
         # Verify
         mock_binding.assert_called_with(bindings=False, details=False)
         lines = self.recorder.lines
-        self.assertEqual(len(lines), 16)
-        self.assertTrue(commands.NODE_LIST_TITLE in lines[1])
+        self.assertEqual(len(lines), 18)
+        self.assertTrue(commands.NODE_LIST_TITLE in lines[3])
 
     @patch(REPO_LIST_API, return_value=Response(200, ALL_REPOSITORIES))
     @patch(DISTRIBUTORS_API, return_value=Response(200, NON_NODES_DISTRIBUTORS_ONLY))
@@ -146,8 +146,8 @@ class TestListCommands(ClientTests):
         # Verify
         mock_binding.assert_called_with(REPOSITORY_ID)
         lines = self.recorder.lines
-        self.assertEqual(len(lines), 4)
-        self.assertTrue(commands.REPO_LIST_TITLE in lines[1])
+        self.assertEqual(len(lines), 6)
+        self.assertTrue(commands.REPO_LIST_TITLE in lines[3])
 
     @patch(REPO_LIST_API, return_value=Response(200, ALL_REPOSITORIES))
     @patch(DISTRIBUTORS_API, return_value=Response(200, MIXED_DISTRIBUTORS))
@@ -158,8 +158,8 @@ class TestListCommands(ClientTests):
         # Verify
         mock_binding.assert_called_with(REPOSITORY_ID)
         lines = self.recorder.lines
-        self.assertEqual(len(lines), 9)
-        self.assertTrue(commands.REPO_LIST_TITLE in lines[1])
+        self.assertEqual(len(lines), 11)
+        self.assertTrue(commands.REPO_LIST_TITLE in lines[3])
 
 
 class TestPublishCommand(ClientTests):


### PR DESCRIPTION
Update the documentation and release notes to indicate that nodes are
deprecated. Also, add warnings in the parent/child tasks and CLI commands.

fixes #1488
https://pulp.plan.io/issues/1488