### PR TITLE
Problem: Content can not be created using REST API

### DIFF
--- a/platform/pulpcore/app/models/__init__.py
+++ b/platform/pulpcore/app/models/__init__.py
@@ -6,7 +6,7 @@ from .generic import (GenericRelationModel, GenericKeyValueManager, GenericKeyVa
                       GenericKeyValueModel, Config, Notes, Scratchpad)  # noqa
 
 from .consumer import Consumer, ConsumerContent  # noqa
-from .content import Content, Artifact  # noqa
+from .content import Content, Artifact, ContentArtifact, DeferredArtifact  # noqa
 from .repository import Repository, Importer, Publisher, RepositoryContent  # noqa
 from .storage import FileContent  # noqa
 from .task import ReservedResource, Worker, Task, TaskTag, TaskLock  # noqa

--- a/platform/pulpcore/app/models/content.py
+++ b/platform/pulpcore/app/models/content.py
@@ -1,41 +1,12 @@
 """
 Content related Django models.
 """
+from django.core import validators
 from django.core.files.storage import default_storage
 from django.db import models
 
+
 from pulpcore.app.models import Model, MasterModel, Notes, GenericKeyValueRelation
-
-
-class Content(MasterModel):
-    """
-    A piece of managed content.
-
-    Attributes:
-
-        natural_key_fields (tuple): Natural key fields.  Must be models.Field subclasses.
-
-    Relations:
-
-        notes (GenericKeyValueRelation): Arbitrary information stored with the content.
-    """
-    TYPE = 'content'
-
-    natural_key_fields = ()
-
-    notes = GenericKeyValueRelation(Notes)
-
-    class Meta:
-        verbose_name_plural = 'content'
-
-    def natural_key(self):
-        """
-        Get the model's natural key based on natural_key_fields.
-
-        :return: The natural key.
-        :rtype: tuple
-        """
-        return tuple(getattr(self, f.name) for f in self.natural_key_fields)
 
 
 class Artifact(Model):
