### PR TITLE
Storing a publish date for predistributors

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -304,7 +304,7 @@ class Publisher(PublishStep):
             string_date = None
         if self.predistributor:
             search_params = {'repo_id': repo.id,
-                             'distributor_id': self.predistributor["id"],
+                             'distributor_id': self.predistributor["distributor_id"],
                              'started': {"$gte": string_date}}
             self.predist_history = RepoPublishResult.get_collection().find(search_params)
         else:
@@ -313,7 +313,7 @@ class Publisher(PublishStep):
         self.remote_path = self.get_remote_repo_path()
 
         if self.is_fastforward():
-            start_date = self.last_published
+            start_date = self.predistributor_publish
             end_date = None
             if self.predistributor:
                 end_date = self.predistributor["last_publish"]

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1272,10 +1272,19 @@ def _do_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_confi
     dist = model.Distributor.objects.get_or_404(
         repo_id=repo_obj.repo_id, distributor_id=dist_id)
 
+    predistributor_id = call_config.get('predistributor_id')
+    if predistributor_id:
+        predist = model.Distributor.objects.get_or_404(
+            repo_id=repo_obj.repo_id, distributor_id=predistributor_id)
+        predistributor_publish = predist['last_publish']
+    else:
+        predistributor_publish = None
+
     if not publish_report.canceled_flag:
         # Use raw pymongo not to fire the signal hander
         model.Distributor.objects(repo_id=repo_obj.repo_id, distributor_id=dist_id).\
-            update(set__last_publish=publish_end_timestamp)
+            update(set__last_publish=publish_end_timestamp,
+                   set__predistributor_publish=predistributor_publish)
 
     # Add a publish entry
     summary = publish_report.summary

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -1263,6 +1263,7 @@ class Distributor(AutoRetryDocument):
     auto_publish = BooleanField(default=False)
     last_publish = UTCDateTimeField()
     last_updated = UTCDateTimeField()
+    predistributor_publish = UTCDateTimeField()
     last_override_config = DictField()
     scratchpad = DictField()
 

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -1361,11 +1361,13 @@ class TestDoPublish(unittest.TestCase):
         fake_repo = model.Repository(repo_id='repo1')
         mock_inst = mock.MagicMock()
         m_dist = m_dist_qs.get_or_404.return_value
+        config = {}
 
         result = repo_controller._do_publish(fake_repo, 'dist', mock_inst,
                                              fake_repo.to_transfer_repo(), 'conduit',
-                                             'conf')
-        m_dist_qs.return_value.update.assert_called_once_with(set__last_publish=mock_now())
+                                             config)
+        m_dist_qs.return_value.update.assert_called_once_with(set__last_publish=mock_now(),
+                                                              set__predistributor_publish=None)
         m_repo_pub_result.expected_result.assert_called_once_with(
             fake_repo.repo_id, m_dist.distributor_id, m_dist.distributor_type_id, mock_now(),
             mock_now(), 'summary', 'details', m_repo_pub_result.RESULT_SUCCESS


### PR DESCRIPTION
Before when publishing rsync content with a yum predistributor, it would
fetch content since the last rsync publish when it should have
considered content since the last predistributor/yum publish in case any
content was added after the last predistributor publish but before the
last rsync publish.

fixes #2532
https://pulp.plan.io/issues/2532