### PR TITLE
Don't use ssh connection sharing in rsync distributor.

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -102,10 +102,7 @@ class RSyncPublishStep(PublishStep):
         key = self.get_config().flatten()["remote"]['ssh_identity_file']
         cmd += ['-i', key,
                 '-o', 'StrictHostKeyChecking no',
-                '-o', 'UserKnownHostsFile /dev/null',
-                '-S', '/tmp/rsync_distributor-%r@%h:%p',
-                '-o', 'ControlMaster auto',
-                '-o', 'ControlPersist 10']
+                '-o', 'UserKnownHostsFile /dev/null']
         if args:
             cmd += args
         return cmd


### PR DESCRIPTION
closes #2689
https://pulp.plan.io/issues/2689

I removed -S as well since it is the location of a control socket for connection sharing( which we are removing in this PR)