### PR TITLE
Replace remap_fields with serialize_unit

### DIFF
--- a/server/pulp/server/webservices/views/repositories.py
+++ b/server/pulp/server/webservices/views/repositories.py
@@ -290,7 +290,7 @@ class RepoUnitSearch(search.SearchView):
         else:
             units = manager.get_units(repo_id, criteria=criteria)
         for unit in units:
-            content.remap_fields_with_serializer(unit['metadata'])
+            content.serialize_unit_with_serializer(unit['metadata'])
         return generate_json_response_with_pulp_encoder(units)
 
 

--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -349,6 +349,19 @@ class ModelSerializer(BaseSerializer):
             crit_dict['fields'] = [self.translate_field(model, field) for field in crit.fields]
         return Criteria.from_dict(crit_dict)
 
+    def serialize(self, instance):
+        """Help convert a single unit to it's dictionary form, handling special field types.
+
+        This object is modified in-place, and should only be invoked by calling
+        :py:func:`pulp.server.webservices.views.serializers.content.serialize_unit_with_serializer`
+        in responses that still serialize pymongo dicts.
+
+        :param instance: The object to be converted
+        :type instance: dict
+        """
+        # base implementation is a no-op
+        pass
+
 
 class Repository(ModelSerializer):
     """

--- a/server/test/unit/server/webservices/views/serializers/test_content.py
+++ b/server/test/unit/server/webservices/views/serializers/test_content.py
@@ -54,7 +54,7 @@ class TestRemapFieldsFromSerializer(TestCase):
     @patch('pulp.plugins.loader.api.get_unit_model_by_id')
     def test_remap_fields(self, mock_get_model):
         mock_get_model.return_value = self.content_unit_model
-        content.remap_fields_with_serializer(self.content_unit)
+        content.serialize_unit_with_serializer(self.content_unit)
         self.assertTrue('type_specific_id' not in self.content_unit,
                         'type-specific ID field not remapped')
         self.assertTrue('id' in self.content_unit)


### PR DESCRIPTION
In order to fix an RPM bug, an opportunity presented itself to slightly
improve this interface, effectively renaming
`remap_fields_with_serializer` to `serialize_unit_with_serializer`, and 
exposing a new "serialize" method on `ModelSerializer` that can be
overridden in subclasses as desired to help with serializing "exotic"
field types, such as BLObs and other things not easily handled with our 
custom JSON encoder.

closes #2620
https://pulp.plan.io/issues/2620