### PR TITLE
Introducing asyncio downloaders

### DIFF
--- a/docs/plugins/plugin-api/asyncio.rst
+++ b/docs/plugins/plugin-api/asyncio.rst
@@ -1,0 +1,154 @@
+.. _asyncio-docs:
+
+pulpcore.plugin.download.asyncio
+================================
+
+The module implements downloaders that solve many of the common problems plugin writers have while
+downloading remote data. A high level list of features provided by these downloaders include:
+
+* auto-configuration from importer settings (auth, ssl, proxy)
+* efficient parallel downloading
+* digest and size validation computed during download
+* grouping downloads together to return to the user when all files are downloaded
+* customizable download behaviors via subclassing
+
+All classes documented here should be imported directly from the
+``pulpcore.plugin.download.asyncio`` namespace.
+
+
+Overview
+--------
+
+For basic synchronous or parallel downloading of files, the easiest usage is using the
+:ref:`DownloaderFactory <downloader-factory>` and scheduling those downloads with asyncio.
+
+For parallel downloading where multiple files need to be downloaded before a content unit can be
+saved, use the :ref:`GroupDownloader <group-downloader>`. The GroupDownloader manages the asyncio
+loop for you, which some users may prefer even for basic usage.
+
+.. _downloader-factory:
+
+Basic Downloading
+-----------------
+
+The DownloaderFactory constructs a downloader for any given url. It contains built-in support for
+`http://`, `https://` and `file://`. It creates :ref:`HttpDownloader <http-downloader>` objects for
+`http` and `https` and :ref:`FileDownloader <file-downloader>` objects for `file`. All downloaders
+are auto-configured from the core settings saved on an importer.
+
+All downloaders can be run in parallel using asyncio. Each downloader has a `run()` method which
+returns a coroutine object that asyncio can run.
+
+:ref:`HttpDownloader <http-downloader>` objects produced by an instantiated DownloaderFactory share
+a session, which contains a connection pool inside, connection reusage and keep-alives.
+
+Size and/or digest based validation can be configured using arguments provided to the
+:func:`~pulpcore.plugin.download.asyncio.DownloaderFactory.build`. method.
+
+.. autoclass:: pulpcore.plugin.download.asyncio.DownloaderFactory
+    :members:
+
+.. _download-result:
+
+Download Results
+----------------
+
+The download result contains all the information about a completed download and is returned from a
+the downloader's `run()` method when the download is complete.
+
+.. autoclass:: pulpcore.plugin.download.asyncio.DownloadResult
+    :no-members:
+
+.. _group-downloader:
+
+Downloading Groups of Files
+---------------------------
+
+Motivation
+##########
+
+A content unit that requires multiple files to be all downloaded before the content unit can be
+saved is a common problem. Consider a content unit foo, that requires three files, A, B, and C. One
+option is to use the :ref:`DownloaderFactory <downloader-factory>` to generate a downloader for each URL
+(A, B, C) and wait for those downloads to complete and then save the content unit foo and its
+associated Artifacts. The issue with this approach is that you also want to download other content
+units, e.g. a unit named bar with files (D, E, and F) and while waiting on A, B, and C you are not
+also downloading D, E, and F in parallel.
+
+GroupDownloader Overview
+########################
+
+The GroupDownloader allows you to schedule a :class:`~pulpcore.plugin.download.asyncio.Group`
+of downloads in a way that results are returned when the entire Group is ready instead of
+download-by-download. This is significant because multiple downloads from multiple groups still run
+in parallel. See the examples below.
+
+.. autoclass:: pulpcore.plugin.download.asyncio.GroupDownloader
+    :members:
+
+.. autoclass:: pulpcore.plugin.download.asyncio.Group
+    :members:
+
+.. _exception-handling:
+
+Exception Handling
+------------------
+
+All downloaders are expected to handle recoverable errors automatically. When an unrecoverable error
+occurs it can be one of two types of errors, i.e. one of the
+:ref:`validation exceptions <validation-exceptions>`, or a protocol specific error. A validation
+error example would be if a download size is expected to be 1945 bytes but it is actually 1990
+bytes, a :class:`~pulpcore.plugin.download.asyncio.SizeValidationError` would be raised. An example
+of a protocol specific error would be an HTTP 403 response.
+
+In both cases these are fatal exceptions and should likely be recorded with the
+:meth:`~pulpcore.plugin.tasking.Task.append_non_fatal_error` interface. A fatal exception on a single
+download likely does not cause an entire sync to fail, so a downloader's fatal exception is recorded
+as a non-fatal exception on the task. Plugin writers can also opt to halt the entire task by
+allowing the exception be uncaught and propogate up.
+
+.. _http-downloader:
+
+HttpDownloader
+--------------
+
+This downloader is an asyncio-aware parallel downloader which is the default downloader produced by
+the :ref:`downloader-factory` and the :ref:`group-downloader` For urls starting with `http://` or
+`https://`.
+
+.. autoclass:: pulpcore.plugin.download.asyncio.HttpDownloader
+    :members:
+
+.. _file-downloader:
+
+FileDownloader
+--------------
+
+This downloader is an asyncio-aware parallel file reader which is the default downloader produced by
+the :ref:`downloader-factory` and the :ref:`group-downloader` for urls starting with file://
+
+.. autoclass:: pulpcore.plugin.download.asyncio.FileDownloader
+    :members:
+
+.. _base-downloader:
+
+BaseDownloader
+--------------
+
+This is an abstract downloader that is meant for subclassing. All downloaders are expected to be
+descendants of BaseDownloader.
+
+.. autoclass:: pulpcore.plugin.download.asyncio.BaseDownloader
+    :members:
+
+.. autoclass:: pulpcore.plugin.download.asyncio.attach_url_to_exception
+    :members:
+
+.. _validation-exceptions:
+
+Validation Exceptions
+---------------------
+
+.. autoclass:: pulpcore.plugin.download.asyncio.DigestValidationError
+.. autoclass:: pulpcore.plugin.download.asyncio.SizeValidationError
+.. autoclass:: pulpcore.plugin.download.asyncio.DownloaderValidationError

