### PR TITLE
Turn on task_reject_on_worker_lost to prevent lost tasks

### DIFF
--- a/platform/pulpcore/tasking/celery_instance.py
+++ b/platform/pulpcore/tasking/celery_instance.py
@@ -22,6 +22,7 @@ celery.conf.update(CELERYBEAT_SCHEDULER='pulpcore.server.async.scheduler.Schedul
 celery.conf.update(CELERY_WORKER_DIRECT=True)
 celery.conf.update(CELERY_TASK_SERIALIZER='json')
 celery.conf.update(CELERY_ACCEPT_CONTENT=['json'])
+celery.conf.update(CELERY_REJECT_ON_WORKER_LOST=True)
 
 
 def configure_login_method():


### PR DESCRIPTION
Turn on task_reject_on_worker_lost (aka CELERY_REJECT_ON_WORKER_LOST) to prevent the loss of tasks when a worker dies.

fixes #2958
https://pulp.plan.io/issues/2958