### PR TITLE
Fixing bare exceptions in Status view

### DIFF
--- a/platform/pulpcore/app/views/status.py
+++ b/platform/pulpcore/app/views/status.py
@@ -39,7 +39,7 @@ class StatusView(APIView):
 
         try:
             workers = Worker.objects.all()
-        except:
+        except Exception:
             workers = None
 
         data = {
@@ -63,7 +63,7 @@ class StatusView(APIView):
         """
         try:
             Worker.objects.count()
-        except:
+        except Exception:
             _logger.exception(_('Cannot connect to database during status check.'))
             return False
         else:
@@ -81,7 +81,7 @@ class StatusView(APIView):
             conn = celery.connection()
             conn.connect()
             conn.release()
-        except:
+        except Exception:
             _logger.exception(_('Connection to broker failed during status check!'))
             return False
         else:


### PR DESCRIPTION
pep8speaks throws E722 for bare exceptions. From [the Python docs](https://docs.python.org/2/howto/doanddont.html):

> Because `except:` catches all exceptions, including SystemExit, KeyboardInterrupt, and GeneratorExit (which is not an error and should not normally be caught by user code), using a bare `except:` is almost never a good idea. In situations where you need to catch all “normal” errors, such as in a framework that runs callbacks, you can catch the base class for all normal exceptions, Exception.