### PR TITLE
Reduce and simplify timings so that failover occurs within 30 seconds

### DIFF
--- a/common/pulp/common/constants.py
+++ b/common/pulp/common/constants.py
@@ -50,29 +50,21 @@ PRIMARY_ID = '___/primary/___'
 # this is used by both platform and plugins to find the default CA path
 DEFAULT_CA_PATH = '/etc/pki/tls/certs/ca-bundle.crt'
 
-# celerybeat constants
-
 # Scheduler worker name
 SCHEDULER_WORKER_NAME = 'scheduler'
-# Constant used as the default wait time for celerybeat instances with no lock
-CELERY_TICK_DEFAULT_WAIT_TIME = 90
-# Constant used to determine whether a CeleryBeatLock should be removed due to age
-CELERYBEAT_LOCK_MAX_AGE = 200
-# The amount of time in seconds before a Celery process is considered missing
-CELERY_TIMEOUT_SECONDS = 300
-# The interval in seconds for which the Celery Process monitor thread sleeps between
-# checking for missing Celery processes.
-CELERY_CHECK_INTERVAL = 60
-# The maximum number of seconds that will ever elapse before the scheduler looks for
-# new or changed schedules
-CELERY_MAX_INTERVAL = 90
+
+# Resource manager worker name
+RESOURCE_MANAGER_WORKER_NAME = 'resource_manager'
+
+# The amount of time (in seconds) between process wakeups to "heartbeat" and perform
+# their tasks.
+PULP_PROCESS_HEARTBEAT_INTERVAL = 5
+
+# The amount of time (in seconds) after which a Celery process is considered missing.
+PULP_PROCESS_TIMEOUT_INTERVAL = 25
+
 # The amount of time the migration script will wait to confirm that no processes are running.
 # This is the 90s CELERY_TICK_DEFAULT_WAIT_TIME used in Pulp version < 2.12 and a 2s buffer.
 # This ensures that the process check feature works correctly even in cases where a user
 # forgot to restart pulp_celerybeat while upgrading from Pulp 2.11 or earlier.
 MIGRATION_WAIT_TIME = 92
-
-# resource manager constants
-
-# Resource manager worker name
-RESOURCE_MANAGER_WORKER_NAME = 'resource_manager'

--- a/docs/user-guide/release-notes/2.12.x.rst
+++ b/docs/user-guide/release-notes/2.12.x.rst
@@ -8,11 +8,19 @@ Pulp 2.12.0
 New Features
 ------------
 
- * Task profiling can now be enabled. This will use cProfiling on an individual task and write the profile to a directory for a given task. While this can impact performance, this can enable users to get some insight into what a task is doing or use the output to give to a developer for debugging.
- * ``pulp-manage-db`` will not continue if pulp_celerybeat, pulp_resource_manager, or pulp_workers
-   processes are running. This will prevent the user from corrupting their Pulp installation by
-   migrating with running workers. This works in both standalone and clustered installations. Pulp
-   may wait up to 92 seconds to determine if workers are running.
+* Task profiling can now be enabled. This will use `cProfile
+  <https://docs.python.org/2/library/profile.html#module-cProfile>`_ on an individual task and write
+  the profile to a directory for a given task. While this can impact performance, this enables users
+  to get some insight into what a task is doing or give the output to give to a developer for debugging.
+
+* ``pulp-manage-db`` will not continue if pulp_celerybeat, pulp_resource_manager, or pulp_workers
+  processes are running. This prevents the user from corrupting their Pulp installation by applying
+  migrations while workers or pulp_celerybeat are running. This works in both standalone and clustered
+  installations. Pulp may wait up to 92 seconds to determine if workers are running.
+
+* Worker failure detection and high availability failover occurs within 30 seconds. Pulp processes are
+  considered missing after 25 seconds, and heartbeats occur every 5 seconds.
+
 
 Deprecation
 -----------

--- a/docs/user-guide/server.rst
+++ b/docs/user-guide/server.rst
@@ -18,12 +18,12 @@ For a recap of Pulp components and the work they are responsible for, read :ref:
 
 * If a ``pulp_worker`` dies, the dispatched Pulp tasks destined for that worker (both the task
   currently being worked on and queued/related tasks) will not be processed. They will stall for
