### PR TITLE
Explictly log failovers

### DIFF
--- a/docs/user-guide/release-notes/2.12.x.rst
+++ b/docs/user-guide/release-notes/2.12.x.rst
@@ -21,6 +21,9 @@ New Features
 * Worker failure detection and high availability failover occurs within 30 seconds. Pulp processes are
   considered missing after 25 seconds, and heartbeats occur every 5 seconds.
 
+* Failover events are now logged at the WARNING level with a message which explicitly states that
+  failover has occurred.
+
 
 Deprecation
 -----------

--- a/server/pulp/server/async/app.py
+++ b/server/pulp/server/async/app.py
@@ -137,6 +137,11 @@ def get_resource_manager_lock(name):
 
             msg = _("Resource manager '%s' has acquired the resource manager lock") % name
             _logger.info(msg)
+
+            if not _first_check:
+                msg = _("Failover occurred: '%s' is now the primary resource manager") % name
+                _logger.warning(msg)
+
             break
         except mongoengine.NotUniqueError:
             # Only log the message the first time


### PR DESCRIPTION
Failover events are now logged as such
at the WARNING level

closes #2525