### PR TITLE
Fixes #1939: Enable cProfile of tasks

### DIFF
--- a/docs/dev-guide/debugging.rst
+++ b/docs/dev-guide/debugging.rst
@@ -3,14 +3,27 @@ Debugging
 
 .. _runtime_permormance:
 
-Runtime Performance Analysis
-----------------------------
+Task Performance Analysis
+-------------------------
 
 The Python standard library provides a `cProfile` module to assist developers in collecting a set
 of statistics that describes how often and for how long various parts of the program executed. Full
-documentation for this module can be found `here <https://docs.python.org/2/library/profile.htm>`_.
-To capture information about all function calls, add the following lines of code before the code
-you are interested in analyzing::
+documentation for this module can be found `here <https://docs.python.org/2/library/profile.htm>`_. There is built in support for profiling individual tasks. This can be enabled by editing the `server.conf` file:
+
+    [profiling]
+    enabled: true
+
+This will, by default, put task profile output into `/var/lib/pulp/c_profiles` named per task ID. You can modify the location these profiles are stored:
+
+    [profiling]
+    enabled: true
+    directory: /var/www/html/pub
+
+
+Custom Runtime Performance Analysis
+-----------------------------------
+
+Custom code locations be analyzed as well. To capture information about all function calls, add the following lines of code before the code you are interested in analyzing::
 
     import cProfile
     pr = cProfile.Profile()
@@ -24,6 +37,10 @@ After the code that is of interest, add the following two lines::
 .. note::
   The file should be written to somewhere the application has write access. `/tmp` does not seem to
   work for this use case. `/var/lib/pulp/` is guaranteed to provide Pulp write access.
+
+
+Analyzing Profiles
+------------------
 
 Once the captured statistics are written to a file, the file can be examined in two ways. Using
 `pstats` module in the Python standard library or

--- a/docs/user-guide/release-notes/2.12.x.rst
+++ b/docs/user-guide/release-notes/2.12.x.rst
@@ -1,0 +1,11 @@
+=======================
+Pulp 2.12 Release Notes
+=======================
+
+Pulp 2.12.0
+===========
+
+New Features
+------------
+
+ * Task profiling can now be enabled. This will use cProfiling on an individual task and write the profile to a directory for a given task. While this can impact performance, this can enable users to get some insight into what a task is doing or use the output to give to a developer for debugging.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.12.x
    2.11.x
    2.10.x
    2.9.x

--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -394,3 +394,20 @@
 # https_retrieval: true
 # download_interval: 30
 # download_concurrency: 5
+
+# = Profiling =
+#
+# Settings for profiling Pulp tasks
+#
+# enable:
+#   This enables the cProfile Python module to profile individual tasks and
+#   store the output by task ID in a directory. Note that enabling this can
+#   impact performance.
+#
+# profile_directory:
+#   The directory that the cProfiles are stored in. This directory must be
+#   writeable and readable by Pulp.
+
+[profiling]
+# enable: false
+# directory: /var/lib/pulp/c_profiles

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -136,6 +136,10 @@ _default_values = {
         'download_interval': '30',
         'download_concurrency': '5'
     },
+    'profiling': {
+        'enabled': 'false',
+        'directory': '/var/lib/pulp/c_profiles'
+    }
 }
 
 # to add a default configuration file, list the full path here


### PR DESCRIPTION
Adds the ability to turn on cProfiles of individual Pulp tasks
and dumping of the tasks into a directory. This can have an impact
on performance. The trade off is that users could investigate
individual tasks or provide these cProfiles to developers to help
detect anomalies or systematic issues.