-  at most six minutes before being canceled. Status of the tasks is marked as canceled after
-  5 minutes or in case the worker has been re-started, whichever action occurs first.
-  Cancellation after 5 minutes is dependent on ``pulp_celerybeat`` service running. A monitoring
+  at most 30 seconds before being canceled. Status of the tasks is marked as canceled after
+  30 seconds or in case the worker has been re-started, whichever action occurs first.
+  Cancellation after 30 seconds is dependent on ``pulp_celerybeat`` service running. A monitoring
   component inside of ``pulp_celerybeat`` monitors all workers' heartbeats. If a worker does not
-  heartbeat within five minutes, it is considered missing. This check occurs once a minute, causing
-  a maximum delay of six minutes before a worker is considered missing and tasks canceled by Pulp.
+  heartbeat within 25 seconds, it is considered missing. This check occurs every 5 seconds, causing
+  a maximum delay of 30 seconds before a worker is considered missing and tasks canceled by Pulp.
 
   A missing worker has all tasks destined for it canceled, and no new work is assigned to the
   missing worker. This causes new Pulp operations dispatched to continue normally with the other

--- a/server/etc/default/upstart_pulp_resource_manager
+++ b/server/etc/default/upstart_pulp_resource_manager
@@ -25,7 +25,7 @@ CELERYD_NODES="resource_manager"
 
 # Set the concurrency of each worker node to 1, tell the worker to participate in event
 # broadcasting, and subscribe to the resource_manager queue. DO NOT CHANGE THIS SETTING!
-CELERYD_OPTS="-c 1 --events -Q resource_manager --umask=18 --heartbeat-interval=30"
+CELERYD_OPTS="-c 1 --events -Q resource_manager --umask=18 --heartbeat-interval=5"
 
 CELERYD_USER="apache"
 

--- a/server/etc/default/upstart_pulp_workers
+++ b/server/etc/default/upstart_pulp_workers
@@ -33,7 +33,7 @@ CELERY_CREATE_DIRS=1
 CELERYD_NODES=""
 
 # Set the concurrency of each worker node to 1. DO NOT CHANGE THE CONCURRENCY!
-CELERYD_OPTS="-c 1 --events --umask=18 --heartbeat-interval=30"
+CELERYD_OPTS="-c 1 --events --umask=18 --heartbeat-interval=5"
 
 CELERYD_USER="apache"
 

--- a/server/pulp/server/async/manage_workers.py
+++ b/server/pulp/server/async/manage_workers.py
@@ -22,7 +22,7 @@ User=apache
 WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -n reserved_resource_worker-%(num)s@%%%%h -A pulp.server.async.app\
           -c 1 --events --umask 18 --pidfile=/var/run/pulp/reserved_resource_worker-%(num)s.pid\
-          --heartbeat-interval=30 %(max_tasks_argument)s
+          --heartbeat-interval=5 %(max_tasks_argument)s
 KillSignal=SIGQUIT
 """
 

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -989,8 +989,8 @@ class CeleryBeatLock(AutoRetryDocument):
     """
     Single document collection which gives information about the current celerybeat lock.
 
-    :ivar celerybeat_name: string representing the celerybeat instance name
-    :type celerybeat_name: basestring
+    :ivar name: string representing the celerybeat instance name
+    :type name: basestring
     :ivar timestamp: The timestamp(UTC) at which lock is acquired
     :type timestamp: datetime.datetime
     :ivar lock: A unique key set to "locked" when lock is acquired.
@@ -998,7 +998,7 @@ class CeleryBeatLock(AutoRetryDocument):
     :ivar _ns: (Deprecated), Contains the name of the collection this model represents
     :type _ns: mongoengine.StringField
     """
-    celerybeat_name = StringField(required=True)
+    name = StringField(required=True)
     timestamp = UTCDateTimeField(required=True)
     lock = StringField(required=True, default="locked", unique=True)
 
@@ -1012,12 +1012,15 @@ class ResourceManagerLock(AutoRetryDocument):
 
     :ivar name: string representing the resource manager instance name
     :type name: basestring
+    :ivar timestamp: The timestamp(UTC) at which lock is acquired
+    :type timestamp: datetime.datetime
     :ivar lock: A unique key set to "locked" when lock is acquired.
     :type lock: basestring
     :ivar _ns: (Deprecated), Contains the name of the collection this model represents
     :type _ns: mongoengine.StringField
     """
     name = StringField(required=True)