@@ -63,7 +34,7 @@ class Artifact(Model):
         """
         return default_storage.get_artifact_path(self.sha256)
 
-    file = models.FileField(db_index=True, upload_to=storage_path, max_length=255)
+    file = models.FileField(blank=False, null=False, upload_to=storage_path, max_length=255)
     size = models.IntegerField(blank=False, null=False)
     md5 = models.CharField(max_length=32, blank=False, null=False, unique=False, db_index=True)
     sha1 = models.CharField(max_length=40, blank=False, null=False, unique=False, db_index=True)
@@ -71,3 +42,89 @@ class Artifact(Model):
     sha256 = models.CharField(max_length=64, blank=False, null=False, unique=True, db_index=True)
     sha384 = models.CharField(max_length=96, blank=False, null=False, unique=True, db_index=True)
     sha512 = models.CharField(max_length=128, blank=False, null=False, unique=True, db_index=True)
+
+
+class Content(MasterModel):
+    """
+    A piece of managed content.
+
+    Attributes:
+
+        natural_key_fields (tuple): Natural key fields.  Must be models.Field subclasses.
+
+    Relations:
+
+        notes (GenericKeyValueRelation): Arbitrary information stored with the content.
+        artifacts (models.ManyToManyField): Artifacts related to Content through ContentArtifact
+    """
+    TYPE = 'content'
+
+    natural_key_fields = ()
+
+    notes = GenericKeyValueRelation(Notes)
+    artifacts = models.ManyToManyField(Artifact, through='ContentArtifact')
+
+    class Meta:
+        verbose_name_plural = 'content'
+
+    def natural_key(self):
+        """
+        Get the model's natural key based on natural_key_fields.
+
+        :return: The natural key.
+        :rtype: tuple
+        """
+        return tuple(getattr(self, f.name) for f in self.natural_key_fields)
+
+
+class ContentArtifact(Model):
+    """
+    A relationship between a Content and an Artifact.
+
+    Serves as a through model for the 'artifacts' ManyToManyField in Content.
+    """
+    artifact = models.ForeignKey(Artifact, on_delete=models.CASCADE, null=True)
+    content = models.ForeignKey(Content, on_delete=models.CASCADE)
+    relative_path = models.CharField(max_length=64)
+
+    class Meta:
+        unique_together = ('content', 'relative_path')
+
+
+class DeferredArtifact(Model):
+    """
+    Stores information about an artifact that has not been retrieved yet.
+
+    Importers that want to support deferred download policies should use this model to store
+    information required for downloading an Artifact at some point in the future. At a minimum this
+    includes the URL, the ContentArtifact, and the Importer that created it. It can also store
+    expected size and any expected checksums.
+
+    Fields:
+
+        url (models.TextField): The URL where the artifact can be retrieved.
+        size (models.IntegerField): The expected size of the file in bytes.
+        md5 (models.CharField): The expected MD5 checksum of the file.
+        sha1 (models.CharField): The expected SHA-1 checksum of the file.
+        sha224 (models.CharField): The expected SHA-224 checksum of the file.
+        sha256 (models.CharField): The expected SHA-256 checksum of the file.
+        sha384 (models.CharField): The expected SHA-384 checksum of the file.
+        sha512 (models.CharField): The expected SHA-512 checksum of the file.
+
+    Relations:
+
+        content_artifact (:class:`pulpcore.app.models.GenericKeyValueRelation`): Arbitrary
+            information stored with the content.
+        importer (:class:`django.db.models.ForeignKey`): Importer that created the
+            DeferredArtifact.
+    """
+    url = models.TextField(blank=True, validators=[validators.URLValidator])
+    size = models.IntegerField(blank=True, null=True)
+    md5 = models.CharField(max_length=32, blank=True, null=True)
+    sha1 = models.CharField(max_length=40, blank=True, null=True)
+    sha224 = models.CharField(max_length=56, blank=True, null=True)
+    sha256 = models.CharField(max_length=64, blank=True, null=True)
+    sha384 = models.CharField(max_length=96, blank=True, null=True)
+    sha512 = models.CharField(max_length=128, blank=True, null=True)
+    content_artifact = models.ForeignKey(ContentArtifact, on_delete=models.CASCADE)
+    importer = models.ForeignKey('Importer', on_delete=models.CASCADE)

--- a/platform/pulpcore/app/serializers/content.py
+++ b/platform/pulpcore/app/serializers/content.py
@@ -13,18 +13,16 @@ UNIQUE_ALGORITHMS = ['sha256', 'sha384', 'sha512']
 
 class ContentSerializer(base.MasterModelSerializer):
     _href = base.DetailIdentityField()
-    repositories = fields.RepositoryRelatedField(many=True)
     notes = generic.NotesKeyValueRelatedField()
-    artifacts = serializers.HyperlinkedRelatedField(
-        help_text=_("The associated files."),
-        many=True,
-        read_only=True,
-        view_name='artifacts-detail'
+    artifacts = fields.ContentArtifactsField(
+        help_text=_("A dict mapping relative paths inside the Content to the corresponding"
+                    "Artifact URLs. E.g.: {'relative/path': "
+                    "'http://localhost/full_artifact_path'}"),
     )
 
     class Meta:
         model = models.Content
-        fields = base.MasterModelSerializer.Meta.fields + ('repositories', 'notes', 'artifacts')
+        fields = base.MasterModelSerializer.Meta.fields + ('notes', 'artifacts')
 
 
 class ArtifactSerializer(base.ModelSerializer):
@@ -77,7 +75,8 @@ class ArtifactSerializer(base.ModelSerializer):
         Validate file by size and by all checksums provided.
 
         Args:
-            data (dict): Dictionary mapping Artifact model fields to their values
+            data (:class:`django.http.QueryDict`): QueryDict mapping Artifact model fields to their
+                values
 
         Raises:
             :class:`rest_framework.exceptions.ValidationError`: When the expected file size or any
@@ -91,6 +90,7 @@ class ArtifactSerializer(base.ModelSerializer):
 
         for algorithm in hashlib.algorithms_guaranteed:
             digest = data['file'].hashers[algorithm].hexdigest()
+
             if algorithm in data and digest != data[algorithm]:
                 raise serializers.ValidationError(_("The %s checksum did not match.") % algorithm)
             else:

--- a/platform/pulpcore/app/serializers/fields.py
+++ b/platform/pulpcore/app/serializers/fields.py
@@ -1,4 +1,9 @@
+from gettext import gettext as _
+import os
+
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from rest_framework.reverse import reverse
 
 from pulpcore.app import models
 from pulpcore.app.serializers import DetailRelatedField
@@ -30,3 +35,89 @@ class FileField(serializers.CharField):
 
     def to_representation(self, value):
         return str(value)
+
+
+class ContentArtifactsField(serializers.DictField):
+    """
+    A serializer field for the 'artifacts' ManyToManyField on the Content model.
+    """
+
+    def run_validation(self, data):
+        """
+        Validates 'data' dict.
+
+        Validates that all keys of 'data' are relative paths. Validates that all values of 'data'
+        are URLs for an existing Artifact.
+
+        Args:
+            data (dict): A dict mapping relative paths inside the Content to the corresponding
+                Artifact URLs.
+
+        Returns:
+            A dict mapping relative paths inside the Content to the corresponding Artifact
+                instances.
+
+        Raises:
+            :class:`rest_framework.exceptions.ValidationError`: When one of the Artifacts does not
+                exist or one of the paths is not a relative path.
+        """
+        ret = {}
+        for relative_path, url in data.items():
+            if os.path.isabs(relative_path):
+                raise ValidationError(_("Relative path can't start with '/'. "
+                                        "{0}").format(relative_path))
+            artifactfield = \
+                serializers.HyperlinkedRelatedField(view_name='artifacts-detail',
+                                                    queryset=models.Artifact.objects.all(),
+                                                    source='*', initial=url)
+            artifactfield.context = self.context
+            try:
+                artifact = artifactfield.run_validation(data=url)
+                ret[relative_path] = artifact
+            except ValidationError as e:
+                # Append the URL of missing Artifact to the error message
+                e.detail[0] = "%s %s" % (e.detail[0], url)
+                raise e
+        return ret
+
+    def get_attribute(self, instance):
+        """
+        Returns the field from the instance that should be serialized using this serializer field.
+
+        This serializer field serializes a ManyToManyField that is actually stored as a
+        ContentArtifact model. Instead of returning the field, this method returns all the
+        ContentArtifact models related to this Content.
+
+        Args:
+            instance (:class:`pulpcore.app.models.Content`): An instance of Content being
+                serialized.
+
+        Returns:
+            A list of ContentArtifact models related to the instance of Content.
+        """
+        return instance.contentartifact_set.all()
+
+    def to_representation(self, value):
+        """
+        Serializes list of ContentArtifacts.
+
+        Returns a dict mapping relative paths inside the Content to the corresponding Artifact
+        URLs.
+
+        Args:
+            value (list of :class:`pulpcore.app.models.ContentArtifact`): A list of all the
+                ContentArtifacts related to the Content model being serialized.
+
+        Returns:
+            A dict where keys are relative path of the artifact inside the Content and values are
+                Artifact URLs.
+        """
+        ret = {}
+        for content_artifact in value:
+            if content_artifact.artifact_id:
+                url = reverse('artifacts-detail', kwargs={'pk': content_artifact.artifact_id},
+                              request=self.context['request'])
+            else:
+                url = None
+            ret[content_artifact.relative_path] = url
+        return ret

--- a/platform/pulpcore/app/signals.py
+++ b/platform/pulpcore/app/signals.py
@@ -13,14 +13,13 @@ def artifact_pre_delete(sender, instance, **kwargs):
     """
     Delete artifact bits from a filesystem
 
