### PR TITLE
Fixes pulp-admin improper base64 encoding for (very long) user basic auth credentials

### DIFF
--- a/bindings/pulp/bindings/server.py
+++ b/bindings/pulp/bindings/server.py
@@ -307,7 +307,7 @@ class HTTPSServerWrapper(object):
 
         if self.pulp_connection.username and self.pulp_connection.password:
             raw = ':'.join((self.pulp_connection.username, self.pulp_connection.password))
-            encoded = base64.encodestring(raw)[:-1]
+            encoded = base64.b64encode(raw)
             headers['Authorization'] = 'Basic ' + encoded
         elif self.pulp_connection.cert_filename:
             ssl_context.load_cert(self.pulp_connection.cert_filename)


### PR DESCRIPTION
Fixes https://pulp.plan.io/issues/2825

* Use `base64.b64encode()` instead of `base64.encodestring()` for
  encoding Basic Auth informations