### PR TITLE
Add publication models.

### DIFF
--- a/platform/pulpcore/app/models/__init__.py
+++ b/platform/pulpcore/app/models/__init__.py
@@ -7,6 +7,7 @@ from .generic import (GenericRelationModel, GenericKeyValueManager, GenericKeyVa
 
 from .consumer import Consumer, ConsumerContent  # noqa
 from .content import Content, Artifact, ContentArtifact, RemoteArtifact  # noqa
+from .publication import Distribution, Publication, PublishedArtifact, PublishedMetadata  # noqa
 from .repository import Repository, Importer, Publisher, RepositoryContent  # noqa
 from .storage import FileContent  # noqa
 from .task import ReservedResource, Worker, Task, TaskTag, TaskLock  # noqa

--- a/platform/pulpcore/app/models/publication.py
+++ b/platform/pulpcore/app/models/publication.py
@@ -1,0 +1,102 @@
+from django.db import models
+from django.core.files.storage import DefaultStorage
+
+from pulpcore.app.models import Model
+
+
+class Publication(Model):
+    """
+    Fields:
+        created (models.DatetimeField): When the publication was created UTC.
+
+    Relations:
+        publisher (models.ForeignKey): The publisher that created the publication.
+    """
+
+    created = models.DateTimeField(auto_now_add=True)
+
+    publisher = models.ForeignKey('Publisher', on_delete=models.CASCADE)
+
+
+class PublishedFile(Model):
+    """
+    A file included in Publication.
+
+    Fields:
+        relative_path (models.CharField): The (relative) path component of the published url.
+
+    Relations:
+        publication (models.ForeignKey): The publication in which the artifact is included.
+
+    """
+    relative_path = models.CharField(max_length=255)
+
+    publication = models.ForeignKey(Publication, on_delete=models.CASCADE)
+
+    class Meta:
+        abstract = True
+
+
+class PublishedArtifact(PublishedFile):
+    """
+    An artifact that is part of a publication.
+
+    Relations:
+        content_artifact (models.ForeignKey): The referenced content artifact.
+    """
+    content_artifact = models.ForeignKey('ContentArtifact', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('publication', 'content_artifact')
+        default_related_name = 'published_artifact'
+
+
+class PublishedMetadata(PublishedFile):
+    """
+    Metadata file that is part of a publication.
+
+    Fields:
+        file (models.FileField): The stored file.
+    """
+
+    def _storage_path(self, name):
+        return DefaultStorage().published_metadata_path(self, name)
+
+    file = models.FileField(upload_to=_storage_path, max_length=255)
+
+    class Meta:
+        unique_together = ('publication', 'file')
+        default_related_name = 'published_metadata'
+
+
+class Distribution(Model):
+    """
+    A distribution defines how a publication is distributed by pulp.
+
+    Fields:
+        name (models.CharField): The name of the distribution.
+            Examples: "rawhide" and "stable".
+        base_path (models.CharField): The base (relative) path component of the published url.
+        auto_updated (models.BooleanField): The publication is updated automatically
+            whenever the publisher has created a new publication.
+        http (models.BooleanField): The publication is distributed using HTTP.
+        https (models.BooleanField): The publication is distributed using HTTPS.
+
+    Relations:
+        publisher (models.ForeignKey): The associated publisher.
+        publication (models.ForeignKey): The current publication associated with
+            the distribution.  This is the publication being served by Pulp through
+            this relative URL path and settings.
+    """
+
+    name = models.CharField(max_length=255)
+    base_path = models.CharField(max_length=255, unique=True)
+    auto_updated = models.BooleanField(default=True)
+    http = models.BooleanField(default=True)
+    https = models.BooleanField(default=True)
+
+    publication = models.ForeignKey(Publication, null=True, on_delete=models.SET_NULL)
+    publisher = models.ForeignKey('Publisher', on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('publisher', 'name')

--- a/platform/pulpcore/app/models/repository.py
+++ b/platform/pulpcore/app/models/repository.py
@@ -179,7 +179,6 @@ class Publisher(ContentAdaptor):
 
         auto_publish (models.BooleanField): Indicates that the adaptor may publish automatically
             when the associated repository's content has changed.
-        relative_path (models.TextField): The (relative) path component of the published url.
         last_published (models.DatetimeField): When the last successful publish occurred.
 
     Relations:
@@ -190,7 +189,6 @@ class Publisher(ContentAdaptor):
     repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
 
     auto_publish = models.BooleanField(default=True)
-    relative_path = models.TextField(blank=True)
     last_published = models.DateTimeField(blank=True, null=True)
 
     class Meta(ContentAdaptor.Meta):

--- a/platform/pulpcore/app/models/storage.py
+++ b/platform/pulpcore/app/models/storage.py
@@ -223,6 +223,25 @@ class FileSystem(Storage):
         """
         return os.path.join(settings.MEDIA_ROOT, 'artifact', sha256digest[0:2], sha256digest[2:])
 
+    @staticmethod
+    def published_metadata_path(model, name):
+        """
+        Get the storage path for published metadata.
+
+        Args:
+            model (pulpcore.app.models.PublishedMetadata): A model instance.
+            name (str): The file name.
+
+        Returns:
+            str: The absolute storage path.
+        """
+        return os.path.join(
+            settings.MEDIA_ROOT,
+            'published',
+            'metadata',
+            str(model.pk),
+            name)
+
     def get_available_name(self, name, max_length=None):
         """
         Get the available absolute path based on the name requested.

--- a/platform/pulpcore/app/serializers/repository.py
+++ b/platform/pulpcore/app/serializers/repository.py
@@ -165,11 +165,6 @@ class PublisherSerializer(MasterModelSerializer, NestedHyperlinkedModelSerialize
                     ' the repository content has changed.'),
         required=False
     )
-    relative_path = serializers.CharField(
-        help_text=_('The (relative) path component of the published url'),
-        required=False,
-        allow_blank=True
-    )
     last_published = serializers.DateTimeField(
         help_text=_('Timestamp of the most recent successful publish.'),
         read_only=True
@@ -179,7 +174,7 @@ class PublisherSerializer(MasterModelSerializer, NestedHyperlinkedModelSerialize
         abstract = True
         model = models.Publisher
         fields = MasterModelSerializer.Meta.fields + (
-            'name', 'last_updated', 'repository', 'auto_publish', 'relative_path', 'last_published'
+            'name', 'last_updated', 'repository', 'auto_publish', 'last_published'
         )
 
 

--- a/platform/pulpcore/app/urls.py
+++ b/platform/pulpcore/app/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls import url, include
 from rest_framework_nested import routers
 
 from pulpcore.app.apps import pulp_plugin_configs
-from pulpcore.app.views.status import StatusView
+from pulpcore.app.views import ContentView, StatusView
 
 root_router = routers.DefaultRouter(
     schema_title='Pulp API',
@@ -63,6 +63,7 @@ except AppRegistryNotReady as ex:
 
 
 urlpatterns = [
+    url(r'^{}/'.format(ContentView.BASE_PATH), ContentView.as_view()),
     url(r'^api/v3/', include(root_router.urls)),
     url(r'^api/v3/status/', StatusView.as_view()),
 ]

--- a/platform/pulpcore/app/views/__init__.py
+++ b/platform/pulpcore/app/views/__init__.py
@@ -1,1 +1,2 @@
-from pulpcore.app.views.status import StatusView  # noqa
+from .content import ContentView  # noqa
+from .status import StatusView  # noqa

--- a/platform/pulpcore/app/views/content.py
+++ b/platform/pulpcore/app/views/content.py
@@ -1,0 +1,188 @@
+import os
+
+from gettext import gettext as _
+from logging import getLogger, DEBUG
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseNotFound, StreamingHttpResponse
+from django.views.generic import View
+
+from wsgiref.util import FileWrapper
+
+from pulpcore.app.models import Distribution
+
+
+log = getLogger(__name__)
+log.level = DEBUG
+
+
+class ContentView(View):
+    """
+    Content endpoint.
+
+    URL matching algorithm.
+
+    http://redhat.com/content/cdn/stage/files/manifest
+                              |-------------||--------|
+                                     (1)          (2)
+
+    1. Match: Distribution.base_path
+    2. Match: PublishedFile.relative_path
+    """
+
+    BASE_PATH = 'content'
+
+    @staticmethod
+    def _base_paths(path):
+        """
+        Get a list of base paths used to match a distribution.
+
+        Args:
+            path (str): The path component of the URL.
+
+        Returns:
+            list: Of base paths.
+
+        """
+        tree = []
+        while True:
+            base = os.path.split(path.strip('/'))[0]
+            if not base:
+                break
+            tree.append(base)
+            path = base
+        return tree
+
+    def _match_distribution(self, path):
+        """
+        Match a distribution using a list of base paths.
+
+        Args:
+            path (str): The path component of the URL.
+
+        Returns:
+            Distribution: The matched distribution.
+
+        Raises:
+            ObjectDoesNotExist: when not matched.
+        """
+        base_paths = self._base_paths(path)
+        try:
+            return Distribution.objects.get(base_path__in=base_paths)
+        except ObjectDoesNotExist:
+            log.debug(
+                _('Distribution not matched for %(path)s using: %(base_paths)s'),
+                {
+                    'path': path,
+                    'base_paths': base_paths
+                })
+            raise
+
+    def _match(self, path):
+        """
+        Match either a PublishedArtifact or PublishedMetadata.
+
+        Args:
+            path (str): The path component of the URL.
+
+        Returns:
+            str: The storage path of the matched object.
+
+        Raises:
+            ObjectDoesNotExist: The referenced object does not exist.
+
+        """
+        distribution = self._match_distribution(path)
+        publication = distribution.publication
+        if not publication:
+            raise ObjectDoesNotExist()
+        rel_path = path.lstrip('/')
+        rel_path = rel_path[len(distribution.base_path):]
+        rel_path = rel_path.lstrip('/')
+        # artifact
+        try:
+            pa = publication.published_artifact.get(relative_path=rel_path)
+        except ObjectDoesNotExist:
+            pass
+        else:
+            artifact = pa.content_artifact.artifact
+            if artifact.file:
+                return artifact.file.name
+            else:
+                raise ObjectDoesNotExist()
+        # metadata
+        pm = publication.published_metadata.get(relative_path=rel_path)
+        if pm.file:
+            return pm.file.name
+        else:
+            raise ObjectDoesNotExist()
+
+    @staticmethod
+    def _stream(storage_path):
+        """
+        Get streaming response.
+
+        Args:
+            storage_path (str): The storage path of the requested object.
+
+        Returns:
+            HttpResponse: Always.
+
+        """
+        try:
+            file = FileWrapper(open(storage_path, 'rb'))
+        except FileNotFoundError:
+            return HttpResponseNotFound()
+        response = StreamingHttpResponse(file)
+        response['Content-Length'] = os.path.getsize(storage_path)
+        response['Content-Disposition'] = \
+            'attachment; filename={n}'.format(n=os.path.basename(storage_path))
+        return response
+
+    @staticmethod
+    def _redirect(storage_path):
+        """
+        Redirect to streamer.
+
+        Args:
+            storage_path (str): The storage path of the requested object.
+
+        Returns:
+
+        """
+        # :TODO:
+
+    @staticmethod
+    def _xsend(storage_path):
+        """
+        Stream using X-SEND.
+
+        Args:
+            storage_path (str): The storage path of the requested object.
+
+        Returns:
+
+        """
+        # :TODO:
+
+    def get(self, request):
+        """
+        Get content artifact (bits).
+
+        Args:
+            request (django.http.HttpRequest): A request for a content artifact.
+
+        Returns:
+            django.http.StreamingHttpResponse: on found.
+            django.http.HttpResponseNotFound: on not-found.
+
+        """
+        try:
+            path = request.path.strip('/')
+            path = path[len(self.BASE_PATH):]
+            storage_path = self._match(path)
+        except ObjectDoesNotExist:
+            return HttpResponseNotFound()
+
+        # TODO: Eventually, choose _redirect() and _xsend() as appropriate.
+        return self._stream(storage_path)

--- a/plugin/pulpcore/plugin/models/__init__.py
+++ b/plugin/pulpcore/plugin/models/__init__.py
@@ -2,8 +2,18 @@
 # Any models defined in the pulpcore.plugin namespace should probably be proxy models.
 
 from pulpcore.app.models import (  # NOQA
-    Artifact, Content, ContentArtifact, RemoteArtifact, ProgressBar,
-    ProgressSpinner, Repository, RepositoryContent)
+    Artifact,
+    Content,
+    ContentArtifact,
+    ProgressBar,
+    ProgressSpinner,
+    Publication,
+    PublishedArtifact,
+    PublishedMetadata,
+    Repository,
+    RemoteArtifact,
+    RepositoryContent
+)
 
 
 from .publisher import Publisher  # noqa


### PR DESCRIPTION
https://pulp.plan.io/issues/2893
https://pulp.plan.io/issues/2895

Add publication models and test using file plugin.

This PR currently includes (2) files for the content app.  May split out into separate PR before merging.

Testing requires creating a `Distribution` in the DB with `psql`.