### PR TITLE
Problem: Artifacts can't be created via REST API

### DIFF
--- a/platform/pulpcore/app/models/content.py
+++ b/platform/pulpcore/app/models/content.py
@@ -1,12 +1,10 @@
 """
 Content related Django models.
 """
-import hashlib
-
+from django.core.files.storage import default_storage
 from django.db import models
 
 from pulpcore.app.models import Model, MasterModel, Notes, GenericKeyValueRelation
-from pulpcore.app.models.storage import ArtifactLocation
 
 
 class Content(MasterModel):
@@ -39,35 +37,6 @@ class Content(MasterModel):
         """
         return tuple(getattr(self, f.name) for f in self.natural_key_fields)
 
-    def natural_key_digest(self):
-        """
-        Get the SHA-256 digest of the natural key.
-        The digest is updated with each field name followed by its value.
-        The field names are only necessary to preserve backward compatibility
-        with digests generated in pulp 2.
-
-        :return: The hex digest.
-        :rtype: str
-        """
-        h = hashlib.sha256()
-        for name in sorted(f.name for f in self.natural_key_fields):
-            h.update(name.encode(encoding='utf-8'))
-            value = getattr(self, name)
-            if isinstance(value, str):
-                h.update(value.encode(encoding='utf-8'))
-            else:
-                h.update(value)
-        return h.hexdigest()
-
-    def __str__(self):
-        cast = self.cast()
-
-        # so here's a pretty good case for making namedtuples for content types
-        # the third replacement string results in "natural_key_fieldname_0=repr(field_value), ..."
-        natural_key_zip = zip(cast.natural_key_fields, cast.natural_key())
-        natural_key_string = ', '.join(('='.join((t[0].name, repr(t[1]))) for t in natural_key_zip))
-        return '<{} (type={}): {}>'.format(self._meta.object_name, cast.TYPE, natural_key_string)
-
 
 class Artifact(Model):
     """
@@ -76,13 +45,6 @@ class Artifact(Model):
     Fields:
 
         file (models.FileField): The stored file.
-        downloaded (models.BooleanField): The associated file has been successfully downloaded.
-        requested (models.BooleanField): The associated file has been requested by a client at
-            least once.
-        relative_path (models.TextField): The artifact's path relative to the associated
-            :class:`Content`. This path is incorporated in the absolute storage path of the file
-            and its published path relative to the root publishing directory. At a minimum the path
-            will contain the file name but may also include sub-directories.
         size (models.IntegerField): The size of the file in bytes.
         md5 (models.CharField): The MD5 checksum of the file.
         sha1 (models.CharField): The SHA-1 checksum of the file.
@@ -90,25 +52,22 @@ class Artifact(Model):
         sha256 (models.CharField): The SHA-256 checksum of the file.
         sha384 (models.CharField): The SHA-384 checksum of the file.
         sha512 (models.CharField): The SHA-512 checksum of the file.
-
-    Relations:
-
-        content (models.ForeignKey): The associated content.
     """
+    def storage_path(self, name):
+        """
+        Callable used by FileField to determine where the uploaded file should be stored.
 
