### PR TITLE
re #2319: Fixes 3.0-dev docs error

### DIFF
--- a/app/pulp/app/models/progress.py
+++ b/app/pulp/app/models/progress.py
@@ -28,7 +28,7 @@ class ProgressReport(Model):
             (required)
         done (models.IntegerField): The count of items already processed. Defaults to 0.
         suffix (models.TextField): Customizable suffix rendered with the progress report
-            See `docs https://github.com/verigak/progress>`_. for more info.
+            See `the docs <https://github.com/verigak/progress>`_. for more info.
 
     Relations:
 


### PR DESCRIPTION
The external link was not formatted correctly.

https://pulp.plan.io/issues/2319