+    timestamp = UTCDateTimeField(required=True)
     lock = StringField(required=True, default="locked", unique=True)
 
     # For backward compatibility

--- a/server/test/unit/server/async/test_app.py
+++ b/server/test/unit/server/async/test_app.py
@@ -8,7 +8,7 @@ import unittest
 
 import mock
 
-from pulp.common.constants import RESOURCE_MANAGER_WORKER_NAME, CELERY_CHECK_INTERVAL
+from pulp.common.constants import RESOURCE_MANAGER_WORKER_NAME, PULP_PROCESS_HEARTBEAT_INTERVAL
 from pulp.server.async import app
 from pulp.server.managers.factory import initialize
 
@@ -86,4 +86,4 @@ class InitializeWorkerTestCase(unittest.TestCase):
             assert_called_with(set__last_heartbeat=mock_datetime.utcnow(), upsert=True)
 
         self.assertEquals(2, len(mock_rm_lock().save.mock_calls))
-        mock_time.sleep.assert_called_once_with(CELERY_CHECK_INTERVAL)
+        mock_time.sleep.assert_called_once_with(PULP_PROCESS_HEARTBEAT_INTERVAL)

--- a/server/test/unit/server/async/test_scheduler.py
+++ b/server/test/unit/server/async/test_scheduler.py
@@ -6,7 +6,7 @@ from celery.beat import ScheduleEntry
 import mock
 from mongoengine import NotUniqueError
 
-from pulp.common.constants import RESOURCE_MANAGER_WORKER_NAME, SCHEDULER_WORKER_NAME
+from pulp.common import constants
 from pulp.server.async import scheduler
 from pulp.server.async.celery_instance import celery as app
 from pulp.server.db.model import dispatch, Worker
@@ -142,10 +142,10 @@ class TestSchedulerTick(unittest.TestCase):
         sched_instance.tick()
 
         lock_timestamp = mock_timestamp.utcnow()
-        celerybeat_name = SCHEDULER_WORKER_NAME + "@" + platform.node()
+        celerybeat_name = constants.SCHEDULER_WORKER_NAME + "@" + platform.node()
 
         mock_celerybeatlock.assert_called_once_with(
-            timestamp=lock_timestamp, celerybeat_name=celerybeat_name)
+            timestamp=lock_timestamp, name=celerybeat_name)
         mock_celerybeatlock.objects().save().assert_called_once()
 
     @mock.patch('celery.beat.Scheduler.__init__', new=mock.Mock())
@@ -406,7 +406,7 @@ class TestCeleryProcessTimeoutMonitorRun(unittest.TestCase):
         self.assertRaises(self.SleepException, scheduler.CeleryProcessTimeoutMonitor().run)
 
         # verify the frequency