-    file = models.FileField(db_index=True, upload_to=ArtifactLocation(), max_length=255)
-    downloaded = models.BooleanField(db_index=True, default=False)
-    requested = models.BooleanField(db_index=True, default=False)
-    relative_path = models.TextField(db_index=True, blank=False, default=None)
-    size = models.IntegerField(blank=True, null=True)
-    md5 = models.CharField(max_length=32, blank=True, null=True)
-    sha1 = models.CharField(max_length=40, blank=True, null=True)
-    sha224 = models.CharField(max_length=56, blank=True, null=True)
-    sha256 = models.CharField(max_length=64, blank=True, null=True)
-    sha384 = models.CharField(max_length=96, blank=True, null=True)
-    sha512 = models.CharField(max_length=128, blank=True, null=True)
+        Args:
+            name (str): Original name of uploaded file. It is ignored by this method because the
+                sha256 checksum is used to determine a file path instead.
+        """
+        return default_storage.get_artifact_path(self.sha256)
 
-    content = models.ForeignKey(Content, related_name='artifacts', on_delete=models.CASCADE)
-
-    class Meta:
-        unique_together = ('content', 'relative_path')
+    file = models.FileField(db_index=True, upload_to=storage_path, max_length=255)
+    size = models.IntegerField(blank=False, null=False)
+    md5 = models.CharField(max_length=32, blank=False, null=False, unique=False, db_index=True)
+    sha1 = models.CharField(max_length=40, blank=False, null=False, unique=False, db_index=True)
+    sha224 = models.CharField(max_length=56, blank=False, null=False, unique=False, db_index=True)
+    sha256 = models.CharField(max_length=64, blank=False, null=False, unique=True, db_index=True)
+    sha384 = models.CharField(max_length=96, blank=False, null=False, unique=True, db_index=True)
+    sha512 = models.CharField(max_length=128, blank=False, null=False, unique=True, db_index=True)

--- a/platform/pulpcore/app/models/storage.py
+++ b/platform/pulpcore/app/models/storage.py
@@ -100,52 +100,6 @@ class TLSLocation:
             self.name)
 
 
-@deconstructible
-class ArtifactLocation:
-    """
-    Determine storage location (path) for file associated with content artifacts.
-    """
-
-    MEDIA_TYPE = 'content'
-
-    @staticmethod
-    def base_path(artifact):
-        """
-        Get the base path used to store a file associated with the specified artifact.
-        All artifact files *must* be stored relative to this location.
-
-        Args:
-            artifact (pulpcore.app.models.content.Artifact): Content artifact.
-
-        Returns:
-            str: An absolute (base) path
-        """
-        digest = artifact.content.natural_key_digest()
-        return os.path.join(
-            settings.MEDIA_ROOT,
-            ArtifactLocation.MEDIA_TYPE,
-            'units',
-            artifact.content.type,
-            digest[0:2],
-            digest[2:])
-
-    def __call__(self, artifact, name):
-        """
-        Get the absolute path used to store a file associated
-        with the specified artifact.
-
-        Stored at: MEDIA_ROOT/content/units/<type>/digest[0:2]/digest[2:]/<rel_path>
-
-        Args:
-            artifact (pulpcore.app.models.content.Artifact): Content artifact.
-            name (str): Unused, here to match Django's FileField API.
-
-        Returns:
-            str: Absolute path.
-        """
-        return os.path.join(self.base_path(artifact), artifact.relative_path)
-
-
 class FileSystem(Storage):
     """
     Provides simplified filesystem storage.
@@ -254,6 +208,20 @@ class FileSystem(Storage):
             st = os.stat(content.name)
             os.chmod(path, stat.S_IMODE(st.st_mode))
         return path
