### PR TITLE
Streamer tries all catalog entries.

### DIFF
--- a/streamer/pulp/streamer/__init__.py
+++ b/streamer/pulp/streamer/__init__.py
@@ -1,2 +1,2 @@
 from pulp.streamer.config import load_configuration, DEFAULT_CONFIG_FILES  # noqa
-from pulp.streamer.server import Streamer, Responder, StreamerListener  # noqa
+from pulp.streamer.server import Streamer, Responder  # noqa


### PR DESCRIPTION
https://pulp.plan.io/issues/2542

The streamer needed to try all available catalog entries.  This ensures that invalid entries don't prevent successful downloading when valid entries exist.  And, more robust in cases where there are multiple importers that can download a content unit and one (or more of them) pull from a remote repository that is temporarily unavailable.

I really tried not to rewrite the streamer but the flow needs to be very different.  Also, a few of the methods were doing too much and needed to be refactored. 
