### PR TITLE
Added release note for docker tag command

### DIFF
--- a/docs/user-guide/release-notes/2.12.x.rst
+++ b/docs/user-guide/release-notes/2.12.x.rst
@@ -29,6 +29,10 @@ New Features
   WARNING level. The log message explicitly states that failover has occurred, along with the
   name of the hot spare process which has taken over as primary.
 
+* Added ``docker repo tag`` command to point a docker tag to a manifest. If the tag we specify does
+  not exist, it will be created. If the tag exists however, it will be updated as tag name is unique
+  per repository and can point to only one manifest.
+
 
 Deprecation
 -----------


### PR DESCRIPTION
Forgot to update the 2.12 release notes with new docker tag feature.