### PR TITLE
Workers write their own hearbeat records to database.

### DIFF
--- a/docs/user-guide/release-notes/2.13.x.rst
+++ b/docs/user-guide/release-notes/2.13.x.rst
@@ -11,3 +11,23 @@ New Features
 * Log statements which are emitted from task processes now include a short task
   id of 8 characters (i.e. ``pulp.server.sync::INFO: [0ca4399c] ...``) which
   can be used to look up a task.
+* Users no longer need to have pulp_celerybeat running to know whether pulp_workers or
+  pulp_resource_manager are online. All workers now write their own heartbeat records to the
+  database, eliminating the dependence on pulp_celerybeat.
+
+Bug Fixes
+---------
+
+See the list of :fixedbugs:`2.13.0`
+
+Upgrade instructions
+--------------------
+
+Upgrade using the normal process::
+
+    $ sudo systemctl stop httpd pulp_workers pulp_resource_manager pulp_celerybeat pulp_streamer goferd
+    $ sudo yum upgrade
+    $ sudo -u apache pulp-manage-db
+    $ sudo systemctl start httpd pulp_workers pulp_resource_manager pulp_celerybeat pulp_streamer goferd
+
+``pulp_streamer`` and ``goferd`` should be omitted if those services are not installed.

--- a/docs/user-guide/release-notes/index.rst
+++ b/docs/user-guide/release-notes/index.rst
@@ -6,6 +6,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
+   2.13.x
    2.12.x
    2.11.x
    2.10.x

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -90,12 +90,12 @@ Task ID
 
 Since Pulp is a multi-process application, Pulp will attempt to log a shortened 8 character version
 of the task id if the log entry is emitted from a task process. This can be used to look up the task
-in ``pulp-admin tasks`` commands.  An example of a log statement with a task id would be:
+in ``pulp-admin tasks`` commands.  An example of a log statement with a task id would be::
 
     Jan 20 23:12:02 myhost pulp[30687]: pulp_rpm.plugins.importers.yum.sync:INFO: [338bdde4] Downloading 32 RPMs
 
 Here the shortened task id is ``338bdde4``. The full task id would be
-``338bdde4-608a-44ab-a79c-49c28b0fe037``. A statement without a task id would look like:
+``338bdde4-608a-44ab-a79c-49c28b0fe037``. A statement without a task id would look like::
 
     Jan 21 23:12:02 myhost pulp[30482]: pulp.server.async.worker_watcher:INFO: New worker 'resource_manager@myhost' discovered
 

--- a/server/etc/default/upstart_pulp_resource_manager
+++ b/server/etc/default/upstart_pulp_resource_manager
@@ -25,7 +25,7 @@ CELERYD_NODES="resource_manager"
 
 # Set the concurrency of each worker node to 1, tell the worker to participate in event
 # broadcasting, and subscribe to the resource_manager queue. DO NOT CHANGE THIS SETTING!
-CELERYD_OPTS="-c 1 --events -Q resource_manager --umask=18 --heartbeat-interval=5"
+CELERYD_OPTS="-c 1 --events -Q resource_manager --umask=18"
 
 CELERYD_USER="apache"
 

--- a/server/etc/default/upstart_pulp_workers
+++ b/server/etc/default/upstart_pulp_workers
@@ -33,7 +33,7 @@ CELERY_CREATE_DIRS=1
 CELERYD_NODES=""
 
 # Set the concurrency of each worker node to 1. DO NOT CHANGE THE CONCURRENCY!
-CELERYD_OPTS="-c 1 --events --umask=18 --heartbeat-interval=5"
+CELERYD_OPTS="-c 1 --events --umask=18"
 
 CELERYD_USER="apache"
 

--- a/server/pulp/server/async/manage_workers.py
+++ b/server/pulp/server/async/manage_workers.py
@@ -22,7 +22,7 @@ User=apache
 WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -n reserved_resource_worker-%(num)s@%%%%h -A pulp.server.async.app\
           -c 1 --events --umask 18 --pidfile=/var/run/pulp/reserved_resource_worker-%(num)s.pid\
