### PR TITLE
Fix scheduled calls with Celery 4.x.

### DIFF
--- a/server/pulp/server/async/scheduler.py
+++ b/server/pulp/server/async/scheduler.py
@@ -6,7 +6,7 @@ import platform
 import threading
 import time
 
-from celery import beat
+from celery import beat, __version__ as celery_version
 import mongoengine
 
 from pulp.common import constants
@@ -199,6 +199,9 @@ class Scheduler(beat.Scheduler):
         """
         worker_watcher.handle_worker_heartbeat(CELERYBEAT_NAME)
 
+        if celery_version.startswith('4') and self.schedule_changed:
+            self._heap = None
+
         now = ensure_tz(datetime.utcnow())
         old_timestamp = now - timedelta(seconds=constants.PULP_PROCESS_TIMEOUT_INTERVAL)
 
@@ -253,7 +256,13 @@ class Scheduler(beat.Scheduler):
             Scheduler._mongo_initialized = True
         _logger.debug(_('loading schedules from app'))
         self._schedule = {}
-        for key, value in self.app.conf.CELERYBEAT_SCHEDULE.iteritems():
+
+        if celery_version.startswith('4'):
+            items = self.app.conf.beat_schedule.iteritems()
+        else:
+            items = self.app.conf.CELERYBEAT_SCHEDULE.iteritems()
+
+        for key, value in items:
             self._schedule[key] = beat.ScheduleEntry(**dict(value, name=key))
 
         # include a "0" as the default in case there are no schedules to load


### PR DESCRIPTION
Celery 4.x changes a number of implentation details which
breaks our assumptions about how the scheduling system
works. Therefore, we want to check for the celery version
and take actions to trigger the desired behavior depending
on that celery version.

closes #2615
https://pulp.plan.io/issues/2615