### PR TITLE
Add dependencies to pulp/docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,10 @@
 sphinx
 sphinx-rtd-theme
 pyyaml
+django
+djangorestframework
+django-filter
+psycopg2
+celery
+coreapi
+drf-nested-routers


### PR DESCRIPTION
The pulp/docs requirements.py should include everything necessary to run 'make html'
Since we are calling 'import django; django.setup()' in the sphinx conf.py
every dependency used by pulp needs to be installed (and not mocked).

Usually this is not a problem if the docs are being built on the same machine pulp is
installed on, but in cases where only doc building is done, only one requirements.txt
should need to be instatlled.