### PR TITLE
Appending 8 character task id to log output

### DIFF
--- a/docs/user-guide/release-notes/2.13.x.rst
+++ b/docs/user-guide/release-notes/2.13.x.rst
@@ -1,0 +1,13 @@
+=======================
+Pulp 2.13 Release Notes
+=======================
+
+Pulp 2.13.0
+===========
+
+New Features
+------------
+
+* Log statements which are emitted from task processes now include a short task
+  id of 8 characters (i.e. ``pulp.server.sync::INFO: [0ca4399c] ...``) which
+  can be used to look up a task.

--- a/docs/user-guide/troubleshooting.rst
+++ b/docs/user-guide/troubleshooting.rst
@@ -85,6 +85,20 @@ processes to write to the same file path, and so Pulp had to do something differ
 widely used logging protocol, and given the distributed nature of Pulp it was the most appropriate
 logging solution available.
 
+Task ID
+^^^^^^^
+
+Since Pulp is a multi-process application, Pulp will attempt to log a shortened 8 character version
+of the task id if the log entry is emitted from a task process. This can be used to look up the task
+in ``pulp-admin tasks`` commands.  An example of a log statement with a task id would be:
+
+    Jan 20 23:12:02 myhost pulp[30687]: pulp_rpm.plugins.importers.yum.sync:INFO: [338bdde4] Downloading 32 RPMs
+
+Here the shortened task id is ``338bdde4``. The full task id would be
+``338bdde4-608a-44ab-a79c-49c28b0fe037``. A statement without a task id would look like:
+
+    Jan 21 23:12:02 myhost pulp[30482]: pulp.server.async.worker_watcher:INFO: New worker 'resource_manager@myhost' discovered
+
 Other logs
 ^^^^^^^^^^
 

--- a/server/pulp/server/logs.py
+++ b/server/pulp/server/logs.py
@@ -10,6 +10,7 @@ import threading
 from celery.signals import setup_logging
 
 from pulp.server import config
+from pulp.server.async.tasks import get_current_task_id
 
 
 DEFAULT_LOG_LEVEL = logging.INFO
@@ -18,6 +19,7 @@ DEFAULT_LOG_LEVEL = logging.INFO
 # future.
 LOG_BLACKLIST = ['qpid.messaging.io.ops', 'qpid.messaging.io.raw']
 LOG_FORMAT_STRING = 'pulp: %(name)s:%(levelname)s: %(message)s'
+TASK_LOG_FORMAT_STRING = 'pulp: %(name)s:%(levelname)s: [%(task_id)-8s] %(message)s'
 LOG_PATH = os.path.join('/', 'dev', 'log')
 
 
@@ -58,7 +60,9 @@ def start_logging(*args, **kwargs):
         sys.exit(os.EX_UNAVAILABLE)
 
     handler = CompliantSysLogHandler(address=LOG_PATH, facility=CompliantSysLogHandler.LOG_DAEMON)
-    formatter = logging.Formatter(LOG_FORMAT_STRING)
+    task_filter = TaskIDFilter()
+    handler.addFilter(task_filter)
+    formatter = TaskLogFormatter()
     handler.setFormatter(formatter)
     root_logger.handlers = []
     root_logger.addHandler(handler)
@@ -82,6 +86,29 @@ def stop_logging():
     logging.shutdown()
     root_logger = logging.getLogger()
     root_logger.handlers = []
+
+
+class TaskIDFilter(logging.Filter):
+    """
+    This is a filter which injects the current task id from celery into the log.
+    """
+    def filter(self, record):
+        record.task_id = get_current_task_id()
+        return True
+
+
+class TaskLogFormatter(logging.Formatter):
+    """
+    This formatter changes format depending on whether there is a task_id in
+    the LogRecord
+    """
+    def format(self, record):
+        if record.task_id is None:
+            self._fmt = LOG_FORMAT_STRING
+        else:
+            record.task_id = record.task_id[:8]
+            self._fmt = TASK_LOG_FORMAT_STRING
+        return logging.Formatter.format(self, record)
 
 
 class CompliantSysLogHandler(logging.handlers.SysLogHandler):
@@ -156,6 +183,8 @@ class CompliantSysLogHandler(logging.handlers.SysLogHandler):
                     name=record.name, level=record.levelno, pathname=record.pathname,
                     lineno=record.lineno, msg=message_chunk, args=tuple(),
                     exc_info=None, func=record.funcName)
+
+                self.filter(new_record)
                 # In Python 2.6 and earlier, the SysLogHandler is not a new-style class. This means
                 # that super() cannot be used, so we will just call the SysLogHandler's emit()
                 # directly.

--- a/server/test/unit/server/test_logs.py
+++ b/server/test/unit/server/test_logs.py
@@ -810,7 +810,7 @@ class TestStartLogging(unittest.TestCase):
         self.assertEqual(root_handler.facility, logs.CompliantSysLogHandler.LOG_DAEMON)
 
         # And the handler should have the formatter with our format string
-        self.assertEqual(root_handler.formatter._fmt, logs.LOG_FORMAT_STRING)
+        self.assertTrue(isinstance(root_handler.formatter, logs.TaskLogFormatter))
 
 
 class TestStopLogging(unittest.TestCase):


### PR DESCRIPTION
Appending a 8 character task id to log output if there is a relevant
task id.

fixes #2324
https://pulp.plan.io/issues/2324

TODO
- [x] Add a release note
- [x] Update troubleshooting guide
- [x] Add two examples to the troubleshooting guide
- [x] Address unit tests