### PR TITLE
Fix rsync distributor publishing units not published by predistributor

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -351,6 +351,10 @@ class Publisher(PublishStep):
         else:
             date_filter = None
 
+            if self.predistributor:
+                end_date = self.predistributor["last_publish"]
+                date_filter = self.create_date_range_filter(None, end_date=end_date)
+
         self.symlink_list = []
         self.content_unit_file_list = []
         self.symlink_src = os.path.join(self.get_working_dir(), '.relative/')
@@ -371,10 +375,12 @@ class Publisher(PublishStep):
             force_full |= predistributor_force_full
             if entry.get("result", "error") == "error":
                 force_full = True
+
         if self.last_published:
             last_published = self.last_published.replace(tzinfo=None)
         else:
             last_published = None
+
         if self.last_deleted:
             last_deleted = self.last_deleted.replace(tzinfo=None)
         else:


### PR DESCRIPTION
Fixes an issue with rsync logic where some units which have 
not yet been published by the predistributor are included
with rsync publishes.

closes #2791
https://pulp.plan.io/issues/2791

### Don't merge until after #3039 