### PR TITLE
Update spec file

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -17,7 +17,7 @@
 %if %{pulp_server}
 #SELinux
 %define selinux_variants mls strict targeted
-%define selinux_policyver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
+%global selinux_policyver %(rpm --qf "%%{version}-%%{release}" -q selinux-policy)
 %define moduletype apps
 %endif
 


### PR DESCRIPTION
When https://github.com/pulp/devel/blob/master/ansible/library/pulp_facts.py is ran
in vagrant, it  to failes to gather the dependencies for pulp with the error:
"can't parse, unknown tag" for %{selinux_policyver}.
Updating the selinux_policyver tag to global resolves this issue.

Fedora packaging guidelines also state a preference for %global over %define
https://fedoraproject.org/wiki/PackagingDrafts/global_preferred_over_define

re #2497
https://pulp.plan.io/issues/2497