-          --heartbeat-interval=5 %(max_tasks_argument)s
+          %(max_tasks_argument)s
 KillSignal=SIGQUIT
 """
 

--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -32,56 +32,6 @@ _logger = logging.getLogger(__name__)
 CELERYBEAT_NAME = constants.SCHEDULER_WORKER_NAME + "@" + platform.node()
 
 
-class EventMonitor(threading.Thread):
-    """
-    The EventMonitor is a thread dedicated to handling worker discovery/departure.
-    """
-
-    def __init__(self):
-        super(EventMonitor, self).__init__()
-
-    def run(self):
-        """
-        The thread entry point, which calls monitor_events().
-
-        monitor_events() is a blocking call, but in the case where an unexpected Exception is
-        raised, a log-but-continue behavior is desired. This is especially the case given this is
-        a background thread. Exiting is not a concern because this is a daemon=True thread. The
-        method loops unconditionally using a try/except pattern around the call to
-        monitor_events() to log and then re-enter if an exception is encountered.
-        """
-        while True:
-            try:
-                self.monitor_events()
-            except Exception as e:
-                _logger.error(e)
-            time.sleep(10)
-
-    def monitor_events(self):
-        """
-        Process Celery events.
-
-        Receives events from Celery and matches each with the appropriate handler function. The
-        following events are monitored for: 'task-failed', 'task-succeeded', 'worker-heartbeat',
-        and 'worker-offline'. The call to capture() is blocking, and does not return.
-
-        Capture is called with wakeup=True causing a gratuitous 'worker-heartbeat' to be sent
-        from all workers. This should handle the case of worker discovery where workers already
-        exist, and this EventMonitor is started afterwards.
-
-        The call to capture is wrapped in a log-but-continue try/except statement, which along
-        with the loop will cause the capture method to be re-entered.
-        """
-        with app.connection() as connection:
-            recv = app.events.Receiver(connection, handlers={
-                'worker-heartbeat': worker_watcher.handle_worker_heartbeat,
-                'worker-offline': worker_watcher.handle_worker_offline,
-                'worker-online': worker_watcher.handle_worker_heartbeat,
-            })
-            _logger.info(_('Event Monitor Starting'))
-            recv.capture(limit=None, timeout=None, wakeup=True)
-
-
 class CeleryProcessTimeoutMonitor(threading.Thread):
     """
     A thread dedicated to monitoring Celery processes that have stopped checking in.
@@ -90,7 +40,7 @@ class CeleryProcessTimeoutMonitor(threading.Thread):
     """
     def run(self):
         """
-        The thread entry point. Sleep for FREQUENCY seconds, then call check_celery_processes()
+        The thread entry point. Sleep for the heartbeat interval, then call check_celery_processes()
 
         This method has a try/except block around check_celery_processes() to add durability to
         this background thread.
@@ -209,27 +159,30 @@ class Scheduler(beat.Scheduler):
         """
         Start two threads that are important to Pulp. One monitors workers, the other, events.
 
-        Two threads are started, one that uses EventMonitor, and handles all Celery events. The
-        second, is a WorkerTimeoutMonitor thread that watches for cases where all workers
+        A WorkerTimeoutMonitor thread is started that watches for cases where all workers
         disappear at once.
 
-        Both threads are set with daemon = True so that if the main thread exits, both will
-        close automatically. After being daemonized they are each started with a call to start().
+        The thread is set with daemon = True so that if the main thread exits, it will close
+        automatically.
 
         This method should be called only in certain situations, see docstrings on the object for
         more details.
         """
-        # start monitoring events in a thread
-        event_monitor = EventMonitor()
-        event_monitor.daemon = True
-        event_monitor.start()
         # start monitoring workers who may timeout
         worker_timeout_monitor = CeleryProcessTimeoutMonitor()
         worker_timeout_monitor.daemon = True
         worker_timeout_monitor.start()
 
-    @staticmethod
     def call_tick(self, celerybeat_name):
+        """
+        Call the superclass tick method and log a debug message.
+
+        :param celerybeat_name: hostname of the celerybeat instance
+        :type  celerybeat_name: basestring
+
+        :return:                seconds until the next tick
+        :rtype:                 integer
+        """
         ret = super(Scheduler, self).tick()
         _logger.debug(_("%(celerybeat_name)s will tick again in %(ret)s secs")
                       % {'ret': ret, 'celerybeat_name': celerybeat_name})
@@ -239,22 +192,12 @@ class Scheduler(beat.Scheduler):
         """
         Superclass runs a tick, that is one iteration of the scheduler. Executes all due tasks.
 
-        This method updates the last heartbeat time of the scheduler. We do not actually send a
-        heartbeat message since it would just get read again by this class.
+        This method updates the last heartbeat time of the scheduler.
 
         :return:    number of seconds before the next tick should run
         :rtype:     float
         """
