### PR TITLE
Removed python-okaara<1.0.36 version restriction

### DIFF
--- a/pulp.spec
+++ b/pulp.spec
@@ -800,7 +800,7 @@ Group: Development/Languages
 Provides: python2-pulp-client-lib
 Requires: m2crypto
 Requires: python-%{name}-common = %{pulp_version}
-Requires: python-okaara >= 1.0.32,python-okaara < 1.0.36
+Requires: python-okaara >= 1.0.32
 Requires: python-isodate >= 0.5.0-1.pulp
 Requires: python-setuptools
 Obsoletes: pulp-client-lib


### PR DESCRIPTION
python-okaara recently upgraded their fedora rawhide package to 1.0.37[0]. Pulp on F27 currently has broken dependencies since we're specifying `python-okaara >= 1.0.32,python-okaara < 1.0.36` in our spec file.

Previously we had an issue with python-okaara 1.0.36 because it was incompatible with python runtime 2.7 [1]. This has been fixed for 1.0.37. okaara 1.0.36 is not present in EPEL[0] and PyPI[2], so this spec file version change would not break any of our releases.

[0] https://apps.fedoraproject.org/packages/python-okaara
[1] https://github.com/jdob/okaara/issues/16
[2] https://pypi.python.org/pypi/okaara