### PR TITLE
Fix status API to not show stopped workers and scheduler

### DIFF
--- a/server/pulp/server/async/tasks.py
+++ b/server/pulp/server/async/tasks.py
@@ -245,6 +245,9 @@ def _delete_worker(name, normal_shutdown=False):
         msg = _('The worker named %(name)s is missing. Canceling the tasks in its queue.')
         msg = msg % {'name': name}
         _logger.error(msg)
+    else:
+        msg = _("Cleaning up shutdown worker '%s'.") % name
+        _logger.info(msg)
 
     # Delete the worker document
     Worker.objects(name=name).delete()

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -110,15 +110,14 @@ class TestSchedulerTick(unittest.TestCase):
 
     @mock.patch('celery.beat.Scheduler.__init__', new=mock.Mock())
     @mock.patch('celery.beat.Scheduler.tick')
-    @mock.patch('pulp.server.async.scheduler.platform.node')
+    @mock.patch('pulp.server.async.scheduler.CELERYBEAT_NAME', 'test@some_host')
     @mock.patch('pulp.server.async.scheduler.time')
     @mock.patch('pulp.server.async.scheduler.worker_watcher')
     @mock.patch('pulp.server.async.scheduler.CeleryBeatLock')
-    def test_calls_handle_heartbeat(self, mock_celerybeatlock, mock_worker_watcher, time, node,
+    def test_calls_handle_heartbeat(self, mock_celerybeatlock, mock_worker_watcher, time,
                                     mock_tick):
         sched_instance = scheduler.Scheduler()
         time.time.return_value = 1449261335.275528
-        node.return_value = 'some_host'
 
         sched_instance.tick()
 
@@ -126,7 +125,7 @@ class TestSchedulerTick(unittest.TestCase):
             'timestamp': 1449261335.275528,
             'local_received': 1449261335.275528,
             'type': 'scheduler-event',
-            'hostname': SCHEDULER_WORKER_NAME + '@some_host'
+            'hostname': 'test@some_host'
         }
         mock_worker_watcher.handle_worker_heartbeat.assert_called_once_with(expected_event)
         mock_worker_watcher.assert_called_once()

--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -168,7 +168,7 @@ class TestDeleteWorker(ResourceReservationTests):
 
     def test_normal_shutdown_true_logs_correctly(self):
         tasks._delete_worker('worker1', normal_shutdown=True)
-        self.assertTrue(not self.mock_gettext.called)
+        self.assertTrue(self.mock_gettext.called)
         self.assertTrue(not self.mock_logger.error.called)
 
     def test_normal_shutdown_not_specified_logs(self):


### PR DESCRIPTION
This fix ensures that workers (including resource_manager) and the
scheduler properly clean up their database records when gracefully
shutdown.

fixes #2491
https://pulp.plan.io/issues/2491

Note: This diff is a bit easier to view if you turn off white space checking:

https://github.com/pulp/pulp/pull/2901/files?w=0