### PR TITLE
Update changeset for change in content/artifact models.

### DIFF
--- a/docs/plugins/plugin-api/changeset.rst
+++ b/docs/plugins/plugin-api/changeset.rst
@@ -16,10 +16,10 @@ New Content & Artifacts
 Classes used to define *new* content to be added to a repository.
 
 
-.. autoclass:: pulpcore.plugin.changeset.RemoteContent
+.. autoclass:: pulpcore.plugin.changeset.PendingContent
     :members: artifacts
 
-.. autoclass:: pulpcore.plugin.changeset.RemoteArtifact
+.. autoclass:: pulpcore.plugin.changeset.PendingArtifact
     :members: content
 
 

--- a/platform/pulpcore/download/validation.py
+++ b/platform/pulpcore/download/validation.py
@@ -208,25 +208,6 @@ class DigestValidation(Validation):
         'md5',
     )
 
-    @staticmethod
-    def _find_algorithm(name):
-        """
-        Find the hash algorithm by name in hashlib.
-
-        Args:
-            name: The algorithm name.
-
-        Returns:
-            hashlib.Algorithm: The algorithm object.
-
-        Raises:
-            ValueError: When not found.
-        """
-        try:
-            return getattr(hashlib, name.lower())()
-        except AttributeError:
-            raise ValueError(_('Algorithm {n} not supported').format(n=name))
-
     def __init__(self, algorithm, digest, enforced=True):
         """
         Args:
@@ -238,7 +219,7 @@ class DigestValidation(Validation):
             ValueError: When `algorithm` not supported by hashlib.
         """
         super(DigestValidation, self).__init__(enforced)
-        self.algorithm = self._find_algorithm(algorithm)
+        self.algorithm = hashlib.new(algorithm)
         self.expected = digest
         self.actual = None
 
@@ -268,7 +249,8 @@ class DigestValidation(Validation):
             log.warn(str(error))
 
     def __str__(self):
-        return _(
-            'DigestValidation: alg={al} expected={e} actual={a}').format(al=self.algorithm,
-                                                                         e=self.expected,
-                                                                         a=self.actual)
+        description = _('DigestValidation: alg={al} expected={e} actual={a}')
+        return description.format(
+            al=self.algorithm,
+            e=self.expected,
+            a=self.actual)

--- a/plugin/pulpcore/plugin/changeset/model.py
+++ b/plugin/pulpcore/plugin/changeset/model.py
@@ -1,51 +1,77 @@
 from gettext import gettext as _
 from logging import getLogger
 
+from django.db.models import Q
 from django.db.utils import IntegrityError
 from django.db import transaction
 from django.core.files import File
+
+from pulpcore.app.models import Artifact, ContentArtifact, DeferredArtifact
+from pulpcore.download import Event
+from pulpcore.plugin.download.monitor import DownloadMonitor
 
 
 log = getLogger(__name__)
 
 
-class Remote:
+class Pending:
     """
     Represents content related things contained within the remote repository.
 
     Attributes:
-        model (Model): A remote (wanted) model instance.
+        model (Model): A pending (wanted) model instance.
         settled (bool): All matters are settled and the object is ready
             to be (optionally created) and added to the repository.
+        fetched (bool): model has been fetched from the DB.
     """
 
     __slots__ = (
         'model',
-        'settled'
+        'settled',
+        'fetched',
     )
 
     def __init__(self, model):
         """
         Args:
-            model (Model): A remote (wanted) model instance.
+            model (Model): A pending (wanted) model instance.
         """
         self.model = model
         self.settled = False
+        self.fetched = False
+
+    def settle(self):
+        """
+        Ensures that all prerequisite matters have been settled and the
+        pending object can be created in Pulp.
+        """
+        raise NotImplementedError()
+
+    def update(self, model):
+        """
+        Update with a fetched model instance.
+        Args:
+            model (pulpcore.app.models.Model): The fetched model.
+        """
+        self.model = model
+        self.fetched = True
 
     def save(self):
         """
-        Save the model.
+        Save to the DB.
         """
