### PR TITLE
Add Pulp package path to sphinx build config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,10 @@ except ImportError:
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('./extensions'))
 
+sys.path.insert(0, os.path.abspath('../platform'))
+sys.path.insert(0, os.path.abspath('../plugin'))
+sys.path.insert(0, os.path.abspath('../common'))
+
 # Set environment variable so Sphinx can bootstrap the Django app
 os.environ["DJANGO_SETTINGS_MODULE"] = "pulpcore.app.settings"
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx-rtd-theme
+pyyaml


### PR DESCRIPTION
Building the docs should not require pulp python package to be installed. 