### PR TITLE
Use sphinx<1.6.1 until ImportError in sphinx is fixed

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
-sphinx
+# Sphinx version is limited only due to the following bug:
+# https://github.com/sphinx-doc/sphinx/issues/3779.
+# Whenever it will be resolved, remove this version limitation
+sphinx<1.6.1
 sphinx-rtd-theme


### PR DESCRIPTION
This is a temporary solution until the following issue is fixed:
https://github.com/sphinx-doc/sphinx/issues/3779