### PR TITLE
RSA key pair and SSL CA certificate generation removed from pulp.spec.

### DIFF
--- a/docs/user-guide/installation/f23-.rst
+++ b/docs/user-guide/installation/f23-.rst
@@ -150,6 +150,11 @@ Server
      :ref:`Pulp Broker Settings Guide <pulp-broker-settings>`.
    * **server** if you want to change the server's URL components, hostname, or default credentials
 
+#. Generate RSA key pair and SSL CA certificate::
+
+   $ sudo pulp-gen-key-pair
+   $ sudo pulp-gen-ca-certificate
+
 #. Initialize Pulp's database. It is important that the broker is running before initializing
    Pulp's database. It is also important to do this before starting Apache or any Pulp services.
    The database initialization needs to be run as the ``apache`` user, which can be done by

--- a/docs/user-guide/installation/f24+.rst
+++ b/docs/user-guide/installation/f24+.rst
@@ -120,6 +120,11 @@ Now we are ready to install and configure the Pulp server!
      :ref:`Pulp Broker Settings Guide <pulp-broker-settings>`.
    * **server** if you want to change the server's URL components, hostname, or default credentials
 
+#. Generate RSA key pair and SSL CA certificate::
+
+   $ sudo pulp-gen-key-pair
+   $ sudo pulp-gen-ca-certificate
+
 #. Initialize Pulp's database. It is important that the broker is running before initializing
    Pulp's database. It is also important to do this before starting Apache or any Pulp services.
    The database initialization needs to be run as the ``apache`` user, which can be done by

--- a/docs/user-guide/nodes.rst
+++ b/docs/user-guide/nodes.rst
@@ -105,9 +105,11 @@ To install *Nodes* parent support, follow the instructions below.
    must have OAuth enabled and configured. Please see :ref:`OAuth <oauth-config>` for instructions
    on enabling and configuring OAuth.
 
-3. Run ``pulp-manage-db``.
+3. Run ``pulp-gen-nodes-certificate``.
 
-4. Restart :ref:`server components<server-components>`.
+4. Run ``pulp-manage-db``.
+
+5. Restart :ref:`server components<server-components>`.
 
 
 Child
@@ -170,11 +172,13 @@ Example:
  secret: eePa7Bi3gohdir1pai2icohvaidai0io
  user_id: admin
 
-4. Run ``pulp-manage-db``.
+4. Run ``pulp-gen-nodes-certificate``.
 
-5. Restart :ref:`server components<server-components>`.
+5. Run ``pulp-manage-db``.
 
-6. Restart ``goferd``.
+6. Restart :ref:`server components<server-components>`.
+
+7. Restart ``goferd``.
 
 
 Admin Client Extensions
@@ -408,23 +412,21 @@ On the Pulp server to be used as the parent node:
 
   $ sudo yum install pulp-nodes-parent pulp-nodes-admin-extensions
 
-2. Configure and enable :ref:`OAuth <oauth-config>`.
+3. Run ``pulp-gen-nodes-certificate``.
 
-3. Restart Apache.  For upstart::
+4. Run ``pulp-manage-db``.
 
-     $ sudo service httpd restart
+5. Configure and enable :ref:`OAuth <oauth-config>`.
 
-   For systemd::
+6. Restart :ref:`server components<server-components>`.
 
-     $sudo systemctl restart httpd
-
-4. Enable the ``pulp-goodness`` repository.
+7. Enable the ``pulp-goodness`` repository.
 
 ::
 
  $ pulp-admin node repo enable --repo-id pulp-goodness
 
-5. Publish the ``pulp-goodness`` repository.
+8. Publish the ``pulp-goodness`` repository.
 
 ::
 
@@ -442,10 +444,14 @@ On the Pulp server to be used as the child node:
 
   $ sudo yum install pulp-nodes-child pulp-nodes-consumer-extensions pulp-agent
 
-2. Configure and enable :ref:`OAuth <oauth-config>`. This should use different credentials from
+2. Run ``pulp-gen-nodes-certificate``.
+
+3. Run ``pulp-manage-db``.
+
+4. Configure and enable :ref:`OAuth <oauth-config>`. This should use different credentials from
    the parent for security.
 
