### PR TITLE
Problem: pulp_celerybeat writes hearbeat records to the database

### DIFF
--- a/docs/user-guide/release-notes/2.12.x.rst
+++ b/docs/user-guide/release-notes/2.12.x.rst
@@ -13,6 +13,9 @@ New Features
    processes are running. This will prevent the user from corrupting their Pulp installation by
    migrating with running workers. This works in both standalone and clustered installations. Pulp
    may wait up to 92 seconds to determine if workers are running.
+ * pulp_workers, pulp_resource_manager, and pulp_celerybeat record their own hearbeats to the
+   database. pulp_celerybeat does not need to be running to determine if pulp_resource_manager and
+   pulp_workers are online.
 
 Deprecation
 -----------

--- a/server/pulp/server/async/worker_watcher.py
+++ b/server/pulp/server/async/worker_watcher.py
@@ -78,9 +78,6 @@ def handle_worker_heartbeat(event):
         msg = _("New worker '%(worker_name)s' discovered") % event_info
         _logger.info(msg)
 
-    Worker.objects(name=event_info['worker_name']).\
-        update_one(set__last_heartbeat=event_info['local_received'], upsert=True)
-
 
 def handle_worker_offline(event):
     """

--- a/server/test/unit/server/async/test_worker_watcher.py
+++ b/server/test/unit/server/async/test_worker_watcher.py
@@ -42,7 +42,7 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
     def test_handle_worker_heartbeat_new(self, mock__parse_and_log_event,
                                          mock_worker, mock_logger):
         """
-        Ensure that we save a record and log when a new worker comes online.
+        Ensure that we log when a new worker comes online.
         """
 
         mock_event = mock.Mock()
@@ -53,8 +53,6 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
 
         worker_watcher.handle_worker_heartbeat(mock_event)
 
-        mock_worker.objects.return_value.update_one.\
-            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:36Z', upsert=True)
         mock_logger.info.assert_called_once_with('New worker \'fake-worker\' discovered')
 
     @mock.patch('pulp.server.async.worker_watcher._logger')
@@ -63,7 +61,7 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
     def test_handle_worker_heartbeat_update(self, mock__parse_and_log_event,
                                             mock_worker, mock_logger):
         """
-        Ensure that we save a record but don't log when an existing worker is updated.
+        Ensure that we don't log when an existing worker is updated.
         """
 
         mock_event = mock.Mock()
@@ -74,8 +72,6 @@ class TestHandleWorkerHeartbeat(unittest.TestCase):
 
         worker_watcher.handle_worker_heartbeat(mock_event)
 
-        mock_worker.objects.return_value.update_one.\
-            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:48Z', upsert=True)
         self.assertEquals(mock_logger.info.called, False)
 
 


### PR DESCRIPTION
Solution: All workers write their own records to the db instead of
sending them through the message bus.

This patch makes use of the Consumer blueprint that celery runs at
start time of a worker. An extra bootstep has been added to the
consumer blueprint. The new bootstep sets a 30 second timer which
runs a method that records a heartbeat in the database.

http://docs.celeryproject.org/en/master/userguide/extending.html
https://groups.google.com/d/msg/celery-users/3fs0ocREYqw/C7U1lCAp56sJ

closes #2519
https://pulp.plan.io/issues/2519