### PR TITLE
Removes two unexpected Importer fields

### DIFF
--- a/app/pulp/app/models/repository.py
+++ b/app/pulp/app/models/repository.py
@@ -110,10 +110,6 @@ class Importer(ContentAdaptor):
             Format: scheme://user:password@host:port
         basic_auth_user (models.TextField): The user used in HTTP basic authentication.
         basic_auth_password (models.TextField): The password used in HTTP basic authentication.
-        max_download_bandwidth (models.IntegerField): The max amount of bandwidth used per download
-            in bytes per second.
-        max_concurrent_downloads (models.IntegerField): The number of concurrent downloads
-            permitted.
         download_policy (models.TextField): The policy for downloading content.
         last_sync (models.DatetimeField): When the last successful synchronization occurred.
 
@@ -155,9 +151,6 @@ class Importer(ContentAdaptor):
 
     basic_auth_user = models.TextField(blank=True)
     basic_auth_password = models.TextField(blank=True)
-
-    max_download_bandwidth = models.IntegerField(null=True)
-    max_concurrent_downloads = models.IntegerField(null=True)
 
     download_policy = models.TextField(choices=DOWNLOAD_POLICIES)
     last_sync = models.DateTimeField(blank=True, null=True)

--- a/app/pulp/app/serializers/repository.py
+++ b/app/pulp/app/serializers/repository.py
@@ -112,14 +112,6 @@ class ImporterSerializer(MasterModelSerializer):
         write_only=True,
         required=False,
     )
-    max_download_bandwidth = serializers.IntegerField(
-        help_text='The max amount of bandwidth used per download (Bps).',
-        required=False,
-    )
-    max_concurrent_downloads = serializers.IntegerField(
-        help_text='The number of concurrent downloads permitted.',
-        required=False,
-    )
     download_policy = serializers.MultipleChoiceField(
         help_text='The policy for downloading content.',
         allow_empty=False,


### PR DESCRIPTION
The max_download_bandwidth and max_concurrent_downloads fields were not
expected to be on the model. These features are not included in the
MVP. This PR removes those fields from the model along with their
serializers.

There isn't an issue tracking this change. It is too small.