### PR TITLE
Convert all default CA_PATH settings to work with multiple distibutio…

### DIFF
--- a/bindings/test/unit/test_server.py
+++ b/bindings/test/unit/test_server.py
@@ -9,6 +9,7 @@ from M2Crypto import m2, SSL
 import mock
 
 from pulp.bindings import exceptions, server
+from pulp.common.constants import DEFAULT_CA_PATH_LIST
 
 
 class TestHTTPSServerWrapper(unittest.TestCase):
@@ -210,9 +211,9 @@ class TestPulpConnection(unittest.TestCase):
         self.assertTrue(isinstance(connection.server_wrapper, server.HTTPSServerWrapper))
         self.assertEqual(connection.server_wrapper.pulp_connection, connection)
         self.assertEqual(connection.verify_ssl, True)
-        self.assertEqual(connection.ca_path, server.DEFAULT_CA_PATH)
+        self.assertTrue(connection.ca_path in DEFAULT_CA_PATH_LIST)
         # 1142376 - verify default path points to a known valid file
-        self.assertEqual(server.DEFAULT_CA_PATH, '/etc/pki/tls/certs/ca-bundle.crt')
+        self.assertTrue(server.DEFAULT_CA_PATH is not None)
 
     def test___init___ca_path_set(self):
         """

--- a/client_admin/pulp/client/admin/config.py
+++ b/client_admin/pulp/client/admin/config.py
@@ -3,7 +3,7 @@ import os
 import socket
 
 from pulp.common.config import Config, REQUIRED, ANY, NUMBER, BOOL
-
+from pulp.common.constants import DEFAULT_CA_PATH
 
 DEFAULT = {
     'server': {
@@ -11,7 +11,7 @@ DEFAULT = {
         'port': '443',
         'api_prefix': '/pulp/api',
         'verify_ssl': 'true',
-        'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+        'ca_path': DEFAULT_CA_PATH,
         'upload_chunk_size': '1048576',
     },
     'client': {

--- a/client_consumer/pulp/client/consumer/config.py
+++ b/client_consumer/pulp/client/consumer/config.py
@@ -1,7 +1,8 @@
 import os
 import socket
 
-from pulp.common.config import Config, REQUIRED, ANY, NUMBER, BOOL, OPTIONAL
+from pulp.common.config import Config, REQUIRED, ANY, NUMBER, BOOL, OPTIONAL, get_from_default_paths
+from pulp.common.constants import DEFAULT_CA_PATH_LIST
 
 
 DEFAULT = {
@@ -11,7 +12,7 @@ DEFAULT = {
         'api_prefix': '/pulp/api',
         'rsa_pub': '/etc/pki/pulp/consumer/server/rsa_pub.key',
         'verify_ssl': 'true',
-        'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+        'ca_path': get_from_default_paths(DEFAULT_CA_PATH_LIST),
     },
     'authentication': {
         'rsa_key': '/etc/pki/pulp/consumer/rsa.key',

--- a/client_consumer/pulp/client/consumer/config.py
+++ b/client_consumer/pulp/client/consumer/config.py
@@ -1,8 +1,8 @@
 import os
 import socket
 
-from pulp.common.config import Config, REQUIRED, ANY, NUMBER, BOOL, OPTIONAL, get_from_default_paths
-from pulp.common.constants import DEFAULT_CA_PATH_LIST
+from pulp.common.config import Config, REQUIRED, ANY, NUMBER, BOOL, OPTIONAL
+from pulp.common.constants import DEFAULT_CA_PATH
 
 
 DEFAULT = {
@@ -12,7 +12,7 @@ DEFAULT = {
         'api_prefix': '/pulp/api',
         'rsa_pub': '/etc/pki/pulp/consumer/server/rsa_pub.key',
         'verify_ssl': 'true',
-        'ca_path': get_from_default_paths(DEFAULT_CA_PATH_LIST),
+        'ca_path': DEFAULT_CA_PATH,
     },
     'authentication': {
         'rsa_key': '/etc/pki/pulp/consumer/rsa.key',

--- a/common/pulp/common/constants.py
+++ b/common/pulp/common/constants.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os.path
 
 # key used in a repository's "notes" field with a value describing what type
 # of content is in the repository.
@@ -48,7 +49,19 @@ CALL_STATES = (CALL_WAITING_STATE, CALL_SKIPPED_STATE, CALL_ACCEPTED_STATE, CALL
 PRIMARY_ID = '___/primary/___'
 
 # this is used by both platform and plugins to find the default CA path
-DEFAULT_CA_PATH = '/etc/pki/tls/certs/ca-bundle.crt'
+DEFAULT_CA_PATH_LIST = [
+    '/etc/pki/tls/certs/ca-bundle.crt',    # Fedora/RHEL
+    '/etc/ssl/certs/ca-certificates.crt',  # Debian/Ubuntu/Gentoo etc.
+    '/etc/ssl/ca-bundle.pem',              # OpenSUSE
+    '/etc/pki/tls/cacert.pem',             # OpenELEC
+]
+# set DEFAULT_CA_PATH based on DEFAULT_CA_PATH_LIST for backward compatibility with plugins
+for path in DEFAULT_CA_PATH_LIST:
+    if os.path.exists(path):
+        DEFAULT_CA_PATH = path
+        break
+else:
+    DEFAULT_CA_PATH = None
 
 # Scheduler worker name
 SCHEDULER_WORKER_NAME = 'scheduler'

--- a/common/test/unit/common/test_constants.py
+++ b/common/test/unit/common/test_constants.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+from pulp.common import constants
+
+
+class TestConstants(unittest.TestCase):
+    """
+    This class contains tests for the pulp.common.constants configuration.
+    """
+
+    def test_default_ca_path(self):
+        self.assertTrue(constants.DEFAULT_CA_PATH is not None)

--- a/devel/pulp/devel/unit/base.py
+++ b/devel/pulp/devel/unit/base.py
@@ -9,6 +9,7 @@ from pulp.bindings.server import PulpConnection
 from pulp.client.extensions.core import ClientContext, PulpPrompt, PulpCli
 from pulp.client.extensions.exceptions import ExceptionHandler
 from pulp.common.config import Config
+from pulp.common.constants import DEFAULT_CA_PATH
 
 
 # Copy the config here from pulp.client.admin.config so we don't have to start an import chain
@@ -19,7 +20,7 @@ DEFAULT_CONFIG = {
         'port': '443',
         'api_prefix': '/pulp/api',
         'verify_ssl': 'true',
-        'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+        'ca_path': DEFAULT_CA_PATH,
         'upload_chunk_size': '1048576',
     },
     'client': {

--- a/nodes/common/pulp_node/config.py
+++ b/nodes/common/pulp_node/config.py
@@ -1,11 +1,12 @@
 from pulp.common.config import ANY, BOOL, Config, REQUIRED
+from pulp.common.constants import DEFAULT_CA_PATH
 
 
 NODE_CONFIGURATION_PATH = '/etc/pulp/nodes.conf'
 
 DEFAULT = {
     'main': {
-        'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+        'ca_path': DEFAULT_CA_PATH,
         'node_certificate': '/etc/pki/pulp/nodes/node.crt',
         'verify_ssl': 'true',
     },

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -2,6 +2,8 @@ import os
 import socket
 from ConfigParser import SafeConfigParser
 
+from pulp.common.constants import DEFAULT_CA_PATH
+
 
 class LazyConfigParser(SafeConfigParser):
     def __init__(self, *args, **kwargs):
@@ -41,6 +43,7 @@ class LazyConfigParser(SafeConfigParser):
         check_config_files()
         self.read(_config_files)
 
+
 config = LazyConfigParser()
 
 # to guarantee that a section and/or setting exists, add a default value here
@@ -70,7 +73,7 @@ _default_values = {
         'ssl_keyfile': '',
         'ssl_certfile': '',
         'verify_ssl': 'true',
-        'ca_path': '/etc/pki/tls/certs/ca-bundle.crt',
+        'ca_path': DEFAULT_CA_PATH,
         'unsafe_autoretry': 'false',
         'write_concern': 'majority',
     },


### PR DESCRIPTION
…n default locations.

This is related to :
https://pulp.plan.io/issues/2538
https://pulp.plan.io/issues/2444

This is the first step towards building a working cross distibution pulp
package. This should start to support similar cross distibution files
for other defaults in configuration settings.

This PR removes 2 tests that were based around assumptions that are no longer valid with the change in how CA_PATH is defaulted. I would like to add new tests to counter act this removal, but I'm not sure about how best to go about it. I'm very open to suggestions on testing and the make up of this change in general. I chose to use the defaults in pulp.common.constants as it keeps this change fairly small and reasonable, but it does mean that all of these packages will require pulp.common. I assume that this is a likely scenario even without this PR, but it should be noted. 