### PR TITLE
Fix trace in get_downloader().

### DIFF
--- a/streamer/pulp/streamer/server.py
+++ b/streamer/pulp/streamer/server.py
@@ -253,7 +253,7 @@ class Streamer(Resource):
                 model, entry.url, working_dir='/tmp')
             listener = DownloadListener(self, request)
             downloader.event_listener = listener
-            downloader.session = self.session_cache.get(request.uri, downloader)
+            downloader.session = self.session_cache.get_or_create(request.uri, downloader)
             return downloader
         except (PluginNotFound, DoesNotExist):
             msg = _('Plugin not-found: referenced by catalog entry for {path}')

--- a/streamer/test/unit/streamer/test_server.py
+++ b/streamer/test/unit/streamer/test_server.py
@@ -334,9 +334,10 @@ class TestStreamer(unittest.TestCase):
         container.return_value.download(downloader, [request.return_value], listener)
         downloader.config.finalize.assert_called_once_with()
 
+    @patch(MODULE_PREFIX + 'Session')
     @patch(MODULE_PREFIX + 'DownloadListener')
     @patch(MODULE_PREFIX + 'repo_controller')
-    def test_get_downloader(self, controller, listener):
+    def test_get_downloader(self, controller, listener, session):
         request = Mock(uri='http://pulp.org/content')
         entry = Mock(importer_id='123')
         importer = Mock()
@@ -347,7 +348,6 @@ class TestStreamer(unittest.TestCase):
 
         # test
         streamer = Streamer(Mock())
-        streamer.session_cache = Mock()
         downloader = streamer._get_downloader(request, entry)
 
         # validation
@@ -358,7 +358,7 @@ class TestStreamer(unittest.TestCase):
         listener.assert_called_once_with(streamer, request)
         self.assertEqual(downloader, importer.get_downloader_for_db_importer.return_value)
         self.assertEqual(downloader.event_listener, listener.return_value)
-        self.assertEqual(downloader.session, streamer.session_cache.get.return_value)
+        self.assertEqual(downloader.session, session.return_value)
 
     @patch(MODULE_PREFIX + 'AggregatingEventListener')
     @patch(MODULE_PREFIX + 'repo_controller')


### PR DESCRIPTION
https://pulp.plan.io/issues/2798

Method renamed to `get_or_create()` during review and unit test failed to catch the name not changed in the code making the call.