-        # this is not an event that gets sent anywhere. We process it
-        # immediately.
-        scheduler_event = {
-            'timestamp': time.time(),
-            'local_received': time.time(),
-            'type': 'scheduler-event',
-            'hostname': CELERYBEAT_NAME
-        }
-
-        worker_watcher.handle_worker_heartbeat(scheduler_event)
+        worker_watcher.handle_worker_heartbeat(CELERYBEAT_NAME)
 
         now = ensure_tz(datetime.utcnow())
         old_timestamp = now - timedelta(seconds=constants.PULP_PROCESS_TIMEOUT_INTERVAL)
@@ -267,7 +210,7 @@ class Scheduler(beat.Scheduler):
         if result == 1:
             _logger.debug(_('Lock updated by %(celerybeat_name)s')
                           % {'celerybeat_name': CELERYBEAT_NAME})
-            ret = self.call_tick(self, CELERYBEAT_NAME)
+            ret = self.call_tick(CELERYBEAT_NAME)
         else:
             # check for old enough time_stamp and remove if such lock is present
             CeleryBeatLock.objects(timestamp__lte=old_timestamp).delete()
@@ -286,7 +229,7 @@ class Scheduler(beat.Scheduler):
                     _logger.warning(msg)
 
                 # After acquiring new lock call super to dispatch tasks
-                ret = self.call_tick(self, CELERYBEAT_NAME)
+                ret = self.call_tick(CELERYBEAT_NAME)
 
             except mongoengine.NotUniqueError:
                 # Setting a default wait time for celerybeat instances with no lock
@@ -305,7 +248,7 @@ class Scheduler(beat.Scheduler):
         "_schedule" dictionary as instances of celery.beat.ScheduleEntry
         """
         if not Scheduler._mongo_initialized:
-            _logger.debug('Initializing Mongo client connection to read celerybeat schedule')
+            _logger.debug(_('Initializing Mongo client connection to read celerybeat schedule'))
             db_connection.initialize()
             Scheduler._mongo_initialized = True
         _logger.debug(_('loading schedules from app'))
@@ -329,7 +272,7 @@ class Scheduler(beat.Scheduler):
                 update_timestamps.append(call.last_updated)
                 self._loaded_from_db_count += 1
 
-        _logger.debug('loaded %(count)d schedules' % {'count': self._loaded_from_db_count})
+        _logger.debug(_('loaded %(count)d schedules') % {'count': self._loaded_from_db_count})
 
         self._most_recent_timestamp = max(update_timestamps)
 
@@ -381,5 +324,5 @@ class Scheduler(beat.Scheduler):
 
     def close(self):
         """This is called when celerybeat is being shutdown."""
-        _delete_worker(CELERYBEAT_NAME, normal_shutdown=True)
+        worker_watcher.handle_worker_offline(CELERYBEAT_NAME)
         super(Scheduler, self).close()

--- a/server/pulp/server/async/worker_watcher.py
+++ b/server/pulp/server/async/worker_watcher.py
@@ -17,97 +17,48 @@ from datetime import datetime
 from gettext import gettext as _
 import logging
 
-from pulp.common import constants
 from pulp.server.async.tasks import _delete_worker
-from pulp.server.db.model import Worker, ResourceManagerLock
+from pulp.server.db.model import Worker
 
 
 _logger = logging.getLogger(__name__)
 
 
-def _parse_and_log_event(event):
+def handle_worker_heartbeat(worker_name):
     """
-    Parse and return the event information we are interested in. Also log it.
+    This is a generic function for updating worker heartbeat records.
 
-    A new dict is returned containing the keys 'timestamp', 'local_received', 'type', and
-    'worker_name'. The data transformations here are on the timestamp and local_received. They
-    both arrive as seconds since the epoch, and are converted to a naive datetime.datetime object in
-    UTC. The timestamp is set by the sender, and the local_received time is set by the receiver.
-    Beware of a bug in the value of the timestamp as of the time of this commit as it suffers from
-    issues in localities that use daylight savings time during the non-daylight savings time part of
-    the year. See https://github.com/celery/celery/issues/1802#issuecomment-161916587 for discussion
-    around this issue. Until that issue is resolved, consider using the local_received time instead
-    of the timestamp.
+    Existing Worker objects are searched for one to update. If an existing one is found, it is
+    updated. Otherwise a new Worker entry is created. Logging at the info level is also done.
 
