### PR TITLE
update last_unit_added when units are copied

### DIFF
--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -275,10 +275,14 @@ class RepoUnitAssociationManager(object):
                 suc_units_ids = [u.to_id_dict() for u in copied_units[0] if u is not None]
                 unsuc_units_ids = [u.to_id_dict() for u in copied_units[1]]
                 repo_controller.rebuild_content_unit_counts(dest_repo)
+                if suc_units_ids:
+                    repo_controller.update_last_unit_added(dest_repo.repo_id)
                 return {'units_successful': suc_units_ids,
                         'units_failed_signature_filter': unsuc_units_ids}
             unit_ids = [u.to_id_dict() for u in copied_units if u is not None]
             repo_controller.rebuild_content_unit_counts(dest_repo)
+            if unit_ids:
+                repo_controller.update_last_unit_added(dest_repo.repo_id)
             return {'units_successful': unit_ids}
         except Exception as e:
             msg = _('Exception from importer [%(i)s] while importing units into repository [%(r)s]')

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -230,12 +230,13 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.assertEqual(1, mock_imp_inst.import_units.call_count)
         self.assertEqual(ret.get('units_successful'), [])
 
+    @mock.patch('pulp.server.controllers.repository.update_last_unit_added')
     @mock.patch('pulp.server.controllers.repository.rebuild_content_unit_counts', spec_set=True)
     @mock.patch('pulp.server.managers.repo.unit_association.UnitAssociationCriteria')
     @mock.patch('pulp.server.managers.repo.unit_association.plugin_api')
     @mock.patch('pulp.server.managers.repo.unit_association.model.Importer')
     def test_associate_from_repo_return_tuple(self, mock_importer, mock_plugin, mock_repo,
-                                              mock_crit, mock_rebuild_count):
+                                              mock_crit, mock_rebuild_count, mock_last_unit_added):
         mock_imp_inst = mock.MagicMock()
         mock_plugin.get_importer_by_id.return_value = (mock_imp_inst, mock.MagicMock())
         source_repo = mock.MagicMock(repo_id='source-repo')
@@ -248,6 +249,7 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         mock_imp_inst.import_units.return_value = (list(), list())
         ret = self.manager.associate_from_repo('source_repo', 'dest_repo', mock_crit)
 
+        mock_last_unit_added.assert_called_once()
         self.assertEqual(1, mock_imp_inst.import_units.call_count)
         self.assertEqual(ret.get('units_successful'), [])
         self.assertEqual(ret.get('units_failed_signature_filter'), [])


### PR DESCRIPTION
re #2577
https://pulp.plan.io/issues/2577

(cherry picked from commit 0005b1375f02d9cbe29bf23b892fa5ec7af343b8)

The cherry-picked commit was accidentally reverted on 2.12-dev in
commit c0ea5ee4bf8898d80d72c481fbc116fc548b8eeb. The original PR
containing this change was https://github.com/pulp/pulp/pull/2949

closes #2688
https://pulp.plan.io/issues/2688