### PR TITLE
Sign certificates with sha256

### DIFF
--- a/nodes/common/bin/pulp-gen-nodes-certificate
+++ b/nodes/common/bin/pulp-gen-nodes-certificate
@@ -65,7 +65,7 @@ openssl x509 \
   -req  \
   -in $TMP/$BASE.req \
   -out $TMP/$BASE.crt \
-  -sha1 \
+  -sha256 \
   -CA $CA_CRT \
   -CAkey $CA_KEY \
   -CAcreateserial \

--- a/server/bin/pulp-gen-ca-certificate
+++ b/server/bin/pulp-gen-ca-certificate
@@ -46,7 +46,7 @@ openssl req \
 openssl x509 \
   -req \
   -days 7035 \
-  -sha1 \
+  -sha256 \
   -extensions ca  \
   -signkey ${CA_KEY} \
   -in ${TMP}/ca.req \

--- a/server/pulp/server/managers/auth/cert/cert_generator.py
+++ b/server/pulp/server/managers/auth/cert/cert_generator.py
@@ -204,5 +204,5 @@ def _make_cert_request(cn, rsa, uid=None):
     extensions = X509.X509_Extension_Stack()
     extensions.push(ext2)
     request.add_extensions(extensions)
-    request.sign(pub_key, 'sha1')
+    request.sign(pub_key, 'sha256')
     return request, pub_key


### PR DESCRIPTION
SHA1 certificates are deprecated and should be phased out. While most serious deployments will use their own certificates, the default install should at least be sane.