### PR TITLE
Pins okaara dependency versions

### DIFF
--- a/client_lib/setup.py
+++ b/client_lib/setup.py
@@ -9,5 +9,5 @@ setup(
     packages=find_packages(exclude=['test']),
     author='Pulp Team',
     author_email='pulp-list@redhat.com',
-    install_requires=['isodate>0.5.0', 'm2crypto', 'okaara>=1.0.32', 'setuptools']
+    install_requires=['isodate>0.5.0', 'm2crypto', 'okaara>=1.0.32,<1.0.36', 'setuptools']
 )

--- a/pulp.spec
+++ b/pulp.spec
@@ -787,7 +787,7 @@ Summary: Pulp client extensions framework
 Group: Development/Languages
 Requires: m2crypto
 Requires: python-%{name}-common = %{pulp_version}
-Requires: python-okaara >= 1.0.32
+Requires: python-okaara >= 1.0.32,python-okaara < 1.0.36
 Requires: python-isodate >= 0.5.0-1.pulp
 Requires: python-setuptools
 Obsoletes: pulp-client-lib


### PR DESCRIPTION
The okaara 1.0.36 release is incompatible with Python
2.7. This Pins the versions to 1.0.32 <= okaara <=
1.0.35 which are compatible with Pulp. This range limit
is made in the spec file and the setup.py requirements.

https://pulp.plan.io/issues/2464
closes #2464