### PR TITLE
 Update plugin API and base classes for plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ before_script:
     - psql -U postgres -c "CREATE USER pulp WITH SUPERUSER LOGIN;"
     - psql -U postgres -c "CREATE DATABASE pulp OWNER pulp;"
 script:
-    - "flake8 --config flake8.cfg app/"
-    - "app/pulp/app/db-reset.sh && python manage.py test app"
+    # flake8 the diff
     - "git diff HEAD^ '*.py' | flake8 --diff --config flake8.cfg"
+    # tests can't run without migrations being made
+    - "python manage.py makemigrations pulp_app"
+    # run the tests!
+    - "python manage.py test app"

--- a/app/pulp/app/db-reset.sh
+++ b/app/pulp/app/db-reset.sh
@@ -15,7 +15,13 @@ sleep 1
 fi
 
 python manage.py reset_db --noinput
-python manage.py makemigrations pulp_app --noinput
+# the pulp platform app depends on auth being migrated before its own tables
+# can be created, since we're using pulp's 'User' model as our AUTH_USER_MODEL
+# this should only be required until we "makemigrations" and check those migrations
+# in for the platform app, at which point we can declare this dependency in the
+# migration itself:
+# https://docs.djangoproject.com/en/1.8/topics/migrations/#dependencies
+python manage.py migrate --noinput auth
 python manage.py migrate --noinput
 python manage.py reset-admin-password --password admin
 popd

--- a/app/pulp/app/models/content.py
+++ b/app/pulp/app/models/content.py
@@ -5,7 +5,6 @@ import hashlib
 
 from django.db import models
 
-
 from pulp.app.models import Model, MasterModel, Notes, GenericKeyValueRelation
 from pulp.app.models.storage import StoragePath
 
@@ -59,6 +58,15 @@ class Content(MasterModel):
             else:
                 h.update(value)
         return h.hexdigest()
+
+    def __str__(self):
+        cast = self.cast()
+
+        # so here's a pretty good case for making namedtuples for content types
+        # the third replacement string results in "natural_key_fieldname_0=repr(field_value), ..."
+        natural_key_zip = zip(cast.natural_key_fields, cast.natural_key())
+        natural_key_string = ', '.join(('='.join((t[0].name, repr(t[1]))) for t in natural_key_zip))
+        return '<{} (type={}): {}>'.format(self._meta.object_name, cast.TYPE, natural_key_string)
 
 
 class Artifact(Model):

--- a/app/pulp/app/serializers/__init__.py
+++ b/app/pulp/app/serializers/__init__.py
@@ -2,8 +2,10 @@
 # - fields can import directly from base if needed
 # - all can import directly from base and fields if needed
 from pulp.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # NOQA
-    ModelSerializer, MasterModelSerializer, viewset_for_model)  # NOQA
-from pulp.app.serializers.fields import (ContentRelatedField, RepositoryRelatedField)  # NOQA
+    ModelSerializer, MasterModelSerializer, DetailIdentityField, DetailRelatedField,
+    viewset_for_model)
+from pulp.app.serializers.fields import (ContentRelatedField, RepositoryRelatedField,  # NOQA
+    ImporterRelatedField, PublisherRelatedField)
 from pulp.app.serializers.generic import (ConfigKeyValueRelatedField,  # NOQA
     NotesKeyValueRelatedField, ScratchpadKeyValueRelatedField)  # NOQA
 from pulp.app.serializers.catalog import DownloadCatalogSerializer  # NOQA

--- a/app/pulp/app/serializers/fields.py
+++ b/app/pulp/app/serializers/fields.py
@@ -18,3 +18,17 @@ class RepositoryRelatedField(serializers.HyperlinkedRelatedField):
     view_name = 'repositories-detail'
     lookup_field = 'name'
     queryset = models.Repository.objects.all()
+
+
+class ImporterRelatedField(DetailRelatedField):
+    """
+    Serializer Field for use when relating to Importer Detail Models
+    """
+    queryset = models.Importer.objects.all()
+
+
+class PublisherRelatedField(DetailRelatedField):
+    """
+    Serializer Field for use when relating to Publisher Detail Models
+    """
+    queryset = models.Publisher.objects.all()

--- a/app/pulp/app/serializers/repository.py
+++ b/app/pulp/app/serializers/repository.py
@@ -3,9 +3,10 @@ from gettext import gettext as _
 from rest_framework import serializers
 
 from pulp.app import models
-from pulp.app.serializers import (MasterModelSerializer, ModelSerializer,
+from pulp.app.serializers import (MasterModelSerializer, ModelSerializer, DetailIdentityField,
                                   NotesKeyValueRelatedField, RepositoryRelatedField,
-                                  ScratchpadKeyValueRelatedField, ContentRelatedField)
+                                  ScratchpadKeyValueRelatedField, ContentRelatedField,
+                                  ImporterRelatedField, PublisherRelatedField)
 
 
 class RepositorySerializer(ModelSerializer):
@@ -36,11 +37,18 @@ class RepositorySerializer(ModelSerializer):
     )
     notes = NotesKeyValueRelatedField()
     scratchpad = ScratchpadKeyValueRelatedField()
