### PR TITLE
Fix relative path issue and exit tests on missing dependencies.

### DIFF
--- a/devel/pulp/devel/test_runner.py
+++ b/devel/pulp/devel/test_runner.py
@@ -12,6 +12,27 @@ import sys
 os.environ['DJANGO_SETTINGS_MODULE'] = 'pulp.server.webservices.settings'
 
 
+# From: http://stackoverflow.com/questions/377017/test-if-executable-exists-in-python/377028#377028
+def which(program):
+    import os
+
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            path = path.strip('"')
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
+
 def run_tests(packages, tests_all_platforms, tests_non_rhel5,
               flake8_paths=None, flake8_exclude=None):
     """
@@ -33,6 +54,15 @@ def run_tests(packages, tests_all_platforms, tests_non_rhel5,
     :return: the exit code from nosetests
     :rtype:  integer
     """
+
+    # Test to make sure the necessary executables exist
+    if which('flake8') is None:
+        print 'flake8 not found or is not executable! Please correct before running tests.'
+        exit(2)
+    if which('nosetests') is None:
+        print 'nosetests not found or is not executable! Please correct before running tests.'
+        exit(2)
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--xunit-file')
     parser.add_argument('--with-xunit', action='store_true')

--- a/devel/setup.py
+++ b/devel/setup.py
@@ -4,10 +4,11 @@ from setuptools import setup, find_packages
 
 PYTHON_MAJOR_MINOR = '%s.%s' % (sys.version_info[0], sys.version_info[1])
 
+requires = {'install_requires': ['mock<1.1']}
+
 if PYTHON_MAJOR_MINOR < '2.7':
-    requires = {'install_requires': ['argparse']}
-else:
-    requires = {}
+    requires['install_requires'].append('argparse')
+
 
 setup(
     name='pulp-devel',

--- a/run-tests.py
+++ b/run-tests.py
@@ -10,7 +10,7 @@ from pulp.server.constants import PULP_DJANGO_SETTINGS_MODULE
 
 
 # Find and eradicate any existing .pyc files, so they do not eradicate us!
-PROJECT_DIR = os.path.dirname(__file__)
+PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 subprocess.call(['find', PROJECT_DIR, '-name', '*.pyc', '-delete'])
 
 # These paths should all pass PEP-8 checks


### PR DESCRIPTION
This relates to https://pulp.plan.io/issues/2444 and trying to get pulp
running on other operating systems and installing through pip. These changes
were tested on the docker image python:2.

Trying to run the tests for the first time, I was met with a few missing dependencies. It seems like this is something that the test runner should check instead of giving a generic no file or directory error. 