-    Logging is done through a call to _log_event().
-
-    :param event: A celery event
-    :type  event: dict
-    :return:      A dict containing the keys 'timestamp', 'local_received', 'type', and
-                  'worker_name'. 'timestamp' and 'local_received' are naive datetime.datetime
-                  objects reported in UTC. 'type' is the event name as a string
-                  (ie: 'worker-heartbeat'), and 'worker_name' is the name of the worker as a string.
-    :rtype:       dict
+    :param worker_name: The hostname of the worker
+    :type  worker_name: basestring
     """
-    event_info = {
-        'timestamp': datetime.utcfromtimestamp(event['timestamp']),
-        'local_received': datetime.utcfromtimestamp(event['local_received']), 'type': event['type'],
-        'worker_name': event['hostname']}
-    msg = _("'%(type)s' sent at time %(timestamp)s from %(worker_name)s, received at time: "
-            "%(local_received)s")
-    msg = msg % event_info
-    _logger.debug(msg)
-    return event_info
-
-
-def handle_worker_heartbeat(event):
-    """
-    Celery event handler for 'worker-heartbeat' events.
-
-    The event is first parsed and logged.  Then the existing Worker objects are
-    searched for one to update. If an existing one is found, it is updated.
-    Otherwise a new Worker entry is created. Logging at the info and debug
-    level is also done.
-
-    :param event: A celery event to handle.
-    :type event: dict
-    """
-    event_info = _parse_and_log_event(event)
-    existing_worker = Worker.objects(name=event_info['worker_name']).first()
+    existing_worker = Worker.objects(name=worker_name).first()
 
     if not existing_worker:
-        msg = _("New worker '%(worker_name)s' discovered") % event_info
+        msg = _("New worker '%s' discovered") % worker_name
         _logger.info(msg)
 
-    # Update the worker timestamp, and create a new worker record if the worker did not previously
-    # exist
-    Worker.objects(name=event_info['worker_name']).\
-        update_one(set__last_heartbeat=event_info['local_received'], upsert=True)
+    timestamp = datetime.utcnow()
+    msg = _("Worker heartbeat from '{name}' at time {timestamp}").format(timestamp=timestamp,
+                                                                         name=worker_name)
+    _logger.debug(msg)
 
-    # If the worker is a resource manager, update the associated ResourceManagerLock timestamp
-    if event_info['worker_name'].startswith(constants.RESOURCE_MANAGER_WORKER_NAME):
-        ResourceManagerLock.objects(name=event_info['worker_name']).\
-            update_one(set__timestamp=datetime.utcnow(), upsert=False)
+    Worker.objects(name=worker_name).update_one(set__last_heartbeat=timestamp,
+                                                upsert=True)
 
 
-def handle_worker_offline(event):
+def handle_worker_offline(worker_name):
     """
-    Celery event handler for 'worker-offline' events.
+    This is a generic function for handling workers going offline.
 
-    The 'worker-offline' event is emitted when a worker gracefully shuts down. It is not
-    emitted when a worker is killed instantly.
+    _delete_worker() task is called to handle any work cleanup associated with a worker going
+    offline. Logging at the info level is also done.
 
-    The event is first parsed and logged. If this event is from the resource manager, there is
-    no further processing to be done. Otherwise, a worker is shutting down, and a
-    _delete_worker() task is dispatched so that the resource manager will remove the record,
-    and handle any work cleanup associated with a worker going offline. Logging at the info
-    and debug level is also done.
-
-    :param event: A celery event to handle.
-    :type event: dict
+    :param worker_name: The hostname of the worker
+    :type  worker_name: basestring
     """
-    event_info = _parse_and_log_event(event)
-
-    msg = _("Worker '%(worker_name)s' shutdown") % event_info
+    msg = _("Worker '%s' shutdown") % worker_name
     _logger.info(msg)
-    _delete_worker(event_info['worker_name'], normal_shutdown=True)
+    _delete_worker(worker_name, normal_shutdown=True)

--- a/server/test/unit/server/async/test_app.py
+++ b/server/test/unit/server/async/test_app.py
@@ -27,7 +27,7 @@ class InitializeWorkerTestCase(unittest.TestCase):
     @mock.patch('pulp.server.async.app.get_resource_manager_lock')
     def test_initialize_worker(self,
                                mock_get_resource_manager_lock,
-                               _delete_worker, initialize,
+                               _delete_worker, mock_initialize,
                                create_worker_working_directory,
                                delete_worker_working_directory):
         """