-    :param sender: The model class
-    :type  sender: pulpcore.app.model.Artifact
-    :param instance: The actual instance being deleted
-    :type instance: pulpcore.app.model.Artifact instance
+    Args:
+        sender (class): The model class
+        instance (:class:`pulpcore.app.model.Artifact`): The actual instance being deleted.
+
     """
     artifact = instance
-    if artifact.downloaded:
-        units_root = os.path.join(settings.MEDIA_ROOT, 'units')
-        artifact_dir = os.path.dirname(artifact.file.path)
-        artifact.file.delete()
-        FileSystem.delete_empty_dirs(artifact_dir, units_root)
+    units_root = os.path.join(settings.MEDIA_ROOT, 'artifact')
+    artifact_dir = os.path.dirname(artifact.file.path)
+    artifact.file.delete()
+    FileSystem.delete_empty_dirs(artifact_dir, units_root)

--- a/platform/pulpcore/app/viewsets/__init__.py
+++ b/platform/pulpcore/app/viewsets/__init__.py
@@ -1,4 +1,5 @@
-from pulpcore.app.viewsets.base import NamedModelViewSet  # noqa
+from pulpcore.app.viewsets.base import (GenericNamedModelViewSet, NamedModelViewSet,  # noqa
+                                        CreateDestroyReadNamedModelViewSet)  # noqa
 from pulpcore.app.viewsets.content import ArtifactViewSet, ContentViewSet  # noqa
 from pulpcore.app.viewsets.repository import (ImporterViewSet, PublisherViewSet,  # noqa
     RepositoryViewSet, RepositoryContentViewSet)  # noqa

--- a/platform/pulpcore/app/viewsets/base.py
+++ b/platform/pulpcore/app/viewsets/base.py
@@ -1,10 +1,10 @@
 import warnings
 
 from pulpcore.app.models import MasterModel
-from rest_framework import viewsets
+from rest_framework import viewsets, mixins
 
 
-class NamedModelViewSet(viewsets.ModelViewSet):
+class GenericNamedModelViewSet(viewsets.GenericViewSet):
     """
     A customized named ModelViewSet that knows how to register itself with the Pulp API router.
 
