### PR TITLE
mentionbot: stop recommending jcline.

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -8,6 +8,7 @@
         "jwmatthews",
         "mccun943",
         "pkilambi",
-        "slagle"
+        "slagle",
+        "jeremycline"
     ]
 }


### PR DESCRIPTION
This will allow mentionbot to include *active* developers instead.