@@ -38,7 +38,7 @@ class InitializeWorkerTestCase(unittest.TestCase):
         # The instance argument isn't used and don't matter, so we'll just pass a mock
         app.initialize_worker(sender, mock.MagicMock())
 
-        initialize.assert_called_once_with()
+        mock_initialize.assert_called_once_with()
         _delete_worker.assert_called_once_with(sender, normal_shutdown=True)
         create_worker_working_directory.assert_called_once_with(sender)
         delete_worker_working_directory.assert_called_once_with(sender)
@@ -51,7 +51,7 @@ class InitializeWorkerTestCase(unittest.TestCase):
     @mock.patch('pulp.server.async.app.get_resource_manager_lock')
     def test_initialize_worker_resource_manager(self,
                                                 mock_get_resource_manager_lock,
-                                                _delete_worker, initialize,
+                                                _delete_worker, mock_initialize,
                                                 create_worker_working_directory,
                                                 delete_worker_working_directory):
         """
@@ -62,7 +62,7 @@ class InitializeWorkerTestCase(unittest.TestCase):
         # The instance argument isn't used and don't matter, so we'll just pass a mock
         app.initialize_worker(sender, mock.MagicMock())
 
-        initialize.assert_called_once_with()
+        mock_initialize.assert_called_once_with()
         _delete_worker.assert_called_once_with(sender, normal_shutdown=True)
         create_worker_working_directory.assert_called_once_with(sender)
         delete_worker_working_directory.assert_called_once_with(sender)

--- a/server/test/unit/server/async/test_worker_watcher.py
+++ b/server/test/unit/server/async/test_worker_watcher.py
@@ -1,4 +1,3 @@
-import datetime
 import unittest
 
 import mock
@@ -6,92 +5,44 @@ import mock
 from pulp.server.async import worker_watcher
 
 
-class TestParseAndLogEvent(unittest.TestCase):
-    def test__parse_and_log_event(self):
-        event = {'timestamp': 1449260644.097711, 'local_received': 1449260669.830475,
-                 'type': 'fake-type', 'hostname': 'fake-worker'}
-
-        result = worker_watcher._parse_and_log_event(event)
-
-        # assert that the values in the result dictionary are right
-        self.assertEqual(result['timestamp'], datetime.datetime.utcfromtimestamp(1449260644.097711))
-        self.assertEqual(result['local_received'],
-                         datetime.datetime.utcfromtimestamp(1449260669.830475))
-        self.assertTrue(result['type'] is event['type'])
-        self.assertTrue(result['worker_name'] is event['hostname'])
-
-    @mock.patch('pulp.server.async.worker_watcher._logger')
-    @mock.patch('pulp.server.async.worker_watcher._')
-    def test__log_event_logs_correctly(self, mock_gettext, mock__logger):
-        event_info = {'timestamp': 1449260644.097711, 'local_received': 1449260669.830475,
-                      'type': 'fake-type', 'hostname': 'fake-worker'}
-
-        worker_watcher._parse_and_log_event(event_info)
-
-        log_string = ("'%(type)s' sent at time %(timestamp)s from %(worker_name)s, received at "
-                      "time: %(local_received)s")
-        mock_gettext.assert_called_with(log_string)
-        mock__logger.assert_called_once()
-
-
 class TestHandleWorkerHeartbeat(unittest.TestCase):
 
+    @mock.patch('pulp.server.async.worker_watcher.datetime')
     @mock.patch('pulp.server.async.worker_watcher._logger')
     @mock.patch('pulp.server.async.worker_watcher.Worker')
-    @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event')
-    def test_handle_worker_heartbeat_new(self, mock__parse_and_log_event,
-                                         mock_worker, mock_logger):
+    def test_handle_worker_heartbeat_new(self, mock_worker, mock_logger, mock_datetime):
         """
         Ensure that we save a record and log when a new worker comes online.
         """
-
-        mock_event = mock.Mock()
         mock_worker.objects.return_value.first.return_value = None
-        mock__parse_and_log_event.return_value = {
-            'worker_name': 'fake-worker', 'timestamp': '2014-12-08T15:52:29Z',
-            'local_received': '2014-12-08T15:52:36Z', 'type': 'fake-type'}
-
-        worker_watcher.handle_worker_heartbeat(mock_event)
-
-        mock_worker.objects.return_value.update_one.\
-            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:36Z', upsert=True)
+        worker_watcher.handle_worker_heartbeat('fake-worker')
         mock_logger.info.assert_called_once_with('New worker \'fake-worker\' discovered')
+        mock_worker.objects.return_value.update_one.\
+            assert_called_once_with(set__last_heartbeat=mock_datetime.utcnow(), upsert=True)
 
+    @mock.patch('pulp.server.async.worker_watcher.datetime')
     @mock.patch('pulp.server.async.worker_watcher._logger')
     @mock.patch('pulp.server.async.worker_watcher.Worker')
-    @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event')
-    def test_handle_worker_heartbeat_update(self, mock__parse_and_log_event,
-                                            mock_worker, mock_logger):
+    def test_handle_worker_heartbeat_update(self, mock_worker, mock_logger, mock_datetime):
         """