--- a/docs/plugins/plugin-api/index.rst
+++ b/docs/plugins/plugin-api/index.rst
@@ -12,6 +12,7 @@ Plugin API reaches stability with v1.0. For the latest version of the Plugin API
     serializers
     viewsets
     changeset
+    asyncio
     futures
 
 .. automodule:: pulpcore.plugin

--- a/platform/pulpcore/tasking/tasks.py
+++ b/platform/pulpcore/tasking/tasks.py
@@ -305,6 +305,8 @@ class UserFacingTask(PulpTask):
             einfo: celery's ExceptionInfo instance, containing serialized traceback.
         """
         _logger.error(_('Task failed : [%s]') % task_id)
+        if isinstance(exc, PulpException):
+            _logger.exception(exc)
 
         if not self.request.called_directly:
             task_status = TaskStatus.objects.get(pk=task_id)

--- a/plugin/pulpcore/plugin/download/asyncio/__init__.py
+++ b/plugin/pulpcore/plugin/download/asyncio/__init__.py
@@ -1,0 +1,7 @@
+from .base import attach_url_to_exception, BaseDownloader, DownloadResult  # noqa
+from .exceptions import (DigestValidationError, DownloaderValidationError,  # noqa
+                         SizeValidationError)  # noqa
+from .factory import DownloaderFactory  # noqa
+from .file import FileDownloader  # noqa
+from .http import HttpDownloader  # noqa
+from .group import Group, GroupDownloader  # noqa

--- a/plugin/pulpcore/plugin/download/asyncio/base.py
+++ b/plugin/pulpcore/plugin/download/asyncio/base.py
@@ -1,0 +1,203 @@
+from collections import namedtuple
+import hashlib
+import os
+import tempfile
+
+from pulpcore.app.models import Artifact
+from .exceptions import DigestValidationError, SizeValidationError
+
+
+DownloadResult = namedtuple('DownloadResult', ['url', 'artifact_attributes', 'path', 'exception'])
+"""
+Args:
+    url (str): The url corresponding with the download.
+    path (str): The absolute path to the saved file
+    artifact_attributes (dict): Contains keys corresponding with
+        :class:`pulpcore.plugin.models.Artifact` fields. This includes the computed digest values
+        along with size information.
+    exception (Exception): Any downloader exception emitted while the
+        :class:`~pulpcore.plugin.download.asyncio.GroupDownloader` is downloading. Otherwise this
+        value is `None`.
+"""
+
+
+def attach_url_to_exception(func):
+    """
+    A decorator that attaches the `url` to any exception emitted by a downloader's `run()` method.
+
+    >>> class MyCustomDownloader(BaseDownloader)
+    >>>     @attach_url_to_exception
+    >>>     async def run(self):
+    >>>         pass  # downloader implementation of run() goes here
+
+    The url is stored on the exception as the `_pulp_url` attribute. This is used by the
+    :class:`~pulpcore.plugin.download.asyncio.GroupDownloader` to know the url a given exception
+    is for.
+
+    Args:
+        func: The method being decorated. This is expected to be the `run()` method of a subclass of
+            :class:`~pulpcore.plugin.download.asyncio.BaseDownloader`
+
+    Returns:
+        A function that will attach the `url` to any exception emitted by `func`
+    """
+    async def wrapper(downloader):
+        try:
+            return await func(downloader)
+        except Exception as error:
+            error._pulp_url = downloader.url
+            raise error
+    return wrapper
+
+
+class BaseDownloader:
+    """
+    The base class of all downloaders. This is an abstract class and is meant to be subclassed.
+
+    This provides data digest calculation and validation and the writing to a file.
+
+    All subclassed downloaders should pass all downloaded data the into
+    :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data` to allow the file digest to
+    be computed while data is written to disk. This avoids having to re-read the data later. The
+    digests computed are required to save the file as an Artifact, so we need to compute them.
+
+    The :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data` method by default
+    writes to a random file in the current working directory or you can pass in your own file
+    object. See the ``custom_file_object`` keyword argument for more details. Allowing the download
+    instantiator to define the file to receive data allows the streamer to receive the data instead
+    of having it written to disk.
+
+    Attributes:
+        url (str): The url to download.
+        expected_digests (dict): Keyed on the algorithm name provided by hashlib and stores the
+            value of the expected digest. e.g. {'md5': '912ec803b2ce49e4a541068d495ab570'}
+        expected_size (int): The number of bytes the download is expected to have.
+        path (str): The full path to the file containing the downloaded data if no
+            ``custom_file_object`` option was specified, otherwise None.
+    """
+
+    def __init__(self, url, custom_file_object=None, expected_digests=None, expected_size=None):
+        """
+        Create a BaseDownloader object. This is expected to be called by all subclasses.
+
+        Args:
+            url (str): The url to download.
+            custom_file_object (file object): An open, writable file object that downloaded data
+                can be written to by
+                :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data`.
+            expected_digests (dict): Keyed on the algorithm name provided by hashlib and stores the
+                value of the expected digest. e.g. {'md5': '912ec803b2ce49e4a541068d495ab570'}
+            expected_size (int): The number of bytes the download is expected to have.
+        """
+        self.url = url
+        if custom_file_object:
+            self._writer = custom_file_object
+            self.path = None
+        else:
+            fd, self.path = tempfile.mkstemp(dir=os.getcwd())
+            self._writer = os.fdopen(fd, mode='wb')
+        self.expected_digests = expected_digests
+        self.expected_size = expected_size
+        self._digests = {n: hashlib.new(n) for n in Artifact.DIGEST_FIELDS}
+        self._size = 0
+
+    def handle_data(self, data):
+        """
+        Write data to the file object and compute its digests.
+
+        All subclassed downloaders are expected to pass all data downloaded to this method. Similar
+        to the hashlib docstring, repeated calls are equivalent to a single call with
+        the concatenation of all the arguments: m.handle_data(a); m.handle_data(b) is equivalent to
+        m.handle_data(a+b).
+
+        Args:
+            data (bytes): The data to be handled by the downloader.
+        """
+        self._writer.write(data)
+        self._record_size_and_digests_for_data(data)
+
+    def _record_size_and_digests_for_data(self, data):
+        """
+        Record the size and digest for an available chunk of data.
+
+        Args:
+            data (bytes): The data to have its size and digest values recorded.
+        """
+        for algorithm in self._digests.values():
+            algorithm.update(data)
+        self._size += len(data)
+
+    @property
+    def artifact_attributes(self):
+        """
+        A property that returns a dictionary with size and digest information. The keys of this
+        dictionary correspond with :class:`pulpcore.plugin.models.Artifact` fields.
+        """
+        attributes = {'size': self._size}
+        for algorithm in Artifact.DIGEST_FIELDS:
+            attributes[algorithm] = self._digests[algorithm].hexdigest()
+        return attributes
+
+    def validate_digests(self):
+        """
+        Validate all digests validate if ``expected_digests`` is set
+
+        Raises:
+            :class:`~pulpcore.plugin.download.asyncio.DigestValidationError`: When any of the
+                ``expected_digest`` values don't match the digest of the data passed to
+                :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data`.
+        """
+        if self.expected_digests:
+            for algorithm, expected_digest in self.expected_digests.items():
+                if expected_digest != self._digests[algorithm].hexdigest():
+                    raise DigestValidationError()
+
+    def validate_size(self):
+        """
+        Validate the size if ``expected_size`` is set
+
+        Raises:
+            :class:`~pulpcore.plugin.download.asyncio.SizeValidationError`: When the
+                ``expected_size`` value doesn't match the size of the data passed to
+                :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data`.
+        """
+        if self.expected_size:
+            if self._size != self.expected_size:
+                raise SizeValidationError()
+
+    async def run(self):
+        """
+        Run the downloader.
+
+        This is a coroutine that asyncio can schedule to complete downloading. This is required to
+        be implemented by subclasses.
+
+        It is expected that the subclass implementation call
+        :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.validate_size` and
+        :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.validate_digests` after the last
+        call to :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data` which will
+        validate the data.
+
+        It is also expected that the subclass implementation return a
+        :class:`~pulpcore.plugin.download.asyncio.DownloadResult` object. The
+        ``artifact_attributes`` value of the
+        :class:`~pulpcore.plugin.download.asyncio.DownloadResult` is usually set to the
+        :attr:`~pulpcore.plugin.download.asyncio.BaseDownloader.artifact_attributes` property value.
+
+        It is also expected that the subclass implementation be decorated with the
+        :class:`~pulpcore.plugin.download.asyncio.attach_url_to_exception` decorator. This is
+        required to allow the :class:`~pulpcore.plugin.download.asyncio.GroupDownloader` to properly
+        record the exceptions emitted from subclassed downloaders.
+
+        Returns:
+            :class:`~pulpcore.plugin.download.asyncio.DownloadResult`
+
+        Raises:
+            :class:`~pulpcore.plugin.download.asyncio.DigestValidationError`: When any of the
+                ``expected_digest`` values don't match the digest of the data passed to
+                :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data`.
+            :class:`~pulpcore.plugin.download.asyncio.SizeValidationError`: When the
+                ``expected_size`` value doesn't match the size of the data passed to
+                :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.handle_data`.
+        """
+        raise NotImplementedError('Subclasses must define a run() method that returns a coroutine')

--- a/plugin/pulpcore/plugin/download/asyncio/exceptions.py
+++ b/plugin/pulpcore/plugin/download/asyncio/exceptions.py
@@ -1,0 +1,34 @@
+from gettext import gettext as _
+
+from pulpcore.exceptions import PulpException
+
+
+class DownloaderValidationError(PulpException):
+    """
+    A base class for all Download Validation Errors.
+    """
+    pass
+
+
+class DigestValidationError(DownloaderValidationError):
+    """
+    Raised when a file fails to validate a digest checksum.
+    """
+
+    def __init__(self):
+        super().__init__("PLP0003")
+
+    def __str__(self):
+        return _("A file failed validation due to checksum.")
+
+
+class SizeValidationError(DownloaderValidationError):
+    """
+    Raised when a file fails to validate a size checksum.
+    """
+
+    def __init__(self):
+        super().__init__("PLP0004")
+
+    def __str__(self):
+        return _("A file failed validation due to size.")

--- a/plugin/pulpcore/plugin/download/asyncio/factory.py
+++ b/plugin/pulpcore/plugin/download/asyncio/factory.py
@@ -1,0 +1,157 @@
+import aiohttp
+import atexit
+import copy
+from gettext import gettext as _
+import ssl
+from urllib.parse import urlparse
+
+from .http import HttpDownloader
+from .file import FileDownloader
+
+
+PROTOCOL_MAP = {
+    'http': HttpDownloader,
+    'https': HttpDownloader,
+    'file': FileDownloader
+}
+
+
+class DownloaderFactory:
+    """
+    A factory for creating downloader objects that are configured from with importer settings.
+
+    It supports `http`, `https`, and `file` protocols. The ``downloader_overrides`` option allows
+    the caller to specify the download class to be used for any given protocol. This allows the user
+    to specify custom, subclassed downloaders to be built by the factory.
+
+    Usage:
+        >>> import asyncio
+        >>> loop = asyncio.get_event_loop()
+        >>> the_factory = DownloaderFactory(importer)
+        >>> downloader_a = the_factory.build(url_a)
+        >>> downloader_b = the_factory.build(url_b)
+        >>> downloads_list = [downloader_a, downloader_b]
+        >>> done, not_done = loop.run_until_complete(asyncio.wait(downloads_list))
+        >>> for task in done:
+        >>>     result = task.result()  # 'result' is a DownloadResult
+    """
+
+    def __init__(self, importer, downloader_overrides=None):
+        """
+        Args:
+            importer (:class:`~pulpcore.plugin.models.Importer`): The importer used to populate
+                downloader settings.
+            downloader_overrides (dict): Keyed on a scheme name, e.g. 'https' or 'ftp' and the value
+                is the downloader class to be used for that scheme, e.g.
+                {'https': MyCustomDownloader}. These override the default values.
+        """
+        self._importer = importer
+        self._download_class_map = copy.copy(PROTOCOL_MAP)
+        if downloader_overrides:
+            for protocol, download_class in downloader_overrides.items():  # overlay the overrides
+                self._download_class_map[protocol] = download_class
+        self._handler_map = {'https': self._http_or_https, 'http': self._http_or_https,
+                             'file': self._generic}
+        self._session = self._make_aiohttp_session_from_importer()
+        atexit.register(self._session.close)
+
+    def _make_aiohttp_session_from_importer(self):
+        """
+        Build a :class:`aiohttp.ClientSession` from the importer settings
+
+        Returns:
+            :class:`aiohttp.ClientSession`
+        """
+        tcp_conn_opts = {}
+
+        sslcontext = None
+        if self._importer.ssl_ca_certificate.name:
+            sslcontext = ssl.create_default_context(cafile=self._importer.ssl_ca_certificate.name)
+            if self._importer.ssl_client_key.name and self._importer.ssl_client_certificate.name:
+                sslcontext.load_cert_chain(
+                    self._importer.ssl_client_key.name,
+                    self._importer.ssl_client_certificate.name
+                )
+        else:
+            if self._importer.ssl_client_key.name and self._importer.ssl_client_certificate.name:
+                sslcontext = ssl.create_default_context()
+                sslcontext.load_cert_chain(
+                    self._importer.ssl_client_key.name,
+                    self._importer.ssl_client_certificate.name
+                )
+
+        if sslcontext:
+            tcp_conn_opts['ssl_context'] = sslcontext
+
+        if self._importer.ssl_validation:
+            tcp_conn_opts['verify_ssl'] = self._importer.ssl_validation
+
+        conn = aiohttp.TCPConnector(**tcp_conn_opts)
+
+        auth_options = {}
+        if self._importer.username and self._importer.password:
+            auth_options['auth'] = aiohttp.BasicAuth(
+                login=self._importer.username,
+                password=self._importer.password
+            )
+
+        return aiohttp.ClientSession(connector=conn, **auth_options)
+
+    def build(self, url, **kwargs):
+        """
+        Build a downloader which can optionally verify integrity using either digest or size.
+
+        Args:
+            url (str): The download URL.
+            kwargs (dict): All kwargs are passed along to the downloader. At a minimum, these
+                include the :class:`~pulpcore.plugin.download.asyncio.BaseDownloader` parameters.
+
+        Returns:
+            coroutine: An asyncio-aware based downloader that is configured using the attributes of
+                       the importer. It is a coroutine and schedulable with `asyncio`.
+        """
+        scheme = urlparse(url).scheme.lower()
+        try:
+            builder = self._handler_map[scheme]
+            download_class = self._download_class_map[scheme]
+        except KeyError:
+            raise ValueError(_('URL: {u} not supported.'.format(u=url)))
+        else:
+            return builder(download_class, url, **kwargs)
+
+    def _http_or_https(self, download_class, url, **kwargs):
+        """
+        Build a downloader for http:// or https:// URLs.
+
+        Args:
+            download_class (:class:`~pulpcore.plugin.download.asyncio.BaseDownloader`): The download
+                class to be instantiated.
+            url (str): The download URL.
+            kwargs (dict): All kwargs are passed along to the downloader. At a minimum, these
+                include the :class:`~pulpcore.plugin.download.asyncio.BaseDownloader` parameters.
+
+        Returns:
+            coroutine: A coroutine for the
+                :class:`~pulpcore.plugin.download.asyncio.HttpDownloader`.
+        """
+        options = {}
+        if self._importer.proxy_url:
+            options['proxy'] = self._importer.proxy_url
+
+        return download_class(self._session, url, **options, **kwargs).run()
+
+    def _generic(self, download_class, url, **kwargs):
+        """
+        Build a generic downloader based on the url.
+
+        Args:
+            download_class (:class:`~pulpcore.plugin.download.asyncio.BaseDownloader`): The download
+                class to be instantiated.
+            url (str): The download URL.
+            kwargs (dict): All kwargs are passed along to the downloader. At a minimum, these
+                include the :class:`~pulpcore.plugin.download.asyncio.BaseDownloader` parameters.
+
+        Returns:
+            coroutine: A coroutine produced by the `download_class.run()` method.
+        """
+        return download_class(url, **kwargs).run()

--- a/plugin/pulpcore/plugin/download/asyncio/file.py
+++ b/plugin/pulpcore/plugin/download/asyncio/file.py
@@ -1,0 +1,49 @@
+import os
+from urllib.parse import urlparse
+
+from .base import attach_url_to_exception, BaseDownloader, DownloadResult
+
+
+class FileDownloader(BaseDownloader):
+    """
+    A downloader for downloading files from the filesystem.
+
+    It provides digest and size validation along with computation of the digests needed to save the
+    file as an Artifact. It writes a new file to the disk and the return path is included in the
+    :class:`~pulpcore.plugin.download.asyncio.DownloadResult`.
+
+    This downloader has all of the attributes of
+    :class:`~pulpcore.plugin.download.asyncio.BaseDownloader`
+    """
+
+    def __init__(self, url, **kwargs):
+        """
+        Download files from a url that starts with `file://`
+
+        Args:
+            url (str): The url to the file. This is expected to begin with `file://`
+            kwargs (dict): This accepts the parameters of
+                :class:`~pulpcore.plugin.download.asyncio.BaseDownloader`.
+        """
+        p = urlparse.urlparse(url)
+        self._path = os.path.abspath(os.path.join(p.netloc, p.path))
+        super().__init__(url, **kwargs)
+
+    @attach_url_to_exception
+    async def run(self):
+        """
+        Read, validate, and compute digests on the `url`. This is a coroutine.
+
+        This method provides the same return object type and documented in
+        :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.run`.
+        """
+        with open(self._path, 'r') as f_handle:
+            while True:
+                chunk = await f_handle.read(1024)
+                if not chunk:
+                    self.validate_size()
+                    self.validate_digests()
+                    break  # the reading is done
+                self.handle_data(chunk)
+            return DownloadResult(path=self._path, artifact_attributes=self.artifact_attributes,
+                                  url=self.url, exception=None)

--- a/plugin/pulpcore/plugin/download/asyncio/group.py
+++ b/plugin/pulpcore/plugin/download/asyncio/group.py
@@ -1,0 +1,210 @@
+import asyncio
+from collections import defaultdict
+from contextlib import suppress
+from gettext import gettext as _
+from itertools import chain
+
+from pulpcore.plugin.download.asyncio import DownloadResult
+from pulpcore.plugin.tasking import Task
+
+from .factory import DownloaderFactory
+
+
+class GroupDownloader:
+    """
+    Download groups of files, with all downloads from all groups occurring in parallel.
+
+    This supports groups to be downloaded by adding them explicitly or via an iterator such as a
+    generator. The generator case is useful for limiting the number of in-memory objects.
+
+    Basic Usage:
+        >>> downloader = GroupDownloader(importer)
+        >>> artifact_a = RemoteArtifact(url=url_a, md5='912ec803b2ce49e4a541068d495ab570')
+        >>> artifact_b = RemoteArtifact(url=url_b, size=4172)
+        >>> my_group = Group('my_id', [artifact_a, artifact_b])
+        >>> downloader.schedule_group(my_group)
+        >>> for id, group_results in downloader:
+        >>>     print(id)  # id is set to 'my_id'
+        >>>     # group_results is a dict of DownloadResult objects keyed by RemoteArtifact
+
+    If you register a large number of groups, you could use a lot of memory holding those objects,
+    their associated downloaders, and other related objects. To resolve this, the GroupDownloader
+    provides a way to limit the number of effective in-memory objects by processing objects from a
+    generator that yields the (id, [RemoteArtifact()]) tuples. See the example below and read the
+    schedule_from_iterator() docs for more details.
+
+    Constraining in-memory objects while downloading:
+        >>> def group_generator():
+        >>>    yield Group('id_1', [RemoteArtifact(url=url_a), RemoteArtifact(url=url_b)])
+        >>>    yield Group('id_2', [RemoteArtifact(url=url_a), RemoteArtifact(url=url_b)])
+        >>>
+        >>> downloader = GroupDownloader(importer)
+        >>> downloader.schedule_from_iterator(group_generator)
+        >>> for id, group in downloader:
+        >>>     print(id)  # id is set to 'id_1'
+        >>>     print(group)  # group is the :class:`~pulpcore.plugin.download.asyncio.Group`
+
+    This downloader does not raise Exceptions. Instead any exceptions emitted by the Task are
+    recorded as non-fatal exceptions using :meth:`~pulpcore.plugin.Task.append_non_fatal_error`.
+    """
+
+    def __init__(self, importer, downloader_overrides=None):
+        """
+        Args:
+            importer (:class:`~pulpcore.plugin.models.Importer`): The importer used to configure
+                downloaders with.
+            downloader_overrides (dict): The downloader overrides which are passed along to the
+                :class:`pulpcore.plugin.downloader.asyncio.DownloaderFactory`
+        """
+        self.importer = importer
+
+        self.downloader_factory = DownloaderFactory(self.importer,
+                                                    downloader_overrides=downloader_overrides)
+        self.group_iterator = None
+        self.downloads_not_done = set()
+        self.groups_not_done = []
+        self.urls = defaultdict(list)  # dict with url as the key and a lists of Groups as the value
+        self.loop = asyncio.get_event_loop()
+
+    def schedule_from_iterator(self, group_iterator, parallel_group_limit=50):
+        """
+        Schedule groups to be downloaded using an iterator provided by the user.
+
+        When scheduling groups from the iterator, the ``parallel_group_limit`` argument defines the
+        number of groups that are handled in parallel. Once one
+        :class:`~pulpcore.plugin.download.asyncio.Group` completes and is returned to the user,
+        another one is scheduled which maintains the number of parallel groups until the iterator is
+        exhausted.
+
+        When the group_iterator is a generator, this technique limits the effective memory used by
+        the :class:`~pulpcore.plugin.models.RemoteArtifact` objects and their associated
+        downloaders.
+
+        Additional calls to this will correctly schedule additional iterators, but only the first
+        call will specify the `parallel_group_limit`.
+
+        Args:
+            group_iterator (iterable): An iterable of
+                :class:`~pulpcore.plugin.download.asyncio.Group` objects.
+            parallel_group_limit (int): The number of groups to be handled in parallel at any time.
+        """
+        if self.group_iterator:
+            # This is not the first call to schedule an iterable
+            self.group_iterator = chain(self.group_iterator, group_iterator)
+            return
+
+        self.group_iterator = group_iterator
+        for i in range(parallel_group_limit):
+            with suppress(StopIteration):
+                self.schedule_group(next(self.group_iterator))
+
+    def schedule_group(self, group):
+        """
+        Schedules a group of `remote_artifacts` for downloading, referred to by an `id`.
+
+        Args:
+            group (:class:`~pulpcore.plugin.download.asyncio.Group`): The group to be scheduled.
+        """
+        self.groups_not_done.append(group)
+        for url in group.urls:
+            if len(self.urls[url]) == 0:
+                # This is the first time we've seen this url so make a downloader
+                downloader_for_url = self.downloader_factory.build(url)
+                self.downloads_not_done.add(downloader_for_url)
+            self.urls[url].append(group)
+
+    def _find_and_remove_done_group(self):
+        for index, group in enumerate(self.groups_not_done):
+            if group.done:
+                self.groups_not_done.pop(index)
+                return group
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """
+        Returns:
+            :class:`pulpcore.plugin.download.asyncio.Group`
+        """
+        while self.downloads_not_done:
+            done_this_time, self.downloads_not_done = \
+                self.loop.run_until_complete(asyncio.wait(self.downloads_not_done,
+                                                          return_when=asyncio.FIRST_COMPLETED))
+            with suppress(StopIteration):
+                if self.group_iterator:
+                    self.schedule_group(next(self.group_iterator))
+            for task in done_this_time:
+                try:
+                    download_result = task.result()
+                except Exception as error:
+                    msg = _("{exc} for url {url}").format(exc=error, url=error._pulp_url)
+                    Task().append_non_fatal_error(Exception(msg))
+                    download_result = DownloadResult(url=str(error._pulp_url),
+                                                     artifact_attributes=None, path=None,
+                                                     exception=error)
+                for group in self.urls[download_result.url]:
+                    group.handle_download_result(download_result)
+                group = self._find_and_remove_done_group()
+                if group:
+                    return group
+        finished_group = self._find_and_remove_done_group()
+        if finished_group:
+            return finished_group
+        else:
+            raise StopIteration()
+
+
+class Group:
+    """
+    A group of remote_artifacts to download.
+
+    Each group is downloaded with the :class:`~pulpcore.plugin.download.asyncio.GroupDownloader`.
+
+    Attributes:
+        id (hashable): This id is used to uniquely identify the group.
+        remote_artifacts (dict): Keyed on the remote url with the value containing the
+            :class:`~pulpcore.plugin.models.RemoteArtifact`.
+        downloaded_files (dict): Keyed on the remote url with the value containing the
+             :class:`~pulpcore.plugin.download.asyncio.DownloadResult`
+        urls (set): All remote urls in this group.
+        finished_urls (list): A list of completed urls.
+    """
+
+    def __init__(self, id, remote_artifacts):
+        """
+        Args:
+            id (hashable): This id is used to uniquely identify the group
+            remote_artifacts (list): A list of :class:`~pulpcore.plugin.models.RemoteArtifact`
+                instances that have not been saved to the database.
+        """
+        self.id = id
+        self.remote_artifacts = {}
+        self.downloaded_files = {}
+        urls = []
+        for remote_artifact in remote_artifacts:
+            self.remote_artifacts[remote_artifact.url] = remote_artifact
+            urls.append(remote_artifact.url)
+        self.urls = set(urls)
+        self.finished_urls = []
+
+    def handle_download_result(self, download_result):
+        """
+        Update the Group with download result calculated during the download from the URL
+
+        Args:
+            download_result (:class:`pulpcore.plugin.download.asyncio.DownloadResult`): The return
+                argument from an HttpDownloader
+        """
+        self.finished_urls.append(download_result.url)
+        self.downloaded_files[download_result.url] = download_result
+
+    @property
+    def done(self):
+        """
+        A property that returns True if all downloads are completed.
+
+        Returns:
+            True if the Group has all downloads completed, False otherwise.
+        """
+        return len(self.urls) == len(self.finished_urls)

--- a/plugin/pulpcore/plugin/download/asyncio/http.py
+++ b/plugin/pulpcore/plugin/download/asyncio/http.py
@@ -1,0 +1,113 @@
+from .base import attach_url_to_exception, BaseDownloader, DownloadResult
+
+
+class HttpDownloader(BaseDownloader):
+    """
+    An asyncio aware HTTP/HTTPS Downloader built on aiohttp.
+
+    This is the default downloader used by the DownloaderFactory and GroupDownloader. It is designed
+    to be easily subclassed for customizable download behaviors. If a user subclasses this, they can
+    specify the subclass to be used with either the DownloaderFactory or GroupDownloader.
+
+    Each downloader downloads data from one `url` and are not reused. Each downloader requires an
+    `aiohttp.ClientSession` for it to use. The aiohttp.ClientSession provides connection pooling,
+    connection reusage, and keep-alives. Don't create one session per Downloader, use one session
+    shared by all of your downloaders.
+
+    `aiohttp.ClientSession` objects also accept options which will then apply to all downloads which
+    use them. These things include auth, timeouts, headers, etc. For more info on these options see
+    the `aiohttp.ClientSession` docs for more information:
+    http://aiohttp.readthedocs.io/en/stable/client_reference.html#aiohttp.ClientSession
+
+    The `aiohttp.ClientSession` can additionally be configured for SSL configuration by passing in a
+    `aiohttp.TCPConnector`. For information on configuring either server or client certificate based
+    identity verification, see the aiohttp documentation:
+    http://aiohttp.readthedocs.io/en/stable/client.html#ssl-control-for-tcp-sockets
+
+    For more information on `aiohttp.BasicAuth` objects, see their docs:
+    http://aiohttp.readthedocs.io/en/stable/client_reference.html#aiohttp.BasicAuth
+
+    Usage:
+        >>> session = aiohttp.ClientSession()
+        >>> downloader_obj = HttpDownloader(session, url)
+        >>> downloader_coroutine = downloader_obj.run()
+        >>> loop = asyncio._get_running_loop()
+        >>> done, not_done = loop.run_until_complete(asyncio.wait([downloader_coroutine]))
+        >>> for task in done:
+        >>>     result = task.result()  # This is a DownloadResult
+
+    Attributes:
+        session (aiohttp.ClientSession): The session to be used by the downloader.
+        auth (aiohttp.BasicAuth): An object that represents HTTP Basic Authorization (optional)
+        proxy (str): An optional proxy URL.
+        proxy_auth (aiohttp.BasicAuth): An optional object that represents proxy HTTP Basic
+            Authorization.
+        headers_ready_callback (callable): An optional callback that accepts a single dictionary
+            as its argument. The callback will be called when the response headers are
+            available. The dictionary passed has the header names as the keys and header values
+            as its values. e.g. `{'Transfer-Encoding': 'chunked'}`
+
+    This downloader also has all of the attributes of
+    :class:`~pulpcore.plugin.download.asyncio.BaseDownloader`
+    """
+
+    def __init__(self, session, url, auth=None, proxy=None, proxy_auth=None,
+                 headers_ready_callback=None, **kwargs):
+        """
+        Args:
+            url (str): The url to download.
+            session (aiohttp.ClientSession): The session to be used by the downloader.
+            auth (aiohttp.BasicAuth): An object that represents HTTP Basic Authorization (optional)
+            proxy (str): An optional proxy URL.
+            proxy_auth (aiohttp.BasicAuth): An optional object that represents proxy HTTP Basic
+                Authorization.
+            headers_ready_callback (callable): An optional callback that accepts a single dictionary
+                as its argument. The callback will be called when the response headers are
+                available. The dictionary passed has the header names as the keys and header values
+                as its values. e.g. `{'Transfer-Encoding': 'chunked'}`
+            kwargs (dict): This accepts the parameters of
+                :class:`~pulpcore.plugin.download.asyncio.BaseDownloader`.
+        """
+        self.session = session
+        self.auth = auth
+        self.proxy = proxy
+        self.proxy_auth = proxy_auth
+        self.headers_ready_callback = headers_ready_callback
+        super().__init__(url, **kwargs)
+
+    async def _handle_response(self, response):
+        """
+        Handle the aiohttp response by writing it to disk and calculating digests
+
+        Args:
+            response (aiohttp.ClientResponse): The response to handle.
+
+        Returns:
+             DownloadResult: Contains information about the result. See the DownloadResult docs for
+                 more information.
+        """
+        if self.headers_ready_callback:
+            self.headers_ready_callback(response.headers)
+        while True:
+            chunk = await response.content.read(1024)
+            if not chunk:
+                self.validate_size()
+                self.validate_digests()
+                break  # the download is done
+            self.handle_data(chunk)
+        return DownloadResult(path=self.path, artifact_attributes=self.artifact_attributes,
+                              url=self.url, exception=None)
+
+    @attach_url_to_exception
+    async def run(self):
+        """
+        Download, validate, and compute digests on the `url`. This is a coroutine.
+
+        This method provides the same return object type and documented in
+        :meth:`~pulpcore.plugin.download.asyncio.BaseDownloader.run`.
+        """
+        async with self.session.get(self.url) as response:
+            response.raise_for_status()
+            to_return = await self._handle_response(response)
+            await response.release()
+        return to_return

--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 
 requirements = [
     'pulpcore',
+    'aiohttp',
 ]
 
 setup(


### PR DESCRIPTION
Adds a HttpDownloader
- handles both synchronous and asynchronous downloads
- designed for subclassing to make custom downloader
- size validation works
- digest validation works
- has a well defined return interface DownloadResult

Reworks the Factory
- Updates the Factory to use HttpDownloader
- Fully configures HttpDownloader with all importer settings including:
  ssl client and server options, basic auth, proxy, proxy_auth
- Can be reused with custom downloaders

Adds a GroupDownloader
- Downloads files in parallel but only return back to the use when any
  group of files are fully downloaded.
- Drivable with or with generators
- Constrains in-memory objects through generator use

General Updates
- Updates the importer to use the Factory
- Updates the docs to use docs from the new code

https://pulp.plan.io/issues/2951
closes #2951