### PR TITLE
Fix flake8 warning.

### DIFF
--- a/streamer/pulp/streamer/server.py
+++ b/streamer/pulp/streamer/server.py
@@ -270,7 +270,7 @@ class Streamer(Resource):
         Get the content unit referenced by the catalog entry.
 
         :param entry: A catalog entry.
-        :type  entry: LazyCatalogEntry 
+        :type  entry: LazyCatalogEntry
         :return: The unit.
         :raises DoesNotExist: when not found.
         """


### PR DESCRIPTION
Fix:
```
16:15:47 ./streamer/pulp/streamer/server.py:240:39: W291 trailing whitespace
```
causing jenkins to fail.