### PR TITLE
Closes #2481: Adds kobo as setup.py dependency

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -33,6 +33,6 @@ setup(
     },
     install_requires=[
         'blinker', 'celery >=3.1.0, <3.2.0', 'httplib2', 'iniparse', 'isodate>=0.5.0',
-        'mongoengine>=0.10.0', 'oauth2>=1.5.211', 'pymongo>=3.0.0', 'setuptools',
+        'mongoengine>=0.10.0', 'oauth2>=1.5.211', 'kobo', 'pymongo>=3.0.0', 'setuptools',
         DJANGO_REQUIRES, SEMVER_REQUIRES, M2CRYPTO_REQUIRES],
 )


### PR DESCRIPTION
With 2.10.0 Kobo became a spec file dependency, which
handled installing it for users. For developers, the
Ansible playbook seems to get its Pulp dependencies from
the setup.py files. This adds the kobo dependency to
the pulp.server setup.py file which fixes `vagrant up`
for developers.

https://pulp.plan.io/issues/2481