### PR TITLE
Align importer models and serializers with MVP

### DIFF
--- a/platform/pulpcore/app/serializers/repository.py
+++ b/platform/pulpcore/app/serializers/repository.py
@@ -74,28 +74,30 @@ class ImporterSerializer(MasterModelSerializer, NestedHyperlinkedModelSerializer
     _href = DetailNestedHyperlinkedIdentityField(
         lookup_field='name', parent_lookup_kwargs={'repository_name': 'repository__name'},
     )
-
     name = serializers.CharField(
         help_text=_('A name for this importer, unique within the associated repository.')
     )
-    last_updated = serializers.DateTimeField(
-        help_text='Timestamp of the most recent update of this configuration.',
-        read_only=True
-    )
-
     feed_url = serializers.CharField(
         help_text='The URL of an external content source.',
         required=False,
     )
-
+    download_policy = serializers.ChoiceField(
+        help_text='The policy for downloading content.',
+        allow_blank=False,
+        choices=models.Importer.DOWNLOAD_POLICIES,
+    )
+    sync_mode = serializers.ChoiceField(
+        help_text='How the importer should sync from the upstream repository.',
+        allow_blank=False,
+        choices=models.Importer.SYNC_MODES,
+    )
     validate = serializers.BooleanField(
-        help_text='Whether to validate imported content.',
+        help_text='If True, the plugin will validate imported artifacts.',
         required=False,
     )
-
     ssl_ca_certificate = FileField(
         help_text='A PEM encoded CA certificate used to validate the server '
-                  'certificate presented by the external source.',
+                  'certificate presented by the remote server.',
         write_only=True,
         required=False,
     )
@@ -110,30 +112,29 @@ class ImporterSerializer(MasterModelSerializer, NestedHyperlinkedModelSerializer
         required=False,
     )
     ssl_validation = serializers.BooleanField(
-        help_text='Indicates whether SSL peer validation must be performed.',
+        help_text='If True, SSL peer validation must be performed.',
         required=False,
     )
     proxy_url = serializers.CharField(
-        help_text='The optional proxy URL. Format: scheme://user:password@host:port',
+        help_text='The proxy URL. Format: scheme://user:password@host:port',
         required=False,
     )
-    basic_auth_user = serializers.CharField(
-        help_text='The username to be used in HTTP basic authentication when syncing.',
+    username = serializers.CharField(
+        help_text='The username to be used for authentication when syncing.',
         write_only=True,
         required=False,
     )
-    basic_auth_password = serializers.CharField(
-        help_text='The password to be used in HTTP basic authentication when syncing.',
+    password = serializers.CharField(
+        help_text='The password to be used for authentication when syncing.',
         write_only=True,
         required=False,
     )
-    download_policy = serializers.ChoiceField(
-        help_text='The policy for downloading content.',
-        allow_blank=False,
-        choices=models.Importer.DOWNLOAD_POLICIES,
-    )
-    last_sync = serializers.DateTimeField(
+    last_synced = serializers.DateTimeField(
         help_text='Timestamp of the most recent successful sync.',
+        read_only=True
+    )
+    last_updated = serializers.DateTimeField(
+        help_text='Timestamp of the most recent update of the importer.',
         read_only=True
     )
 
@@ -143,9 +144,9 @@ class ImporterSerializer(MasterModelSerializer, NestedHyperlinkedModelSerializer
         abstract = True
         model = models.Importer
         fields = MasterModelSerializer.Meta.fields + (
-            'name', 'last_updated', 'feed_url', 'validate', 'ssl_ca_certificate',
+            'name', 'feed_url', 'download_policy', 'sync_mode', 'validate', 'ssl_ca_certificate',
             'ssl_client_certificate', 'ssl_client_key', 'ssl_validation', 'proxy_url',
-            'basic_auth_user', 'basic_auth_password', 'download_policy', 'last_sync', 'repository',
+            'username', 'password', 'last_synced', 'last_updated', 'repository',
         )
 
 

--- a/plugin/pulpcore/plugin/download/futures/factory.py
+++ b/plugin/pulpcore/plugin/download/futures/factory.py
@@ -84,8 +84,8 @@ class Factory:
             HttpDownload: An http download.
         """
         download = HttpDownload(url, FileWriter(path))
-        download.user.name = self.importer.basic_auth_user
-        download.user.password = self.importer.basic_auth_password
+        download.user.name = self.importer.username
+        download.user.password = self.importer.password
         self._add_validation(download, artifact)
         return download
 
@@ -106,8 +106,8 @@ class Factory:
         download.ssl.client_certificate = self.importer.ssl_client_certificate.name
         download.ssl.client_key = self.importer.ssl_client_key.name
         download.ssl.validation = self.importer.ssl_validation
-        download.user.name = self.importer.basic_auth_user
-        download.user.password = self.importer.basic_auth_password
+        download.user.name = self.importer.username
+        download.user.password = self.importer.password
         download.proxy_url = self.importer.proxy_url
         self._add_validation(download, artifact)
         return download


### PR DESCRIPTION
closes #2818
re #2817
closes #2816

This commit aligns the Importer model and serializer with the MVP
document for Pulp 3. The model docstrings are redundant with the
serializer help_text. The help_text will eventually become the
documentation, so removing using it exclusively will be the best way to
keep the code, comments, and documentation up to date.