### PR TITLE
Use rsync's -K to preserve symlinks on publish with rsync distributor

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -75,7 +75,7 @@ class RSyncPublishStep(PublishStep):
         """
         tmpdir = os.path.join(self.get_working_dir(), '.tmp')
         os.makedirs(os.path.join(tmpdir, path.lstrip("/")))
-        args = ['rsync', '-avr', '-f+ */']
+        args = ['rsync', '-avrK', '-f+ */']
         args.extend(self.make_authentication())
         args.append("%s/" % tmpdir)
         args.append(self.make_destination(path).replace(str(path), ""))


### PR DESCRIPTION
closes #2687
https://pulp.plan.io/issues/2687

I tried to make the title to fit the 80 characters, but not sure if it still makes sense.