### PR TITLE
Support calculating all artifact digests during download.

### DIFF
--- a/platform/pulpcore/download/__init__.py
+++ b/platform/pulpcore/download/__init__.py
@@ -67,5 +67,6 @@ from .file import FileDownload  # noqa
 from .http import HttpDownload  # noqa
 from .settings import Settings, SSL, Timeout, User  # noqa
 from .single import Download  # noqa
+from .tools import MetricsCollector  # noqa
 from .validation import ValidationError, SizeValidation, DigestValidation  # noqa
 from .writer import Writer, FileWriter, BufferWriter  # noqa

--- a/platform/pulpcore/download/tools.py
+++ b/platform/pulpcore/download/tools.py
@@ -1,0 +1,87 @@
+"""
+Download tools.
+"""
+from .event import Fetched
+from .validation import DigestValidation
+
+
+class MetricsCollector:
+    """
+    Download metrics collector.
+
+    The set of metrics collected include:
+     - Total number of bytes downloaded.
+     - Standard set of file digests.
+
+    Attributes:
+        algorithms (dict): Dictionary of validations keyed by algorithm.
+            Used only to leverage digest calculation.
+        size (int): The total file size in bytes.
+
+    Examples:
+        >>> download = ...
+        >>> metrics = MetricsCollector(download)
+        >>> download()
+        >>> metrics.dict()
+            {'size': 1109, 'sha1': aFc12, 'sha256': '837e9ab1', ...}
+    """
+
+    __slots__ = (
+        'algorithms',
+        'size'
+    )
+
+    def __init__(self, download=None):
+        """
+        Args:
+            download (pulpcore.download.Download): An (optional) download object
+                for which metrics are collected.
+        """
+        self.algorithms = {
+            n: DigestValidation.find_algorithm(n) for n in DigestValidation.ALGORITHMS
+        }
+        self.size = 0
+        if download:
+            self.attach(download)
+
+    def attach(self, download):
+        """
+        Args:
+            download (pulpcore.download.Download): A download object
+                for which metrics are collected.
+        """
+        download.register(Fetched.NAME, self.fetched)
+
+    def dict(self):
+        """
+        Get a dictionary representation of the collected metrics.
+
+        Returns:
+            dict: Collected metrics.
+        """
+        metrics = {n: a.hexdigest() for n, a in self.algorithms.items()}
+        metrics['size'] = self.size
+        return metrics
+
+    def update(self, buffer):
+        """
+        Update metrics using the fetched buffer.
+
+        Args:
+            buffer (bytes): A buffer of downloaded data.
+        """
+        self.size += len(buffer)
+        for algorithm in self.algorithms.values():
+            algorithm.update(buffer)
+
+    def fetched(self, event):
+        """
+        The FETCHED event handler.
+
+        Args:
+            event (pulpcore.download.Fetched): A buffer fetched event.
+        """
+        self.update(event.buffer)
+
+    def __str__(self):
+        return str(self.dict())

--- a/platform/pulpcore/download/validation.py
+++ b/platform/pulpcore/download/validation.py
@@ -209,7 +209,7 @@ class DigestValidation(Validation):
     )
 
     @staticmethod
-    def _find_algorithm(name):
+    def find_algorithm(name):
         """
         Find the hash algorithm by name in hashlib.
 
@@ -238,7 +238,7 @@ class DigestValidation(Validation):
             ValueError: When `algorithm` not supported by hashlib.
         """
         super(DigestValidation, self).__init__(enforced)
-        self.algorithm = self._find_algorithm(algorithm)
+        self.algorithm = self.find_algorithm(algorithm)
         self.expected = digest
         self.actual = None
 


### PR DESCRIPTION
Was thinking we could use something that could be shared by the artifact upload, changeset and plugin writers (not using changeset).  Basically anything creating artifacts.

This is the intended way to _hook_ into download processing.  Anything using a `Download` directly can simply register this event handler and then use the digest dictionary to set the digest fields on an Artifact.  This can also be used by the _upload_ code as well by calling `DigestHandler.update()` directly. 