### PR TITLE
Prevent exceptions raised in finally:

### DIFF
--- a/server/pulp/plugins/util/publish_step.py
+++ b/server/pulp/plugins/util/publish_step.py
@@ -162,7 +162,10 @@ class Step(object):
             for step in _post_order(self):
                 step.process()
         finally:
-            self.report_progress(force=True)
+            try:
+                self.report_progress(force=True)
+            except Exception:
+                _logger.exception(_('Progress reporting failed'))
 
     def is_skipped(self):
         """
@@ -257,7 +260,10 @@ class Step(object):
                     return
             finally:
                 # Always call finalize to allow cleanup of file handles
-                self.finalize()
+                try:
+                    self.finalize()
+                except Exception:
+                    _logger.exception(_('Finalizing failed'))
             self.post_process()
         except Exception as e:
             tb = sys.exc_info()[2]

--- a/server/test/unit/plugins/util/test_publish_step.py
+++ b/server/test/unit/plugins/util/test_publish_step.py
@@ -301,19 +301,6 @@ class PluginStepTests(PluginBase):
         step = publish_step.PluginStep('foo_step')
         self.assertEquals(None, step.get_conduit())
 
-    @patch('pulp.plugins.conduits.repo_publish.RepoPublishConduit.get_units')
-    def test_process_step_failure_reported_on_metadata_finalized(self, mock_get_units):
-        self.pluginstep.repo.content_unit_counts = {'FOO_TYPE': 1}
-        mock_get_units.return_value = ['mock_unit']
-        step = publish_step.PluginStep('foo_step')
-        step.parent = self.pluginstep
-        step.finalize = Mock(side_effect=Exception())
-        self.assertRaises(Exception, step.process)
-        self.assertEquals(step.state, reporting_constants.STATE_FAILED)
-        self.assertEquals(step.progress_successes, 1)
-        self.assertEquals(step.progress_failures, 1)
-        self.assertEquals(step.total_units, 1)
-
     def test_cancel_before_processing(self):
         self.pluginstep.repo.content_unit_counts = {'FOO_TYPE': 2}
         step = publish_step.PluginStep('foo_step')


### PR DESCRIPTION
https://pulp.plan.io/issues/2136

The issue proposes to catch and log the exception raised in the `try:` but this exception is most likely the root cause.  The code in `finally:` *should* just clean up resources.  Allowing an exception out of the `finally:` results in exceptions raised in the `try:` to be *swallowed*.

This seemed like a more appropriate solution and results in the root cause being reported as desired by the reporter. 