### PR TITLE
The importer serializer's download_policy field should be a ChoiceField.

### DIFF
--- a/platform/pulp/app/serializers/repository.py
+++ b/platform/pulp/app/serializers/repository.py
@@ -112,9 +112,9 @@ class ImporterSerializer(MasterModelSerializer):
         write_only=True,
         required=False,
     )
-    download_policy = serializers.MultipleChoiceField(
+    download_policy = serializers.ChoiceField(
         help_text='The policy for downloading content.',
-        allow_empty=False,
+        allow_blank=False,
         choices=models.Importer.DOWNLOAD_POLICIES,
     )
     last_sync = serializers.DateTimeField(


### PR DESCRIPTION
It was previously a MultipleChoiceField, which caused problems. It should only
ever have one value.