### PR TITLE
Update last_unit_removed when unit is disassociated

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -336,7 +336,8 @@ def associate_single_unit(repository, unit):
 
 def disassociate_units(repository, unit_iterable):
     """
-    Disassociate all units in the iterable from the repository
+    Disassociate all units in the iterable from the repository.
+    Update `last_unit_removed` timestamp for the repository.
 
     :param repository: The repository to update.
     :type repository: pulp.server.db.model.Repository
@@ -348,6 +349,8 @@ def disassociate_units(repository, unit_iterable):
         qs = model.RepositoryContentUnit.objects(
             repo_id=repository.repo_id, unit_id__in=unit_id_list)
         qs.delete()
+
+    update_last_unit_removed(repository.repo_id)
 
 
 def create_repo(repo_id, display_name=None, description=None, notes=None, importer_type_id=None,

--- a/server/test/unit/server/controllers/test_repository.py
+++ b/server/test/unit/server/controllers/test_repository.py
@@ -361,11 +361,11 @@ class AssociateSingleUnitTests(unittest.TestCase):
 
 
 class TestDisassociateUnits(unittest.TestCase):
-
+    @patch('pulp.server.controllers.repository.update_last_unit_removed')
     @patch('pulp.server.controllers.repository.model.RepositoryContentUnit.objects')
-    def test_disaccociate_units(self, m_rcu_objects):
+    def test_disassociate_units(self, m_rcu_objects, m_update_last_unit_removed):
         """"
-        Test that multiple objects are all deleted
+        Test that multiple objects are all deleted and timestamp for units removal updated
         """
         test_unit1 = DemoModel(id='bar', key_field='baz')
         test_unit2 = DemoModel(id='baz', key_field='baz')
@@ -373,6 +373,7 @@ class TestDisassociateUnits(unittest.TestCase):
         repo_controller.disassociate_units(repo, [test_unit1, test_unit2])
         m_rcu_objects.assert_called_once_with(repo_id='foo', unit_id__in=['bar', 'baz'])
         m_rcu_objects.return_value.delete.assert_called_once()
+        m_update_last_unit_removed.assert_called_once_with('foo')
 
 
 @mock.patch('pulp.server.controllers.repository.dist_controller')


### PR DESCRIPTION
It will force subsequent publish to be from scratch.
Before that publish could be incremental and in some cases, like
upload of the RPM with same NEVRA, resulted in duplicated
or outdated metadata in the published repository.

closes #1389
https://pulp.plan.io/issues/1389