### PR TITLE
Run flake8 against entire codebase for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
 install:
     - "pip install flake8"
 script:
-    - "git diff HEAD^ '*.py' | flake8 --diff --config flake8.cfg"
+    - "flake8 --config flake8.cfg"

--- a/bindings/test/unit/test_tasks.py
+++ b/bindings/test/unit/test_tasks.py
@@ -86,6 +86,7 @@ class TestPurgeTasks(unittest.TestCase):
         self.api.purge_tasks(states=states)
         self.server.DELETE.assert_called_once()
 
+
 TASKS = [
     {
         'exception': None,

--- a/client_lib/pulp/client/commands/consumer/query.py
+++ b/client_lib/pulp/client/commands/consumer/query.py
@@ -148,6 +148,7 @@ class ConsumerHistoryCommand(PulpCliCommand):
         for event in event_list:
             self.context.prompt.render_document(event, filters=filters, order=order)
 
+
 # options and flags ------------------------------------------------------------
 
 OPTION_FIELDS = PulpCliOption('--fields',

--- a/common/pulp/common/config.py
+++ b/common/pulp/common/config.py
@@ -143,6 +143,7 @@ def parse_bool(value):
 
     return value.upper() in ('YES', 'TRUE', '1')
 
+
 def parse_header(headers):
     """
        Parses the given header into its dictionary representation.

--- a/devel/pulp/devel/dummy_plugins.py
+++ b/devel/pulp/devel/dummy_plugins.py
@@ -68,6 +68,7 @@ class DummyGroupDistributor(DummyPlugin):
     def validate_config(self, repo_group, config, related_repo_groups):
         return True, None
 
+
 # dummy instances --------------------------------------------------------------
 
 DUMMY_IMPORTER = DummyImporter()

--- a/server/pulp/plugins/rsync/configuration.py
+++ b/server/pulp/plugins/rsync/configuration.py
@@ -100,6 +100,7 @@ class RelativePathValidation(object):
         """
         return _("attribute cannot start with a /")
 
+
 REMOTE_MANDATORY_KEYS = {
     "ssh_identity_file": [TypeValidation([basestring]), NonEmptyValidation()],
     "ssh_user": [TypeValidation([basestring]), NonEmptyValidation()],

--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -391,7 +391,8 @@ class Publisher(PublishStep):
         delete = self.get_config().get("delete", False)
 
         return not force_full and not delete and self.last_predist_last_published and \
-            ((last_deleted and last_published and last_published > last_deleted) or not last_deleted)
+            ((last_deleted and last_published and last_published > last_deleted) or
+             not last_deleted)
 
     def create_date_range_filter(self, start_date=None, end_date=None):
         """

--- a/server/pulp/server/async/celery_instance.py
+++ b/server/pulp/server/async/celery_instance.py
@@ -69,5 +69,6 @@ def configure_SSL():
         }
         celery.conf.update(BROKER_USE_SSL=BROKER_USE_SSL)
 
+
 configure_SSL()
 configure_login_method()

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -919,7 +919,7 @@ class FileContentUnit(ContentUnit):
         """
         try:
             self.import_content(path, location)
-        except:
+        except:  # noqa
             self.clean_orphans()
             raise
 
@@ -1295,6 +1295,7 @@ class Distributor(AutoRetryDocument):
         :type document: Distributor
         """
         document.last_updated = dateutils.now_utc_datetime_with_tzinfo()
+
 
 signals.pre_save.connect(Distributor.pre_save_signal, sender=Distributor)
 

--- a/server/pulp/server/event/notifiers.py
+++ b/server/pulp/server/event/notifiers.py
@@ -56,5 +56,6 @@ def reset():
         amqp.TYPE_ID: amqp.handle_event,
     }
 
+
 # Perform the initial populating of the notifier functions on module load
 reset()

--- a/server/pulp/server/managers/auth/permission/cud.py
+++ b/server/pulp/server/managers/auth/permission/cud.py
@@ -305,5 +305,6 @@ class PermissionManager(object):
             return None
         return authorization.OPERATION_NAMES[operation]
 
+
 grant = task(PermissionManager.grant, base=Task, ignore_result=True)
 revoke = task(PermissionManager.revoke, base=Task, ignore_result=True)

--- a/server/pulp/server/managers/consumer/applicability.py
+++ b/server/pulp/server/managers/consumer/applicability.py
@@ -456,6 +456,8 @@ class RepoProfileApplicabilityManager(object):
         # Remove all RepoProfileApplicability objects that reference these profile hashes
         if missing_profile_hashes:
             rpa_collection.remove({'profile_hash': {'$in': missing_profile_hashes}})
+
+
 # Instantiate one of the managers on the object it manages for convenience
 RepoProfileApplicability.objects = RepoProfileApplicabilityManager()
 

--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -64,7 +64,7 @@ from pulp.server.webservices.views.repo_groups import (
     RepoGroupPublishView, RepoGroupResourceView, RepoGroupSearch, RepoGroupsView,
     RepoGroupUnassociateView
 )
-from pulp.server.webservices.views.repositories import(
+from pulp.server.webservices.views.repositories import (
     ContentApplicabilityRegenerationView, RepoDistributorResourceView, RepoDistributorsSearchView,
     RepoDistributorsView, RepoAssociate, RepoImporterResourceView, RepoImportersView,
     RepoImportUpload, RepoPublish, RepoPublishHistory, RepoPublishScheduleResourceView,

--- a/server/pulp/server/webservices/views/serializers/content.py
+++ b/server/pulp/server/webservices/views/serializers/content.py
@@ -58,6 +58,8 @@ def serialize_unit_with_serializer(content_unit):
 
     for original_field, remapped_field in field_map.items():
         content_unit[remapped_field] = content_unit.pop(original_field)
+
+
 # remap_fields_with_serializer was renamed to serialize_unit_with_serializer. Alias the old
 # name for backward compatibility in the unlikely event that the old name is still in use.
 remap_fields_with_serializer = serialize_unit_with_serializer

--- a/server/test/unit/server/db/migrations/test_0015_load_content_types.py
+++ b/server/test/unit/server/db/migrations/test_0015_load_content_types.py
@@ -58,6 +58,7 @@ def mock_open(mock=None, read_data=None):
     mock.return_value = handle
     return mock
 
+
 migration = _import_all_the_way('pulp.server.db.migrations.0015_load_content_types')
 
 

--- a/server/test/unit/server/managers/auth/cert/test_cert_generator.py
+++ b/server/test/unit/server/managers/auth/cert/test_cert_generator.py
@@ -84,6 +84,7 @@ class TestCertGeneration(unittest.TestCase):
         invalid_result = self.cert_gen_manager.verify_cert(INVALID_CERT)
         self.assertTrue(not invalid_result)
 
+
 if __name__ == '__main__':
     logging.root.addHandler(logging.StreamHandler())
     logging.root.setLevel(logging.INFO)


### PR DESCRIPTION
Having flake8 run against diffs won't pick up things like unused imports
if the import line wasn't touched. Therefore, we should run flake8
against the entire codebase for each PR.

Also, fixing a bunch of breakages.