-        self.model.save()
+        raise NotImplementedError()
 
 
-class RemoteContent(Remote):
+class PendingContent(Pending):
     """
     Represents content that is contained within the remote repository.
 
     Attributes:
         model (pulpcore.plugin.Content): A content model instance.
-        artifacts (set): The set of related `RemoteArtifact`.
+        changeset (pulpcore.plugin.ChangeSet): A changeset.
+            Set by the ContentIterator.
+        artifacts (set): The set of related `PendingArtifact`.
 
     Examples:
         >>>
@@ -56,20 +82,25 @@ class RemoteContent(Remote):
         >>>    ...
         >>> thing = Thing()  # DB model instance.
         >>> ...
-        >>> content = RemoteContent(thing)
+        >>> content = PendingContent(thing)
         >>>
     """
 
-    __slots__ = ('artifacts',)
+    __slots__ = (
+        'changeset',
+        'artifacts',
+    )
 
-    def __init__(self, model):
+    def __init__(self, model, artifacts=()):
         """
         Args:
             model (pulpcore.plugin.models.Content): A content model instance.
                 This instance will be used to store newly created content in the DB.
+            artifacts (iterable): A set of PendingArtifact.
         """
-        super(RemoteContent, self).__init__(model)
-        self.artifacts = set()
+        super().__init__(model)
+        self.artifacts = set(artifacts)
+        self.changeset = None
 
     @property
     def key(self):
@@ -81,6 +112,20 @@ class RemoteContent(Remote):
         """
         return {f.name: getattr(self.model, f.name) for f in self.model.natural_key_fields}
 
+    def bind(self, changeset):
+        """
+        Bind to a changeset.
+        Creates an association to a changeset being applied.
+
+        Args:
+            changeset (pulpcore.plugin.changeset.ChangeSet): A changeset.
+
+        Returns:
+            PendingContent: self to support comprehensions.
+        """
+        self.changeset = changeset
+        return self
+
     def update(self, model):
         """
         Update this `model` stored with the specified model that has been
@@ -90,14 +135,16 @@ class RemoteContent(Remote):
         Args:
             model (pulpcore.plugin.Content): A fetched content model object.
         """
-        self.model = model
-        known = {a.model.relative_path: a for a in self.artifacts}
+        super().update(model)
+        artifacts = {a.relative_path: a for a in self.artifacts}
         self.artifacts.clear()
-        for artifact in model.artifacts.all():
+        for content_artifact in model.contentartifact_set.all():
             try:
-                found = known[artifact.relative_path]
-                found.model = artifact
-                self.artifacts.add(found)
+                matched = artifacts[content_artifact.relative_path]
+                if not matched.model.is_equal(content_artifact.artifact):
+                    continue
+                matched.update(content_artifact.artifact)
+                self.artifacts.add(matched)
             except KeyError:
                 log.error(_('Artifact not matched.'))
 
@@ -124,32 +171,31 @@ class RemoteContent(Remote):
         Due to race conditions, the content may already exist raising an IntegrityError.
         When this happens, the model is fetched and replaced.
         """
-        is_duplicate = False
         with transaction.atomic():
             try:
-                super(RemoteContent, self).save()
+                with transaction.atomic():
+                    self.model.save()
             except IntegrityError:
-                is_duplicate = True
-            else:
-                for artifact in self.artifacts:
-                    artifact.model.content = self.model
-                    artifact.save()
-        if is_duplicate:
-            model = type(self.model)
-            content = model.objects.get(**self.key)
-            self.update(content)
+                content = type(self.model).objects.get(**self.key)
+                self.update(content)
+
+            for artifact in self.artifacts:
+                artifact.save()
 
 
-class RemoteArtifact(Remote):
+class PendingArtifact(Pending):
     """
     Represents an artifact related to content that is contained within
     the remote repository.
 
     Attributes:
-        download (pulpcore.download.Download): An object used to download the content.
-        content (RemoteContent): The associated remote content.
-        path (str): Absolute path to the downloaded file.  May be (None) when
-            downloading is deferred or the artifact has already been downloaded.
+        url (str): The URL used to download the artifact.
+        relative_path (str): The relative path within the content.
+        content (PendingContent): The associated pending content.
+            This is the reverse relationship.
+        monitor (pulpcore.plugin.DownloadMonitor): Used to collect information about
+            downloaded artifacts.
+        _path (str): An absolute path to a downloaded artifact.
 
     Examples:
         >>>
@@ -158,30 +204,81 @@ class RemoteArtifact(Remote):
         >>> model = Artifact(...)  # DB model instance.
         >>> download = ...
         >>> ...
-        >>> artifact = RemoteArtifact(model, download)
+        >>> artifact = PendingArtifact(model, 'http://zoo.org/lion.rpm', 'lion.rpm')
         >>>
     """
 
     __slots__ = (
+        'url',
+        'relative_path',
+        'monitor',
         'content',
-        'download',
-        'path'
+        '_path',
     )
 