+    importers = ImporterRelatedField(many=True)
+    publishers = PublisherRelatedField(many=True)
+    content = serializers.HyperlinkedIdentityField(
+        view_name='repositories-content',
+        lookup_field='name'
+    )
 
     class Meta:
         model = models.Repository
         fields = ModelSerializer.Meta.fields + ('name', 'description', 'notes', 'scratchpad',
-                                                'last_content_added', 'last_content_removed')
+                                                'last_content_added', 'last_content_removed',
+                                                'importers', 'publishers', 'content')
 
 
 class ImporterSerializer(MasterModelSerializer):
@@ -50,10 +58,7 @@ class ImporterSerializer(MasterModelSerializer):
     """
     # _href is normally provided by the base class, but Importers's
     # "name" lookup field means _href must be explicitly declared.
-    _href = serializers.HyperlinkedIdentityField(
-        view_name='importers-detail',
-        lookup_field='name',
-    )
+    _href = DetailIdentityField()
 
     name = serializers.CharField(
         help_text=_('A name for this importer, unique within the associated repository.')
@@ -145,10 +150,7 @@ class PublisherSerializer(MasterModelSerializer):
     """
     # Every subclass must override the `_href` field with a `RepositoryNestedIdentityField` that
     # defines the view_name.
-    _href = serializers.HyperlinkedIdentityField(
-        view_name='publishers-detail',
-        lookup_field='name',
-    )
+    _href = DetailIdentityField()
     name = serializers.CharField(
         help_text=_('A name for this publisher, unique within the associated repository.')
     )

--- a/app/pulp/app/settings.py
+++ b/app/pulp/app/settings.py
@@ -28,6 +28,12 @@ SECRET_KEY = '*u&ouzf)09#*dnm8t9jxahz-y=uwe0g&yn9ir-(lj@l*$cc%qo'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+# Silenced warnings
+# - fields.W342 is the warning for having "unique=True" on a ForeignKeyField, which is something
+#   we explicitly want, so we can enforce a single Importer per-repository in 3.0, but easily
+#   allow for multiple importers per-repository in a later version by lifting the contraint.
+SILENCED_SYSTEM_CHECKS = ["fields.W342"]
+
 ALLOWED_HOSTS = ['*']
 
 MEDIA_ROOT = '/var/lib/pulp/content/'

--- a/app/pulp/app/viewsets/repository.py
+++ b/app/pulp/app/viewsets/repository.py
@@ -39,8 +39,6 @@ class RepositoryViewSet(NamedModelViewSet):
 
     @decorators.detail_route()
     def content(self, request, name):
-        # XXX Not sure if we actually want to put a content view on repos like this, this is
-        #     just an example of how you might include a related queryset, and in a paginated way.
         repo = self.get_object()
         paginator = UUIDPagination()
         page = paginator.paginate_queryset(repo.content, request)

--- a/plugin/pulp/plugin/__init__.py
+++ b/plugin/pulp/plugin/__init__.py
@@ -1,8 +1,12 @@
-from pulp.app.models import ProgressBar, ProgressSpinner, Repository, RepositoryContent
-from pulp.exceptions import PulpException
+# Expose models from a selective set of imports in the local models module
+from . import models  # NOQA
 
-from .cataloger import Cataloger
-from .publisher import Publisher
-from .importer import Importer
-from .profiler import Profiler
-from .tasking import Task
+# plugins declare that they are a pulp plugin by subclassing PulpPluginAppConfig
+from pulp.app.apps import PulpPluginAppConfig
+
+# All serializers and viewsets defined in platform should be useful for plugins
+from pulp.app import serializers  # NOQA
+from pulp.app import viewsets  # NOQA
+
+# Allow plugin writers to subclass PulpException
+from pulp.exceptions import PulpException  # NOQA

--- a/plugin/pulp/plugin/models/__init__.py
+++ b/plugin/pulp/plugin/models/__init__.py
@@ -1,0 +1,5 @@
+from pulp.app.models import (  # NOQA
+    Content, ProgressBar, ProgressSpinner, Repository, RepositoryContent)
+
+from .publisher import Publisher
+from .importer import Importer

--- a/plugin/pulp/plugin/models/importer.py
+++ b/plugin/pulp/plugin/models/importer.py
@@ -68,3 +68,6 @@ class Importer(PlatformImporter):
         Subclasses are designed to override this default implementation and should not call super().
         """
         raise NotImplementedError()
+
+    class Meta:
+        abstract = True

--- a/plugin/pulp/plugin/models/publisher.py
+++ b/plugin/pulp/plugin/models/publisher.py
@@ -71,3 +71,6 @@ class Publisher(PlatformPublisher):
         Subclasses are designed to override this default implementation and should not call super().
         """
         raise NotImplementedError()
+
+    class Meta:
+        abstract = True


### PR DESCRIPTION
This reorganizes the plugin API a little bit, and exposes all the pieces needed to create a basic pulp plugin. I also added some "quality of life" stuff I ran into while working on this, including:

- friendlier implementation of `__str__` in model base classes so running str/repr on a pulp model should give you sane behavior by default (it was't)
- the "one importer per-repo" constraint is now enforced in the data model

I also implemented a 'pulp.plugin' entrypoint in its own commit. If desired, I can split that off into a later PR and work it in another issue, or we can leave what's here in and improve it later if needed.

re #2454
https://pulp.plan.io/issues/2454