### PR TITLE
Use the latest Sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,2 @@
-# Sphinx version is limited only due to the following bug:
-# https://github.com/sphinx-doc/sphinx/issues/3779.
-# Whenever it will be resolved, remove this version limitation
-sphinx<1.6.1
+sphinx
 sphinx-rtd-theme


### PR DESCRIPTION
The issue which did not allow us to use the latest sphinx is fixed in 1.6.2
sphinx-doc/sphinx#3779