### PR TITLE
Filtering predistributor results by distributor_id

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -304,7 +304,7 @@ class Publisher(PublishStep):
             string_date = None
         if self.predistributor:
             search_params = {'repo_id': repo.id,
-                             'distributor_id': self.predistributor["id"],
+                             'distributor_id': self.predistributor["distributor_id"],
                              'started': {"$gte": string_date}}
             self.predist_history = RepoPublishResult.get_collection().find(search_params)
         else:


### PR DESCRIPTION
Fixing a bug where we were filtering predistributor publish results by predistributor id instead of distributor_id.

fixes #2550
https://pulp.plan.io/issues/2550