+
+    @staticmethod
+    def get_artifact_path(sha256digest):
+        """
+        Determine the absolute path where a file backing the Artifact should be stored.
+
+        Args:
+            sha256digest (str): sha256 digest of the file for the Artifact
+
+        Returns:
+            A string representing the absolute path where a file backing the Artifact should be
+            stored
+        """
+        return os.path.join(settings.MEDIA_ROOT, 'artifact', sha256digest[0:2], sha256digest[2:])
 
     def get_available_name(self, name, max_length=None):
         """

--- a/platform/pulpcore/app/serializers/content.py
+++ b/platform/pulpcore/app/serializers/content.py
@@ -1,9 +1,14 @@
 from gettext import gettext as _
+import hashlib
 
 from rest_framework import serializers
+from rest_framework.validators import UniqueValidator
 
 from pulpcore.app import models
 from pulpcore.app.serializers import base, fields, generic
+
+
+UNIQUE_ALGORITHMS = ['sha256', 'sha384', 'sha512']
 
 
 class ContentSerializer(base.MasterModelSerializer):
@@ -23,70 +28,83 @@ class ContentSerializer(base.MasterModelSerializer):
 
 
 class ArtifactSerializer(base.ModelSerializer):
+    _href = serializers.HyperlinkedIdentityField(
+        view_name='artifacts-detail',
+    )
+
     file = serializers.FileField(
         help_text=_("The stored file."),
-        read_only=True
-    )
-
-    downloaded = serializers.BooleanField(
-        help_text=_("An indication that the associated file has been downloaded."),
-        read_only=True
-    )
-
-    requested = serializers.BooleanField(
-        help_text=_("An indication that the associated file has been requested by a client."),
-        read_only=True
-    )
-
-    relative_path = serializers.CharField(
-        help_text=_("The relative path of the artifact which is incorporated into the storage and"
-                    " published paths."),
-        read_only=True
+        required=True
     )
 
     size = serializers.IntegerField(
         help_text=_("The size of the file in bytes."),
-        read_only=True
+        required=False
     )
 
     md5 = serializers.CharField(
         help_text=_("The MD5 checksum of the file if available."),
-        read_only=True,
         required=False
     )
 
     sha1 = serializers.CharField(
         help_text=_("The SHA-1 checksum of the file if available."),
-        read_only=True,
         required=False
     )
 
     sha224 = serializers.CharField(
         help_text=_("The SHA-224 checksum of the file if available."),
-        read_only=True,
         required=False
     )
 
     sha256 = serializers.CharField(
         help_text=_("The SHA-256 checksum of the file if available."),
-        read_only=True,
         required=False
     )
 
     sha384 = serializers.CharField(
         help_text=_("The SHA-384 checksum of the file if available."),
-        read_only=True,
         required=False
     )
 
     sha512 = serializers.CharField(
         help_text=_("The SHA-512 checksum of the file if available."),
-        read_only=True,
         required=False
     )
 
+    def validate(self, data):
+        """
+        Validate file by size and by all checksums provided.
+
+        Args:
+            data (dict): Dictionary mapping Artifact model fields to their values
+
+        Raises:
+            :class:`rest_framework.exceptions.ValidationError`: When the expected file size or any
+                of the checksums don't match their actual values.
+        """
+        if 'size' in data:
+            if data['file'].size != int(data['size']):
+                raise serializers.ValidationError(_("The size did not match actual size of file."))
+        else:
+            data['size'] = data['file'].size
+
+        for algorithm in hashlib.algorithms_guaranteed:
+            digest = data['file'].hashers[algorithm].hexdigest()
+            if algorithm in data and digest != data[algorithm]:
+                raise serializers.ValidationError(_("The %s checksum did not match.") % algorithm)
+            else:
+                data[algorithm] = digest
+            if algorithm in UNIQUE_ALGORITHMS:
+                validator = UniqueValidator(models.Artifact.objects.all(),
+                                            message=_("{0} checksum must be "
+                                                      "unique.").format(algorithm))
+                validator.field_name = algorithm
+                validator.instance = None
+                validator(digest)
+        return data
+
     class Meta:
         model = models.Artifact
-        fields = base.ModelSerializer.Meta.fields + ('file', 'downloaded', 'requested',
-                                                     'relative_path', 'size', 'md5', 'sha1',
-                                                     'sha224', 'sha256', 'sha384', 'sha512')
+        fields = base.ModelSerializer.Meta.fields + ('file', 'size', 'md5', 'sha1', 'sha224',
+                                                     'sha256', 'sha384', 'sha512')

--- a/platform/pulpcore/app/settings.py
+++ b/platform/pulpcore/app/settings.py
@@ -35,6 +35,13 @@ ALLOWED_HOSTS = ['*']
 MEDIA_ROOT = '/var/lib/pulp/'
 DEFAULT_FILE_STORAGE = 'pulpcore.app.models.storage.FileSystem'
 
+FILE_UPLOAD_TEMP_DIR = '/var/lib/pulp/tmp/'
+# List of upload handler classes to be applied in order.
+FILE_UPLOAD_HANDLERS = (
+    'pulpcore.app.upload.HashingFileUploadHandler',
+)
+
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/platform/pulpcore/app/upload.py
+++ b/platform/pulpcore/app/upload.py
@@ -1,0 +1,46 @@
+import hashlib
+from django.core.files.uploadhandler import TemporaryFileUploadHandler
+from django.core.files.uploadedfile import TemporaryUploadedFile
+
+
+class PulpTemporaryUploadedFile(TemporaryUploadedFile):
+    """
+    A file uploaded to a temporary location in Pulp.
+    """
+
+    def __init__(self, name, content_type, size, charset, content_type_extra=None):
+        self.hashers = {}
+        for hasher in hashlib.algorithms_guaranteed:
+            self.hashers[hasher] = getattr(hashlib, hasher)()
+        super().__init__(name, content_type, size, charset, content_type_extra)
+
+
+class HashingFileUploadHandler(TemporaryFileUploadHandler):
+    """
+    Upload handler that streams data into a temporary file.
+    """
+
+    def new_file(self, field_name, file_name, content_type, content_length, charset=None,
+                 content_type_extra=None):
+        """
+        Signal that a new file has been started.
+
+        Args:
+            field_name (str): Name of the model field that this file is associated with. This
+                value is not used by this implementation of TemporaryFileUploadHandler.
+            file_name (str): Name of file being uploaded.
+            content_type (str): Type of file
+            content_length (int): Size of the file being stored. This value is not used by this
+                implementation of TemporaryFileUploadHandler.
+            charset (str):
+        """
+        self.field_name = field_name
+        self.content_length = content_length
+        self.file = PulpTemporaryUploadedFile(file_name, content_type, 0, charset,
+                                              content_type_extra)
+
+    def receive_data_chunk(self, raw_data, start):
+        self.file.write(raw_data)
+        for hasher in hashlib.algorithms_guaranteed:
+            self.file.hashers[hasher].update(raw_data)
+

--- a/platform/pulpcore/app/viewsets/__init__.py
+++ b/platform/pulpcore/app/viewsets/__init__.py
@@ -1,5 +1,5 @@
 from pulpcore.app.viewsets.base import NamedModelViewSet  # noqa
-from pulpcore.app.viewsets.content import ContentViewSet  # noqa
+from pulpcore.app.viewsets.content import ArtifactViewSet, ContentViewSet  # noqa
 from pulpcore.app.viewsets.repository import (ImporterViewSet, PublisherViewSet,  # noqa
     RepositoryViewSet, RepositoryContentViewSet)  # noqa
 from pulpcore.app.viewsets.task import TaskViewSet, WorkerViewSet  # noqa

--- a/platform/pulpcore/app/viewsets/base.py
+++ b/platform/pulpcore/app/viewsets/base.py
@@ -13,7 +13,7 @@ class NamedModelViewSet(viewsets.ModelViewSet):
 
     Attributes:
         lookup_field (str): The name of the field by which an object should be looked up, in
-            addition to any parent lookups if this ViewSet is nested. Defaults to 'name'
+            addition to any parent lookups if this ViewSet is nested. Defaults to 'pk'
         endpoint_name (str): The name of the final path segment that should identify the ViewSet's
             collection endpoint.
         nest_prefix (str): Optional prefix under which this ViewSet should be nested. This must

--- a/platform/pulpcore/app/viewsets/content.py
+++ b/platform/pulpcore/app/viewsets/content.py
@@ -1,7 +1,10 @@
 from django_filters.rest_framework import filterset
+from rest_framework import status
+from rest_framework.response import Response
 
-from pulpcore.app.models import Content
-from pulpcore.app.serializers import ContentSerializer
+
+from pulpcore.app.models import Artifact, Content
+from pulpcore.app.serializers import ArtifactSerializer, ContentSerializer
 from pulpcore.app.viewsets import NamedModelViewSet
 
 
@@ -20,8 +23,33 @@ class ContentFilter(filterset.FilterSet):
         fields = ['type']
 
 
+class ArtifactFilter(filterset.FilterSet):
+    """
+    Artifact filter Plugin content filters would need:
+     - to inherit from this class
+     - to add any plugin-specific filters if needed
+     - to define its own `Meta` class which needs:
+
+       - to specify plugin content model
+       - to extend `fields` with plugin-specific ones
+    """
+    class Meta:
+        model = Artifact
+        fields = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
+
+
 class ContentViewSet(NamedModelViewSet):
     endpoint_name = 'content'
     queryset = Content.objects.all()
     serializer_class = ContentSerializer
     filter_class = ContentFilter
+
+
+class ArtifactViewSet(NamedModelViewSet):
+    endpoint_name = 'artifacts'
+    queryset = Artifact.objects.all()
+    serializer_class = ArtifactSerializer
+    filter_class = ArtifactFilter
+
+    def update(self, request, pk):
+        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)


### PR DESCRIPTION
Solution: add a viewset for Artifacts

The REST API user can now POST to /api/v3/artifacts endpoint with a file,
size, and any number of checksums. During the upload of the file, each
possible checksum is calculated. If user provides size or any checksums,
they are verified after the upload finishes. If one of the values does not
match a ValidationError is raised.

The user can also list all the the Artifacts by performing a GET request
to /api/v3/artifacts. An Artifact can be deleted by making a DELETE
request to /api/v3/artifacts/<pk>.

The user can not update Artifacts via REST API after one is created.

The 'django.core.files.uploadhandler.MemoryFileUploadHandler' is disabled so
all uploads are handled by 'pulpcore.app.upload.PulpFileUploadHandler' and
are written to '/var/lib/pulp/tmp' as the file is being uploaded.

closes #2843
https://pulp.plan.io/issues/2843