### PR TITLE
Support for storing units in multiple collections

### DIFF
--- a/common/pulp/common/error_codes.py
+++ b/common/pulp/common/error_codes.py
@@ -101,7 +101,7 @@ PLP0037 = Error(
     "PLP0037",
     _("Content import of %(path)s failed - must be an existing file."),
     ['path'])
-PLP0038 = Error("PLP0038", _("The unit model with id %(model_id)s and class "
+PLP0038 = Error("PLP0038", _("The model with id %(model_id)s and class "
                              "%(model_class)s failed to register. Another model has already "
                              "been registered with the same id."), ['model_id', 'model_class'])
 PLP0040 = Error("PLP0040", _("Database 'seeds' config must include at least one hostname:port "

--- a/server/pulp/plugins/conduits/profiler.py
+++ b/server/pulp/plugins/conduits/profiler.py
@@ -56,6 +56,7 @@ class ProfilerConduit(MultipleRepoUnitsMixin):
         additional_unit_fields = additional_unit_fields or []
         try:
             unit_key_fields = units_controller.get_unit_key_fields_for_type(content_type_id)
+            serializer = units_controller.get_model_serializer_for_type(content_type_id)
 
             # Query repo association manager to get all units of given type
             # associated with given repo. Limit data by requesting only the fields
@@ -69,6 +70,8 @@ class ProfilerConduit(MultipleRepoUnitsMixin):
             # Convert units to plugin units with unit_key and required metadata values for each unit
             all_units = []
             for unit in units:
+                if serializer:
+                    serializer.serialize(unit['metadata'])
                 unit_key = {}
                 metadata = {}
                 for k in unit_key_fields:

--- a/server/pulp/server/db/manage.py
+++ b/server/pulp/server/db/manage.py
@@ -184,6 +184,11 @@ def ensure_database_indexes():
             model_class._build_index_specs(model_class._meta['indexes'])
         model_class.ensure_indexes()
 
+    for model_type, model_class in plugin_manager.auxiliary_models.items():
+        model_class._meta['index_specs'] = \
+            model_class._build_index_specs(model_class._meta['indexes'])
+        model_class.ensure_indexes()
+
 
 def main():
     """

--- a/server/pulp/server/db/migrations/lib/utils.py
+++ b/server/pulp/server/db/migrations/lib/utils.py
@@ -1,0 +1,61 @@
+"""
+Utils for migrations.
+"""
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+MIGRATION_HEADER_MSG = '* Migrating %s content...'
+MIGRATION_PROGRESS_MSG = '* Migrated units: %s of %s'
+STARS = '*' * 79
+
+
+class MigrationProgressLog(object):
+    """
+    Context manager that logs every 10% of migration completion.
+
+    :ivar migrated_units: number of already migrated units
+    :type migrated_units: int
+    :ivar content_type: name of the content to be migrated
+    :type content_type: str
+    :ivar total_units: total number of units to be migrated
+    :type total_units: int
+    :ivar header_msg: message printed at the beginning of migration
+    :type header_msg: str
+    """
+    migrated_units = 0
+
+    def __init__(self, content_type, total_units, msg=MIGRATION_HEADER_MSG):
+        self.content_type = content_type
+        self.total_units = total_units
+        self.msg = msg
+
+    def __enter__(self):
+        """
+        Log a message indicating a start of migration process for a specific content.
+        """
+        if self.total_units:
+            _logger.info(STARS)
+            _logger.info(self.msg % self.content_type)
+
+        return self
+
+    def progress(self, msg=MIGRATION_PROGRESS_MSG):
+        """
+        Count migrated units and logs progress every 10%.
+        Expected to be called for every migrated unit.
+        """
+        self.migrated_units += 1
+        another_ten_percent_completed = self.total_units >= 10 and \
+            not self.migrated_units % (self.total_units // 10)
+        all_units_migrated = self.migrated_units == self.total_units
+        if another_ten_percent_completed or all_units_migrated:
+            _logger.info(msg % (self.migrated_units, self.total_units))
+
+    def __exit__(self, *exc):
+        """
+        Print footer (or delimiter) to indicate the end of the content unit migration.
+        """
+        _logger.info(STARS)


### PR DESCRIPTION
 The following was added:
 - load of auxiliary models
 - post-delete method during orphan removal
 - serialization in profiler to have all the data
   in a proper shape for applicability calculation

re #2681
https://pulp.plan.io/issues/2681