@@ -131,3 +131,30 @@ class NamedModelViewSet(viewsets.ModelViewSet):
                 filters[lookup] = self.kwargs[key]
             qs = qs.filter(**filters)
         return qs
+
+
+class NamedModelViewSet(mixins.CreateModelMixin,
+                        mixins.RetrieveModelMixin,
+                        mixins.DestroyModelMixin,
+                        mixins.UpdateModelMixin,
+                        mixins.ListModelMixin,
+                        GenericNamedModelViewSet):
+    """
+    A viewset that provides default `create()`, `retrieve()`, `update()`, `partial_update()`,
+    `destroy()` and `list()` actions.
+    """
+    pass
+
+
+class CreateDestroyReadNamedModelViewSet(mixins.CreateModelMixin,
+                                         mixins.RetrieveModelMixin,
+                                         mixins.DestroyModelMixin,
+                                         mixins.ListModelMixin,
+                                         GenericNamedModelViewSet):
+    """
+    A customized NamedModelViewSet for models that don't support updates.
+
+    A viewset that provides default `create()`, `retrieve()`, `destroy()` and `list()` actions.
+
+    """
+    pass

--- a/platform/pulpcore/app/viewsets/content.py
+++ b/platform/pulpcore/app/viewsets/content.py
@@ -1,11 +1,12 @@
+from django.db import transaction
 from django_filters.rest_framework import filterset
 from rest_framework import status
 from rest_framework.response import Response
 
 
-from pulpcore.app.models import Artifact, Content
+from pulpcore.app.models import Artifact, Content, ContentArtifact
 from pulpcore.app.serializers import ArtifactSerializer, ContentSerializer
-from pulpcore.app.viewsets import NamedModelViewSet
+from pulpcore.app.viewsets import CreateDestroyReadNamedModelViewSet
 
 
 class ContentFilter(filterset.FilterSet):
@@ -38,18 +39,43 @@ class ArtifactFilter(filterset.FilterSet):
         fields = ['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512']
 
 
-class ContentViewSet(NamedModelViewSet):
+class ContentViewSet(CreateDestroyReadNamedModelViewSet):
     endpoint_name = 'content'
     queryset = Content.objects.all()
     serializer_class = ContentSerializer
     filter_class = ContentFilter
 
+    @transaction.atomic
+    def create(self, request):
+        """
+        Create a new Content instance from a JSON payload in the request.
 
-class ArtifactViewSet(NamedModelViewSet):
+        Args:
+            request (:class:`rest_framework.request.Request`): request containing JSON payload with
+                information about the content being created.
+
+        Returns:
+            :class:`rest_framework.response.Response` with a 201 status code.
+
+        Raises:
+            :class:`rest_framework.exceptions.ValidationError` when artifact URLs are not valid or
+                the relative paths start with a '/'.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        artifacts = serializer.validated_data.pop('artifacts')
+        content = serializer.save()
+
+        for relative_path, artifact in artifacts.items():
+            ca = ContentArtifact(artifact=artifact, content=content, relative_path=relative_path)
+            ca.save()
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+
+class ArtifactViewSet(CreateDestroyReadNamedModelViewSet):
     endpoint_name = 'artifacts'
     queryset = Artifact.objects.all()
     serializer_class = ArtifactSerializer
     filter_class = ArtifactFilter
-
-    def update(self, request, pk):
-        return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/plugin/pulpcore/plugin/models/__init__.py
+++ b/plugin/pulpcore/plugin/models/__init__.py
@@ -2,8 +2,8 @@
 # Any models defined in the pulpcore.plugin namespace should probably be proxy models.
 
 from pulpcore.app.models import (  # NOQA
-    Artifact, Content, DownloadCatalog, ProgressBar, ProgressSpinner, Repository,
-    RepositoryContent)
+    Artifact, Content, ContentArtifact, DeferredArtifact, DownloadCatalog, ProgressBar,
+    ProgressSpinner, Repository, RepositoryContent)
 
 
 from .publisher import Publisher  # noqa


### PR DESCRIPTION
Solution: Add viewset and serializers to serve Content creation API

This change also introduces a DeferredArtifact that will be used by importers that
want to support deferred download policies.

closes #2872
https://pulp.plan.io/issues/2872