-    def __init__(self, model, download):
+    def __init__(self, model, url, relative_path):
         """
-
         Args:
-            model (pulpcore.plugin.models.Artifact): An artifact model instance.
+            model (pulpcore.plugin.models.Artifact): A pending artifact model instance.
                 This instance will be used to store a newly created or updated
-                artifact in the DB.
-            download (pulpcore.download.Download): A An object used to download the content.
+                pending artifact in the DB.
+            url (str): The URL used to download the artifact.
+            relative_path (str): The relative path within the content.
         """
-        super(RemoteArtifact, self).__init__(model)
-        self.download = download
-        self.download.attachment = self
-        self.path = download.writer.path
+        super().__init__(model)
+        self.url = url
+        self.relative_path = relative_path
+        self.monitor = None
         self.content = None
+        self._path = ''
+
+    @property
+    def changeset(self):
+        """
+        Returns:
+            pulpcore.plugin.changeset.Changeset: The active changeset.
+        """
+        return self.content.changeset
+
+    @property
+    def importer(self):
+        """
+        Returns:
+            pulpcore.plugin.models.Importer: An importer.
+        """
+        return self.changeset.importer
+
+    def downloader(self):
+        """
+        Get a downloader.
+
+        Returns:
+            pulpcore.download.Download: A downloader.
+        """
+        def succeeded(event):
+            self._path = event.download.writer.path
+        download = self.importer.get_download(
+            self.url,
+            self.relative_path,
+            self.model)
+        download.attachment = self
+        download.register(Event.SUCCEEDED, succeeded)
+        self.monitor = DownloadMonitor(download)
+        return download
+
+    def artifact_q(self):
+        """
+        Get a query for the actual artifact.
+
+        Returns:
+            django.db.models.Q: A query to get the actual artifact.
+        """
+        q = Q()
+        for field in Artifact.RELIABLE_DIGEST_FIELDS:
+            digest = getattr(self.model, field)
+            if digest:
+                q |= Q(**{field: digest})
+        return q
 
     def settle(self):
         """
@@ -198,10 +295,58 @@ class RemoteArtifact(Remote):
         Update the DB model to store the downloaded file.
         Then, save in the DB.
         """
-        if self.path:
-            self.model.file = File(open(self.path, mode='rb'))
-            self.model.downloaded = True
-        super(RemoteArtifact, self).save()
+        artifact = None
+
+        if not self.fetched:
+            if self._path:  # downloaded
+                try:
+                    with transaction.atomic():
+                        self.model = Artifact(
+                            file=File(open(self._path, mode='rb')),
+                            **self.monitor.dict())
+                        self.model.save()
+                except IntegrityError:
+                    q = self.artifact_q()
+                    self.model = Artifact.objects.get(q)
+                finally:
+                    artifact = self.model
+        else:
+            artifact = self.model
+
+        try:
+            with transaction.atomic():
+                content_artifact = ContentArtifact(
+                    relative_path=self.relative_path,
+                    content=self.content.model,
+                    artifact=artifact)
+                content_artifact.save()
+        except IntegrityError:
+            content_artifact = ContentArtifact.objects.get(
+                relative_path=self.relative_path,
+                content=self.content.model)
+            if self.fetched:
+                content_artifact.artifact = artifact
+                content_artifact.save()
+
+        digests = {f: getattr(self.model, f) for f in Artifact.DIGEST_FIELDS}
+
+        try:
+            with transaction.atomic():
+                deferred_artifact = DeferredArtifact(
+                    url=self.url,
+                    importer=self.importer,
+                    content_artifact=content_artifact,
+                    size=self.model.size,
+                    **digests)
+                deferred_artifact.save()
+        except IntegrityError:
+            q_set = DeferredArtifact.objects.filter(
+                importer=self.importer,
+                content_artifact=content_artifact)
+            q_set.update(
+                url=self.url,
+                size=self.model.size,
+                **digests)
 
     def __hash__(self):