-        mock_sleep.assert_called_once_with(60)
+        mock_sleep.assert_called_once_with(constants.PULP_PROCESS_HEARTBEAT_INTERVAL)
 
     @mock.patch.object(scheduler._logger, 'error', spec_set=True)
     @mock.patch.object(scheduler.CeleryProcessTimeoutMonitor, 'check_celery_processes',
@@ -467,7 +467,7 @@ class TestCeleryProcessTimeoutMonitorCheckCeleryProcesses(unittest.TestCase):
     @mock.patch('pulp.server.async.scheduler._logger', spec_set=True)
     def test_logs_scheduler_missing(self, mock__logger, mock_worker, mock_delete_worker):
         mock_worker.objects.all.return_value = [
-            Worker(name=RESOURCE_MANAGER_WORKER_NAME, last_heartbeat=datetime.utcnow()),
+            Worker(name=constants.RESOURCE_MANAGER_WORKER_NAME, last_heartbeat=datetime.utcnow()),
             Worker(name='name2', last_heartbeat=datetime.utcnow()),
         ]
 
@@ -482,7 +482,7 @@ class TestCeleryProcessTimeoutMonitorCheckCeleryProcesses(unittest.TestCase):
     @mock.patch('pulp.server.async.scheduler._logger', spec_set=True)
     def test_logs_resource_manager_missing(self, mock__logger, mock_worker, mock_delete_worker):
         mock_worker.objects.all.return_value = [
-            Worker(name=SCHEDULER_WORKER_NAME, last_heartbeat=datetime.utcnow()),
+            Worker(name=constants.SCHEDULER_WORKER_NAME, last_heartbeat=datetime.utcnow()),
             Worker(name='name2', last_heartbeat=datetime.utcnow()),
         ]
 
@@ -496,19 +496,27 @@ class TestCeleryProcessTimeoutMonitorCheckCeleryProcesses(unittest.TestCase):
     @mock.patch('pulp.server.async.scheduler.Worker', spec_set=True)
     @mock.patch('pulp.server.async.scheduler._logger', spec_set=True)
     def test_debug_logging(self, mock__logger, mock_worker, mock_delete_worker):
+        combined_delay = constants.PULP_PROCESS_TIMEOUT_INTERVAL + \
+            constants.PULP_PROCESS_HEARTBEAT_INTERVAL
+        now = datetime.utcnow()
+
         mock_worker.objects.all.return_value = [
-            Worker(name='name1', last_heartbeat=datetime.utcnow() - timedelta(seconds=400)),
-            Worker(name='name2', last_heartbeat=datetime.utcnow()),
-            Worker(name=RESOURCE_MANAGER_WORKER_NAME, last_heartbeat=datetime.utcnow()),
-            Worker(name=SCHEDULER_WORKER_NAME, last_heartbeat=datetime.utcnow()),
+            Worker(name='name1', last_heartbeat=now - timedelta(seconds=combined_delay)),
+            Worker(name='name2', last_heartbeat=now),
+            Worker(name=constants.RESOURCE_MANAGER_WORKER_NAME, last_heartbeat=now),
+            Worker(name=constants.SCHEDULER_WORKER_NAME, last_heartbeat=now),
         ]
 
         scheduler.CeleryProcessTimeoutMonitor().check_celery_processes()
         mock__logger.debug.assert_has_calls([
-            mock.call('Checking if pulp_workers, pulp_celerybeat, or '
-                      'pulp_resource_manager processes are missing for more than 300 seconds'),
-            mock.call('1 pulp_worker processes, 1 pulp_celerybeat processes, '
-                      'and 1 pulp_resource_manager processes')
+            mock.call(
+                'Checking if pulp_workers, pulp_celerybeat, or pulp_resource_manager processes are '
+                'missing for more than %d seconds' % constants.PULP_PROCESS_TIMEOUT_INTERVAL
+            ),
+            mock.call(
+                '1 pulp_worker processes, 1 pulp_celerybeat processes, '
+                'and 1 pulp_resource_manager processes'
+            )
         ])
 
 

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -1255,8 +1255,8 @@ class TestCeleryBeatLock(unittest.TestCase):
         self.assertTrue(isinstance(sample_model, Document))
 
     def test_attributes(self):
-        self.assertTrue(isinstance(model.CeleryBeatLock.celerybeat_name, StringField))
-        self.assertTrue(model.CeleryBeatLock.celerybeat_name.required)
+        self.assertTrue(isinstance(model.CeleryBeatLock.name, StringField))
+        self.assertTrue(model.CeleryBeatLock.name.required)
 
         self.assertTrue(isinstance(model.CeleryBeatLock.timestamp, DateTimeField))
         self.assertTrue(model.CeleryBeatLock.timestamp.required)

--- a/server/usr/lib/systemd/system/pulp_resource_manager.service
+++ b/server/usr/lib/systemd/system/pulp_resource_manager.service
@@ -9,7 +9,7 @@ User=apache
 WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -A pulp.server.async.app -n resource_manager@%%h\
           -Q resource_manager -c 1 --events --umask 18 --pidfile=/var/run/pulp/resource_manager.pid\
-          --heartbeat-interval=30
+          --heartbeat-interval=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Similified and reduced the timings so that all failure detection occurs within 30 seconds. Changed resource_manager to use a timestamp-based locking mechanism.

closes #2509
https://pulp.plan.io/issues/2509