### PR TITLE
Update path to wsgi for pulp-manager command

### DIFF
--- a/platform/pulpcore/app/settings.py
+++ b/platform/pulpcore/app/settings.py
@@ -103,7 +103,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'wsgi.application'
+WSGI_APPLICATION = 'pulpcore.app.wsgi.application'
 
 REST_FRAMEWORK = {
     'URL_FIELD_NAME': '_href',


### PR DESCRIPTION
pulp-manager command needs full path to wsgi
in order to run from anywhere

closes #2707
https://pulp.plan.io/issues/2707