### PR TITLE
Store importer TLS keys and certificates on the filesystem.

### DIFF
--- a/platform/pulpcore/app/models/__init__.py
+++ b/platform/pulpcore/app/models/__init__.py
@@ -1,4 +1,5 @@
 # https://docs.djangoproject.com/en/1.10/topics/db/models/#organizing-models-in-a-package
+
 from .auth import User  # NOQA
 from .base import Model, MasterModel  # NOQA
 from .generic import (GenericRelationModel, GenericKeyValueManager, GenericKeyValueRelation,  # NOQA
@@ -7,9 +8,11 @@ from .generic import (GenericRelationModel, GenericKeyValueManager, GenericKeyVa
 from .consumer import Consumer, ConsumerContent  # NOQA
 from .content import Content, Artifact  # NOQA
 from .repository import Repository, Importer, Publisher, RepositoryContent  # NOQA
-
-from .catalog import DownloadCatalog  # NOQA
+from .storage import FileContent  # NOQA
 from .task import ReservedResource, Worker, Task, TaskTag, TaskLock  # NOQA
+
+# Moved here: imports Artifact.
+from .catalog import DownloadCatalog  # NOQA
 
 # Moved here to avoid a circular import with Task
 from .progress import ProgressBar, ProgressReport, ProgressSpinner  # NOQA

--- a/platform/pulpcore/app/models/content.py
+++ b/platform/pulpcore/app/models/content.py
@@ -6,7 +6,7 @@ import hashlib
 from django.db import models
 
 from pulpcore.app.models import Model, MasterModel, Notes, GenericKeyValueRelation
-from pulpcore.app.models.storage import StoragePath
+from pulpcore.app.models.storage import ArtifactLocation
 
 
 class Content(MasterModel):
@@ -96,17 +96,11 @@ class Artifact(Model):
         content (models.ForeignKey): The associated content.
     """
 
-    # Note: The FileField does not support unique indexes and has
-    # other undesirable behavior and complexities.  Using a custom
-    # field should be investigated.
-
-    file = models.FileField(db_index=True, upload_to=StoragePath(), max_length=255)
+    file = models.FileField(db_index=True, upload_to=ArtifactLocation(), max_length=255)
     downloaded = models.BooleanField(db_index=True, default=False)
     requested = models.BooleanField(db_index=True, default=False)
     relative_path = models.TextField(db_index=True, blank=False, default=None)
-
     size = models.IntegerField(blank=True, null=True)
-
     md5 = models.CharField(max_length=32, blank=True, null=True)
     sha1 = models.CharField(max_length=40, blank=True, null=True)
     sha224 = models.CharField(max_length=56, blank=True, null=True)

--- a/platform/pulpcore/app/models/repository.py
+++ b/platform/pulpcore/app/models/repository.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils import timezone
 
 from pulpcore.app.models import Model, Notes, Scratchpad, MasterModel, GenericKeyValueRelation
+from pulpcore.app.models.storage import TLSLocation
 
 
 class Repository(Model):
@@ -142,9 +143,13 @@ class Importer(ContentAdaptor):
     feed_url = models.TextField()
     validate = models.BooleanField(default=True)
 
-    ssl_ca_certificate = models.TextField(blank=True)
-    ssl_client_certificate = models.TextField(blank=True)
-    ssl_client_key = models.TextField(blank=True)
+    ssl_ca_certificate = models.FileField(
+        blank=True, upload_to=TLSLocation('ca.pem'), max_length=255)
+    ssl_client_certificate = models.FileField(
+        blank=True, upload_to=TLSLocation('certificate.pem'), max_length=255)
+    ssl_client_key = models.FileField(
+        blank=True, upload_to=TLSLocation('key.pem'), max_length=255)
+
     ssl_validation = models.BooleanField(default=True)
 
     proxy_url = models.TextField(blank=True)

--- a/platform/pulpcore/app/serializers/__init__.py
+++ b/platform/pulpcore/app/serializers/__init__.py
@@ -4,8 +4,8 @@
 from pulpcore.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # NOQA
     ModelSerializer, MasterModelSerializer, DetailIdentityField, DetailRelatedField,
     viewset_for_model)
-from pulpcore.app.serializers.fields import (ContentRelatedField, RepositoryRelatedField,  # NOQA
-    ImporterRelatedField, PublisherRelatedField)
+from pulpcore.app.serializers.fields import (FileField, ContentRelatedField,  # NOQA
+    RepositoryRelatedField, ImporterRelatedField, PublisherRelatedField)  # NOQA
 from pulpcore.app.serializers.generic import (ConfigKeyValueRelatedField,  # NOQA
     NotesKeyValueRelatedField, ScratchpadKeyValueRelatedField)  # NOQA
 from pulpcore.app.serializers.catalog import DownloadCatalogSerializer  # NOQA

--- a/platform/pulpcore/app/serializers/fields.py
+++ b/platform/pulpcore/app/serializers/fields.py
@@ -32,3 +32,15 @@ class PublisherRelatedField(DetailRelatedField):
     Serializer Field for use when relating to Publisher Detail Models
     """
     queryset = models.Publisher.objects.all()
+
+
+class FileField(serializers.CharField):
+    """
+    Serializer Field for model.FileField and REST API passing file content.
+    """
+
+    def to_internal_value(self, data):
+        return models.FileContent(data)
+
+    def to_representation(self, value):
+        return str(value)

--- a/platform/pulpcore/app/serializers/repository.py
+++ b/platform/pulpcore/app/serializers/repository.py
@@ -6,7 +6,7 @@ from pulpcore.app import models
 from pulpcore.app.serializers import (MasterModelSerializer, ModelSerializer, DetailIdentityField,
                                   NotesKeyValueRelatedField, RepositoryRelatedField,
                                   ScratchpadKeyValueRelatedField, ContentRelatedField,
-                                  ImporterRelatedField, PublisherRelatedField)
+                                  ImporterRelatedField, PublisherRelatedField, FileField)
 
 
 class RepositorySerializer(ModelSerializer):
@@ -78,18 +78,18 @@ class ImporterSerializer(MasterModelSerializer):
         required=False,
     )
 
