### PR TITLE
Fix the arguments being passed to celery.apply_async

### DIFF
--- a/tasking/pulp/tasking/tasks.py
+++ b/tasking/pulp/tasking/tasks.py
@@ -85,12 +85,11 @@ def _queue_reserved_task(name, inner_task_id, resource_id, inner_args, inner_kwa
     task_status = TaskStatus.objects.get(pk=inner_task_id)
     ReservedResource.objects.create(task=task_status, worker=worker, resource=resource_id)
 
-    inner_kwargs['routing_key'] = worker.name
-    inner_kwargs['exchange'] = DEDICATED_QUEUE_EXCHANGE
-    inner_kwargs['task_id'] = inner_task_id
 
     try:
-        celery.tasks[name].apply_async(*inner_args, **inner_kwargs)
+        celery.tasks[name].apply_async(inner_args, kwargs=inner_kwargs, task_id=inner_task_id,
+                                       routing_key=worker.name, exchange=DEDICATED_QUEUE_EXCHANGE)
+
     finally:
         _release_resource.apply_async((inner_task_id, ), routing_key=worker.name,
                                       exchange=DEDICATED_QUEUE_EXCHANGE)
@@ -227,7 +226,8 @@ class UserFacingTask(PulpTask):
         """
         tag_list = kwargs.pop('tags', [])
         group_id = kwargs.pop('group_id', None)
-        async_result = super(UserFacingTask, self).apply_async(*args, **kwargs)
+
+        async_result = super(UserFacingTask, self).apply_async(args, **kwargs)
         async_result.tags = tag_list
 
         # Set the parent attribute if being dispatched inside of a Task


### PR DESCRIPTION
Celery's Task.apply_async is expecting args and kwargs as keyword arguments.

If we want to pass any kwargs to the task, it has to be in the kwarg kwarg:
`apply_async(args, kwargs=mykwargs)`

With this PR we also assume that any args being passed in to apply_async will be passed directly to the task. Alternatively we could make this explicit and require any task args to be passed with the  `args` keyword. I am not sure which approach is more correct so any feedback is welcome.