-3. Edit ``/etc/pulp/nodes.conf`` and set the parent OAuth *key* and *secret* to match values found in
+5. Edit ``/etc/pulp/nodes.conf`` and set the parent OAuth *key* and *secret* to match values found in
    ``/etc/pulp/server.conf`` on the parent node.
 
 ::
@@ -454,22 +460,16 @@ On the Pulp server to be used as the child node:
  key:    <matching value from parent /etc/pulp/server.conf>
  secret: <matching value from parent /etc/pulp/server.conf>
 
-4. Edit ``/etc/pulp/consumer/consumer.conf`` and change:
+6. Edit ``/etc/pulp/consumer/consumer.conf`` and change:
 
 ::
 
  [server]
  host = parent.redhat.com
 
-5. Restart Apache.  For upstart::
+7. Restart :ref:`server components<server-components>`.
 
-     $ sudo service httpd restart
-
-   For systemd::
-
-     $sudo systemctl restart httpd
-
-6. Restart the Pulp agent.  For upstart::
+8. Restart the Pulp agent.  For upstart::
 
      $ sudo service goferd restart
 
@@ -478,20 +478,20 @@ On the Pulp server to be used as the child node:
      $ sudo systemctl restart goferd
 
 
-7. Register as a consumer. This command will prompt for a password.
+9. Register as a consumer. This command will prompt for a password.
 
 ::
 
  $ pulp-consumer register --consumer-id child-1
 
-8. Activate the node.
+10. Activate the node.
 
 ::
 
  $ pulp-consumer node activate
 
 
-9. Bind to the ``pulp-goodness`` repository.
+11. Bind to the ``pulp-goodness`` repository.
 
 ::
 

--- a/pulp-dev.py
+++ b/pulp-dev.py
@@ -377,6 +377,8 @@ def install(opts):
 
         # Generate certificates
         print 'generating certificates'
+        if not os.path.exists('/etc/pki/pulp/rsa.key'):
+            os.system(os.path.join(ROOT_DIR, 'server/bin/pulp-gen-key-pair'))
         if not os.path.exists('/etc/pki/pulp/ca.crt'):
             os.system(os.path.join(ROOT_DIR, 'server/bin/pulp-gen-ca-certificate'))
         if not os.path.exists('/etc/pki/pulp/nodes/node.crt'):

--- a/server/bin/pulp-gen-ca-certificate
+++ b/server/bin/pulp-gen-ca-certificate
@@ -1,17 +1,9 @@
 #!/bin/bash
-# Copyright (c) 2013 Red Hat, Inc.
 #
-# This software is licensed to you under the GNU General Public License,
-# version 2 (GPLv2). There is NO WARRANTY for this software, express or
-# implied, including the implied warranties of MERCHANTABILITY or FITNESS
-# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
-# along with this software; if not, see
-# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+# Generate the Pulp CA private key and certificate.
+# They are generated only when both do not already exist.
 #
-# Red Hat trademarks are not licensed under GPLv2. No permission is
-# granted to use or replicate Red Hat trademarks that are incorporated
-# in this software or its documentation.
-#
+
 set -e
 
 READ_PULP_CONF=\
@@ -24,25 +16,30 @@ END
 
 PULP_CONF=(`python -c "$READ_PULP_CONF"`)
 
-# This temporary folder will contain the certificate signing request.
 TMP="$(mktemp -d)"
 CA_KEY=${PULP_CONF[0]}
 CA_CRT=${PULP_CONF[1]}
 CN=`hostname --fqdn`
 ORG="PULP"
 
-OLD_UMASK="$(umask)"
+if [ -f ${CA_KEY} ] && [ -f ${CA_CRT} ]
+then
+  echo "Both ${CA_KEY} and ${CA_CRT} already exist."
+  echo "Nothing generated."
+  exit 0
+fi
+
 umask 027
+
 # create CA key
-openssl genrsa -out $CA_KEY 4096 &> /dev/null
-# Allow httpd to read the key
-chgrp apache $CA_KEY
+openssl genrsa -out ${CA_KEY} 4096 &> /dev/null
+chgrp apache ${CA_KEY}
 
 # create signing request
 openssl req \
   -new \