-    ssl_ca_certificate = serializers.CharField(
+    ssl_ca_certificate = FileField(
         help_text='A PEM encoded CA certificate used to validate the server '
                   'certificate presented by the external source.',
         write_only=True,
         required=False,
     )
-    ssl_client_certificate = serializers.CharField(
+    ssl_client_certificate = FileField(
         help_text='A PEM encoded client certificate used for authentication.',
         write_only=True,
         required=False,
     )
-    ssl_client_key = serializers.CharField(
+    ssl_client_key = FileField(
         help_text='A PEM encoded private key used for authentication.',
         write_only=True,
         required=False,

--- a/platform/pulpcore/app/settings.py
+++ b/platform/pulpcore/app/settings.py
@@ -35,7 +35,7 @@ SILENCED_SYSTEM_CHECKS = ["fields.W342"]
 
 ALLOWED_HOSTS = ['*']
 
-MEDIA_ROOT = '/var/lib/pulp/content/'
+MEDIA_ROOT = '/var/lib/pulp/'
 DEFAULT_FILE_STORAGE = 'pulpcore.app.models.storage.FileSystem'
 
 # Application definition

--- a/platform/pulpcore/app/tests/models/test_repository.py
+++ b/platform/pulpcore/app/tests/models/test_repository.py
@@ -1,6 +1,7 @@
+
 from django.test import TestCase
 
-from pulpcore.app.models import Repository, Importer, Publisher
+from pulpcore.app.models import Repository, Importer, Publisher, FileContent
 
 
 class TestRepository(TestCase):
@@ -35,14 +36,17 @@ class RepositoryExample(TestCase):
         """
         Add an importer with feed URL and some standard settings.
         """
+        ca = 'MY-CA'
+        certificate = 'MY-CERTIFICATE'
+        key = 'MY-KEY'
         repository = Repository.objects.get(name=RepositoryExample.NAME)
         importer = Importer(repository=repository)
         importer.name = 'Upstream'
         importer.feed_url = 'http://content-world/everyting/'
         importer.ssl_validation = True
-        importer.ssl_ca_certificate = 'MY-CA'
-        importer.ssl_client_certificate = 'MY-CERTIFICATE'
-        importer.ssl_client_key = 'MY-KEY'
+        importer.ssl_ca_certificate = FileContent(ca)
+        importer.ssl_client_certificate = FileContent(certificate)
+        importer.ssl_client_key = FileContent(key)
         importer.proxy_url = 'http://elmer:fudd@warnerbrothers.com'
         importer.basic_auth_user = 'Elmer'
         importer.basic_auth_password = 'Fudd'
@@ -95,9 +99,16 @@ class RepositoryExample(TestCase):
 
         # SSL
         self.assertTrue(importer.ssl_validation)
-        self.assertEqual(importer.ssl_ca_certificate, 'MY-CA')
-        self.assertEqual(importer.ssl_client_certificate, 'MY-CERTIFICATE')
-        self.assertEqual(importer.ssl_client_key, 'MY-KEY')
+        # Lousy test that leaks files but fine for initial sanity testing.
+        self.assertEqual(
+            open(str(importer.ssl_ca_certificate)).read(),
+            'MY-CA')
+        self.assertEqual(
+            open(str(importer.ssl_client_certificate)).read(),
+            'MY-CERTIFICATE')
+        self.assertEqual(
+            open(str(importer.ssl_client_key)).read(),
+            'MY-KEY')
 
         # Basic auth settings
         self.assertEqual(importer.basic_auth_user, 'Elmer')


### PR DESCRIPTION
https://pulp.plan.io/issues/2455

Files stored in: `/var/lib/pulp/tls/`

The `StoragePath` needed to be more specific so renamed using `location` semantics as `ArtifactLocation` and `TLSLocation`.  Still need to update the serializer.

The `FileSystem._save()` *storage* also needed to change to use the django `File` appropriately as a stream.  This meant it could not use shutil.copy() (which was not providing much anyway).

Took a stab at serializer changes.  Since certificates are passed by-value we need a way to set the value of `FileField` with content instead of a *file-like* object opened to an actual file.