### PR TITLE
As a user, orphan content delete reports how many units were deleted

### DIFF
--- a/client_lib/pulp/client/commands/unit.py
+++ b/client_lib/pulp/client/commands/unit.py
@@ -24,7 +24,7 @@ DESC_TO_REPO = _('destination repository to copy units into')
 OPTION_TO_REPO = PulpCliOption('--to-repo-id', DESC_TO_REPO, aliases=['-t'], required=True)
 
 OPTION_TYPE = PulpCliOption('--type',
-                            _('restrict to one content type such as "rpm", "errata", '
+                            _('restrict to one content type such as "rpm", "erratum", '
                               '"puppet_module", etc.'),
                             required=False)
 OPTION_UNIT_ID = \

--- a/docs/dev-guide/integration/rest-api/content/orphan.rst
+++ b/docs/dev-guide/integration/rest-api/content/orphan.rst
@@ -143,7 +143,9 @@ return a :ref:`call_report`
 
 Remove All Orphaned Content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Remove all orphaned content units, regardless of type.
+Remove all orphaned content units, regardless of type. The task that gets
+instantiated will have a count of units that get deleted indexed by content
+type id in the result field once the task completes successfully.
 
 | :method:`delete`
 | :path:`/v2/content/orphans/`

--- a/docs/user-guide/admin-client/orphan.rst
+++ b/docs/user-guide/admin-client/orphan.rst
@@ -78,7 +78,11 @@ It has three flags:
  State:        Successful
  Start Time:   2012-12-09T03:26:51Z
  Finish Time:  2012-12-09T03:26:51Z
- Result:       N/A
+ Result:
+   Erratum:          4
+   Package Category: 1
+   Package Group:    2
+   Rpm:              32
  Task Id:      e239ae4f-7fad-4004-bfb6-8e06f17d22ef
  Progress:
 

--- a/server/pulp/server/managers/content/orphan.py
+++ b/server/pulp/server/managers/content/orphan.py
@@ -164,13 +164,21 @@ class OrphanManager(object):
     def delete_all_orphans():
         """
         Delete all orphaned content units.
-        """
 
+        :return: count of units deleted indexed by content_type_id
+        :rtype: dict
+        """
+        ret = {}
         for content_type_id in content_types_db.all_type_ids():
-            OrphanManager.delete_orphans_by_type(content_type_id)
+            count = OrphanManager.delete_orphans_by_type(content_type_id)
+            if count > 0:
+                ret[content_type_id] = count
 
         for content_type_id in plugin_api.list_unit_models():
-            OrphanManager.delete_orphan_content_units_by_type(content_type_id)
+            count = OrphanManager.delete_orphan_content_units_by_type(content_type_id)
+            if count > 0:
+                ret[content_type_id] = count
+        return ret
 
     @staticmethod
     def delete_orphans_by_id(content_unit_list):
@@ -211,10 +219,13 @@ class OrphanManager(object):
         :type content_type_id: basestring
         :param content_unit_ids: list of content unit ids to delete; None means delete them all
         :type content_unit_ids: iterable or None
+        :return: count of units deleted
+        :rtype: int
         """
 
         content_units_collection = content_types_db.type_units_collection(content_type_id)
 
+        count = 0
         for content_unit in OrphanManager.generate_orphans_by_type(content_type_id,
                                                                    fields=['_id', '_storage_path']):
 
@@ -230,6 +241,8 @@ class OrphanManager(object):
             storage_path = content_unit.get('_storage_path', None)
             if storage_path is not None:
                 OrphanManager.delete_orphaned_file(storage_path)
+            count += 1
+        return count
 
     @staticmethod
     def delete_orphan_content_units_by_type(type_id, content_unit_ids=None):
@@ -243,6 +256,8 @@ class OrphanManager(object):
         :type type_id: basestring
         :param content_unit_ids: list of content unit ids to delete; None means delete them all
         :type content_unit_ids: iterable or None
+        :return: count of units deleted
+        :rtype: int
         """
         # get the model matching the type
         content_model = plugin_api.get_unit_model_by_id(type_id)
@@ -254,6 +269,8 @@ class OrphanManager(object):
             content_units = itertools.chain(*query_sets)
         else:
             content_units = content_model.objects.only('id', '_storage_path')
+
+        count = 0
 
         # Paginate the content units
         for units_group in plugin_misc.paginate(content_units):
@@ -279,6 +296,9 @@ class OrphanManager(object):
                 unit_to_delete.delete()
                 if unit_to_delete._storage_path:
                     OrphanManager.delete_orphaned_file(unit_to_delete._storage_path)
+                count += 1
+
+        return count
 
     @staticmethod
     def delete_orphaned_file(path):
@@ -381,6 +401,6 @@ class OrphanManager(object):
             _logger.error(_('Delete path: %(p)s failed: %(m)s'), {'p': path, 'm': str(e)})
 
 
-delete_all_orphans = task(OrphanManager.delete_all_orphans, base=Task, ignore_result=True)
+delete_all_orphans = task(OrphanManager.delete_all_orphans, base=Task)
 delete_orphans_by_id = task(OrphanManager.delete_orphans_by_id, base=Task, ignore_result=True)
 delete_orphans_by_type = task(OrphanManager.delete_orphans_by_type, base=Task, ignore_result=True)

--- a/server/test/unit/server/managers/content/test_orphan.py
+++ b/server/test/unit/server/managers/content/test_orphan.py
@@ -209,22 +209,24 @@ class OrphanManagerGeneratorTests(OrphanManagerTests):
         orphans = list(self.orphan_manager.generate_all_orphans())
         self.assertEqual(len(orphans), 1)
 
-        self.orphan_manager.delete_all_orphans()
+        result = self.orphan_manager.delete_all_orphans()
 
         orphans = list(self.orphan_manager.generate_all_orphans())
         self.assertEqual(len(orphans), 0)
         self.assertEqual(self.number_of_files_in_content_root(), 0)
+        self.assertEqual(1, result[PHONY_TYPE_1.id])
 
     def test_delete_one_orphan_with_directory_using_generators(self):
         gen_content_unit_with_directory(PHONY_TYPE_1.id, self.content_root)
         orphans = list(self.orphan_manager.generate_all_orphans())
         self.assertEqual(len(orphans), 1)
 
-        self.orphan_manager.delete_all_orphans()
+        result = self.orphan_manager.delete_all_orphans()
 
         orphans = list(self.orphan_manager.generate_all_orphans())
         self.assertEqual(len(orphans), 0)
         self.assertEqual(self.number_of_files_in_content_root(), 0)
+        self.assertEqual(1, result[PHONY_TYPE_1.id])
 
     # NOTE this test is disabled for normal test runs
     def _test_delete_using_generators_performance_single_content_type(self):


### PR DESCRIPTION
Track the counts of units being deleted when orphan remove all is executed and
store the result indexed by content type id on the task.

fixes #1268
https://pulp.plan.io/issues/1268