-  -key $CA_KEY \
-  -out $TMP/ca.req \
+  -key ${CA_KEY} \
+  -out ${TMP}/ca.req \
   -subj "/CN=$CN/O=$ORG" &> /dev/null
 
 # create a self-signed CA certificate
@@ -51,12 +48,13 @@ openssl x509 \
   -days 7035 \
   -sha1 \
   -extensions ca  \
-  -signkey $CA_KEY \
-  -in $TMP/ca.req \
-  -out $CA_CRT &> /dev/null
-chgrp apache $CA_CRT
-umask $OLD_UMASK
+  -signkey ${CA_KEY} \
+  -in ${TMP}/ca.req \
+  -out ${CA_CRT} &> /dev/null
+chgrp apache ${CA_CRT}
 
 # clean
-rm $TMP/ca.req
-rmdir $TMP
+rm ${TMP}/ca.req
+rmdir ${TMP}
+
+echo "Created: ${CA_KEY} and ${CA_CRT}"

--- a/server/bin/pulp-gen-key-pair
+++ b/server/bin/pulp-gen-key-pair
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Generate the Pulp server RSA key pair.
+# They are generated only when both do not already exist.
+#
+
+set -e
+
+KEY_DIR="/etc/pki/pulp"
+KEY_PATH="$KEY_DIR/rsa.key"
+KEY_PATH_PUB="$KEY_DIR/rsa_pub.key"
+
+if [ -f ${KEY_PATH} ] && [ -f ${KEY_PATH_PUB} ]
+then
+  echo "Both ${KEY_PATH} and ${KEY_PATH_PUB} already exist."
+  echo "Nothing generated."
+  exit 0
+fi
+
+umask 077
+
+openssl genrsa -out ${KEY_PATH} 2048 &> /dev/null
+openssl rsa -in ${KEY_PATH} -pubout > ${KEY_PATH_PUB} 2> /dev/null
+
+chmod 640 ${KEY_PATH}
+chmod 644 ${KEY_PATH_PUB}
+chown root:apache ${KEY_PATH}
+chown root:apache ${KEY_PATH_PUB}
+
+ln -fs ${KEY_PATH_PUB} /var/lib/pulp/static
+
+echo "Created: ${KEY_PATH} and ${KEY_PATH_PUB}"

--- a/server/bin/pulp-setup
+++ b/server/bin/pulp-setup
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Pulp initial server setup.
+#
+
+set -e
+
+echo ""
+echo "Generating RSA key pair and SSL CA certificate."
+read -p "Proceed (y/n) [y]:" INPUT
+INPUT=${INPUT:-y}
+if [ ${INPUT} == 'y' ]
+then
+  pulp-gen-key-pair
+  pulp-gen-ca-certificate
+fi
+
+
+echo ""
+echo "Initialize the Pulp database."
+read -p "Proceed (y/n) [y]:" INPUT
+INPUT=${INPUT:-y}
+if [ ${INPUT} == 'y' ]
+then
+  sudo -u apache pulp-manage-db
+fi


### PR DESCRIPTION
https://pulp.plan.io/issues/2013

**Server:**
Moved the RSA key pair generation out of the _%post_ of the pulp.spec into a new script named: `pulp-gen-key-par` and removed call to `pulp-gen-ca-certificate`.  Updated the *installation* documentation and added steps to run these (2) scripts.  

I added another script named: `pulp-setup` that is intended to consolidate things.  I'm on the fence about this.  On on hand, it seems valuable to automate and encapsulate the post-install steps into a single script.  This makes it easier for users (run one thing) and hopefully supports future refactoring and/or additions without impacting the user (and documentation).  If we like this, we'll need to change the documentation to instruct the user to run `pulp-setup` instead.  On the other hand, the script currently only does (3) things ...

**Nodes:**
Removed calling `pulp-gen-nodes-certificate` from pulp.spec and updated the nodes _installation_ documentation.  I also noticed that the nodes *Quick Start*  was telling the user to restart `httpd` instead of all of the services.  Pretty sure both `httpd` and the workers need to be restarted to use the newly installed nodes importer and distributor.  Simpler to tell the user to restart all of the services.
