### PR TITLE
django.request log level changed to ERROR

### DIFF
--- a/server/pulp/server/content/web/settings.py
+++ b/server/pulp/server/content/web/settings.py
@@ -40,6 +40,11 @@ LOGGING = {
         'django': {
             'handlers': ['syslog'],
         },
+        # 404 responses trigger logs at WARNING level, which is inappropriate
+        # for Pulp.
+        'django.request': {
+            'level': 'ERROR',
+        },
     }
 }
 


### PR DESCRIPTION
django's normal behavior is to log at WARNING when it issues a 404 response to
a client. That is not the behavior Pulp wants, because it does not indicate a
failure in Pulp.

https://pulp.plan.io/issues/2510
fixes #2510