### PR TITLE
Set batch_size for the cursor in orphan removal tasks

### DIFF
--- a/server/pulp/server/managers/content/orphan.py
+++ b/server/pulp/server/managers/content/orphan.py
@@ -103,7 +103,7 @@ class OrphanManager(object):
         content_units_collection = content_types_db.type_units_collection(content_type_id)
         repo_content_units_collection = RepoContentUnit.get_collection()
 
-        for content_unit in content_units_collection.find({}, projection=fields):
+        for content_unit in content_units_collection.find({}, projection=fields).batch_size(100):
 
             repo_content_units_cursor = repo_content_units_collection.find(
                 {'unit_id': content_unit['_id']})


### PR DESCRIPTION
On a busy system a cursor for iterating over all units
in a collection could be timed out during orphan removal.
The batch size is set to 100 to make sure cursor is active,
it also should not introduce any noticable performance impact.

closes #2584
https://pulp.plan.io/issues/2584