### PR TITLE
Adds upgrade notes to 2.11

### DIFF
--- a/docs/user-guide/release-notes/2.11.x.rst
+++ b/docs/user-guide/release-notes/2.11.x.rst
@@ -29,3 +29,13 @@ New Features
   :ref:`process recycling documentation<process_recycling>` for more info. Thank you to Jan-Otto
   Kröpke for contributing this feature.
 
+
+Upgrade instructions
+--------------------
+
+Upgrade using the normal process::
+
+    $ sudo systemctl stop httpd pulp_workers pulp_resource_manager pulp_celerybeat pulp_streamer goferd
+    $ sudo yum upgrade
+    $ sudo -u apache pulp-manage-db
+    $ sudo systemctl start httpd pulp_workers pulp_resource_manager pulp_celerybeat pulp_streamer goferd


### PR DESCRIPTION
The upgrade notes added also include stopping and
starting pulp_streamer.

This commit is based off of the 'pulp-2.11.0-0.5.rc'.
This allows us to merge it into the 2.11 GA release
at build time, and also merge it into 2.11-dev
and forward using our normal PR process.

https://pulp.plan.io/issues/2485
closes #2485