### PR TITLE
Start using pip to install pulp in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,17 @@ services:
 install:
     # dev_requirements should not be needed for testing; don't install them to make sure
     - "pip install -r test_requirements.txt"
-    - "pushd common/ && python setup.py develop && popd"
-    - "pushd platform/ && python setup.py develop && popd"
-    - "pushd plugin/ && python setup.py develop && popd"
+    # add secret key to django settings.py
+    - echo "SECRET_KEY = '$(cat /dev/urandom | tr -dc 'a-z0-9!@#$%^&*(\-_=+)' | head -c 50)'" >> platform/pulpcore/app/settings.py
+    - "pushd common/ && pip install -e . && popd"
+    - "pushd platform/ && pip install -e . && popd"
+    - "pushd plugin/ && pip install -e .  && popd"
 before_script:
     - psql -U postgres -c "CREATE USER pulp WITH SUPERUSER LOGIN;"
     - psql -U postgres -c "CREATE DATABASE pulp OWNER pulp;"
 script:
     # flake8
     - "flake8 --config flake8.cfg"
-    # add secret key to django settings.py
-    - echo "SECRET_KEY= '$(cat /dev/urandom | tr -dc 'a-z0-9!@#$%^&*(\-_=+)' | head -c 50)'" >> platform/pulpcore/app/settings.py
     # tests can't run without migrations being made
     - "python manage.py makemigrations pulp_app"
     # chain these so we don't try to run tests if the db reset fails


### PR DESCRIPTION
Due to the fact that using setup.py for installation is no longer
suggested practice in the python community. We start using
`pip install -e .` instead of `python setup.py develop`.