-        Ensure that we save a record but don't log when an existing worker is updated.
+        Ensure that we don't log when an existing worker is updated.
         """
-
-        mock_event = mock.Mock()
         mock_worker.objects.return_value.first.return_value = mock.Mock()
-        mock__parse_and_log_event.return_value = {
-            'worker_name': 'fake-worker', 'timestamp': '2014-12-08T15:52:29Z',
-            'local_received': '2014-12-08T15:52:48Z', 'type': 'fake-type'}
-
-        worker_watcher.handle_worker_heartbeat(mock_event)
-
-        mock_worker.objects.return_value.update_one.\
-            assert_called_once_with(set__last_heartbeat='2014-12-08T15:52:48Z', upsert=True)
+        worker_watcher.handle_worker_heartbeat('fake-worker')
         self.assertEquals(mock_logger.info.called, False)
+        mock_worker.objects.return_value.update_one.\
+            assert_called_once_with(set__last_heartbeat=mock_datetime.utcnow(), upsert=True)
 
 
 class TestHandleWorkerOffline(unittest.TestCase):
-    @mock.patch('pulp.server.async.worker_watcher._parse_and_log_event')
     @mock.patch('pulp.server.async.worker_watcher._delete_worker')
     @mock.patch('pulp.server.async.worker_watcher._')
     @mock.patch('pulp.server.async.worker_watcher._logger')
-    def test_handle_worker_offline(self, mock__logger, mock_gettext, mock__delete_worker,
-                                   mock__parse_and_log_event):
-        mock_event = mock.Mock()
-
-        worker_watcher.handle_worker_offline(mock_event)
-
-        event_info = mock__parse_and_log_event.return_value
-        mock__parse_and_log_event.assert_called_once_with(mock_event)
-        mock_gettext.assert_called_once_with("Worker '%(worker_name)s' shutdown")
+    def test_handle_worker_offline(self, mock__logger, mock_gettext, mock__delete_worker):
+        """
+        Ensure that we log and clean up appropriately when the worker goes offline.
+        """
+        worker_watcher.handle_worker_offline('fake-worker')
+        mock_gettext.assert_called_once_with("Worker '%s' shutdown")
         mock__logger.info.assert_called_once()
-        mock__delete_worker.assert_called_once_with(event_info['worker_name'], normal_shutdown=True)
+        mock__delete_worker.assert_called_once_with('fake-worker', normal_shutdown=True)

--- a/server/usr/lib/systemd/system/pulp_resource_manager.service
+++ b/server/usr/lib/systemd/system/pulp_resource_manager.service
@@ -8,8 +8,7 @@ EnvironmentFile=/etc/default/pulp_resource_manager
 User=apache
 WorkingDirectory=/var/run/pulp/
 ExecStart=/usr/bin/celery worker -A pulp.server.async.app -n resource_manager@%%h\
-          -Q resource_manager -c 1 --events --umask 18 --pidfile=/var/run/pulp/resource_manager.pid\
-          --heartbeat-interval=5
+          -Q resource_manager -c 1 --events --umask 18 --pidfile=/var/run/pulp/resource_manager.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
All workers will write their own records to the database
instead of relying on pulp_celerybeat to do so for them
using celery heartbeats.

This patch makes use of the Consumer blueprint that celery
runs at the start time of a worker. An extra boot step has
been added which sets a timer to periodically update the
worker record in the database.

http://docs.celeryproject.org/en/master/userguide/extending.html
https://groups.google.com/d/msg/celery-users/3fs0ocREYqw/C7U1lCAp56sJ

closes #2519
https://pulp.plan.io/issues/2519
closes #2516
https://pulp.plan.io/issues/2516