-        return hash(self.model.id)
+        return hash(self.relative_path)

--- a/plugin/pulpcore/plugin/download/__init__.py
+++ b/plugin/pulpcore/plugin/download/__init__.py
@@ -57,3 +57,5 @@ from pulpcore.download import (  # noqa: F401
     ValidationError)
 
 from .factory import Factory  # noqa: F401
+
+from .monitor import DownloadMonitor  # noqa: F401

--- a/plugin/pulpcore/plugin/download/monitor.py
+++ b/plugin/pulpcore/plugin/download/monitor.py
@@ -1,0 +1,84 @@
+import hashlib
+
+from pulpcore.app.models import Artifact
+from pulpcore.download import Event
+
+
+class DownloadMonitor:
+    """
+    Monitor a download and collect information:
+     - Total number of bytes downloaded.
+     - Standard set of file digests.
+
+    Attributes:
+        algorithms (dict): Dictionary of validations keyed by algorithm.
+            Used only to leverage digest calculation.
+        size (int): The total bytes downloaded.  When the download
+            has completed successfully, this is the total size of the
+            file in bytes.
+
+    Examples:
+        >>> download = ...
+        >>> monitor = DownloadMonitor(download)
+        >>> download()
+        >>> monitor.dict()
+            {'size': 1109, 'sha1': 'aFc12', 'sha256': '837e9ab1', ...}
+    """
+
+    __slots__ = (
+        'algorithms',
+        'size'
+    )
+
+    def __init__(self, download=None):
+        """
+        Args:
+            download (pulpcore.download.Download): An (optional) download object
+                for which metrics are collected.
+        """
+        self.algorithms = {n: hashlib.new(n) for n in Artifact.DIGEST_FIELDS}
+        self.size = 0
+        if download:
+            self.attach(download)
+
+    def attach(self, download):
+        """
+        Args:
+            download (pulpcore.download.Download): A download object
+                for which metrics are collected.
+        """
+        download.register(Event.FETCHED, self.fetched)
+
+    def dict(self):
+        """
+        Get a dictionary representation of the collected information.
+
+        Returns:
+            dict: Collected metrics.
+        """
+        metrics = {n: a.hexdigest() for n, a in self.algorithms.items()}
+        metrics['size'] = self.size
+        return metrics
+
+    def update(self, buffer):
+        """
+        Update metrics using the fetched buffer.
+
+        Args:
+            buffer (bytes): A buffer of downloaded data.
+        """
+        self.size += len(buffer)
+        for algorithm in self.algorithms.values():
+            algorithm.update(buffer)
+
+    def fetched(self, event):
+        """
+        The FETCHED event handler.
+
+        Args:
+            event (pulpcore.download.Fetched): A buffer fetched event.
+        """
+        self.update(event.buffer)
+
+    def __str__(self):
+        return str(self.dict())


### PR DESCRIPTION
https://pulp.plan.io/issues/2942

File plugin counterpart: https://github.com/pulp/pulp_file/pull/9

Update the _changeset_ package to align with changes to the content/artifact model.

With `Artifact` being shared, the changeset needed to find and reuse artifacts much like it does for de-duplicating content.  It also needs to manage the `ContentArtifact`.  This effort revealed a few opportunities for better division of responsibilities.  But, the changeset paradigm remains the same.  A plugin writer will only need to deal with `Content` and `Artifact` DB models.

 This effort also revealed opportunities for minor improvements in API clarity.  It's possible that the `DeferredArtifact` DB model could be renamed to something like `RemoteArtifact` which would be confusing to plugin writers.  With this in mind, I decided to try a change to the idiom in the _changeset_ API from _Remote_ to _Pending_ for classes plugin writers use to express _additions_.  After working with the changeset for a while, _pending_ seems more appropriate and should be less likely to conflict with django models exposed in the plugin API.