### PR TITLE
2916 add distribution viewset and serializer

### DIFF
--- a/platform/pulpcore/app/apps.py
+++ b/platform/pulpcore/app/apps.py
@@ -98,11 +98,12 @@ class PulpPluginAppConfig(apps.AppConfig):
     def import_viewsets(self):
         # circular import avoidance
         from pulpcore.app.viewsets import (GenericNamedModelViewSet, NamedModelViewSet,
-                                           CreateDestroyReadNamedModelViewSet)
+                                           CreateDestroyReadNamedModelViewSet,
+                                           NestedNamedModelViewSet)
         # These viewsets are used as base classes for actual model viewsets and
         # should not be registered
         base_viewsets = [GenericNamedModelViewSet, NamedModelViewSet,
-                         CreateDestroyReadNamedModelViewSet]
+                         CreateDestroyReadNamedModelViewSet, NestedNamedModelViewSet]
         self.named_viewsets = {}
         if module_has_submodule(self.module, VIEWSETS_MODULE_NAME):
             # import the viewsets module and track any interesting viewsets

--- a/platform/pulpcore/app/models/publication.py
+++ b/platform/pulpcore/app/models/publication.py
@@ -100,3 +100,4 @@ class Distribution(Model):
 
     class Meta:
         unique_together = ('publisher', 'name')
+        default_related_name = 'distributions'

--- a/platform/pulpcore/app/serializers/__init__.py
+++ b/platform/pulpcore/app/serializers/__init__.py
@@ -3,13 +3,14 @@
 # - all can import directly from base and fields if needed
 from pulpcore.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # noqa
     ModelSerializer, MasterModelSerializer, DetailIdentityField, DetailRelatedField,
-    DetailNestedHyperlinkedRelatedField, DetailNestedHyperlinkedIdentityField, viewset_for_model)
+    DetailNestedHyperlinkedRelatedField, DetailNestedHyperlinkedIdentityField, viewset_for_model,
+    DetailWritableNestedUrlRelatedField, NestedModelSerializer)
 from pulpcore.app.serializers.fields import (ContentRelatedField, RepositoryRelatedField,  # noqa
     FileField)
 from pulpcore.app.serializers.consumer import ConsumerSerializer  # noqa
 from pulpcore.app.serializers.content import ContentSerializer, ArtifactSerializer  # noqa
 from pulpcore.app.serializers.progress import ProgressReportSerializer  # noqa
-from pulpcore.app.serializers.repository import (ImporterSerializer, PublisherSerializer,  # noqa
+from pulpcore.app.serializers.repository import (DistributionSerializer, ImporterSerializer, PublisherSerializer,  # noqa
     RepositorySerializer, RepositoryContentSerializer)  # noqa
 from pulpcore.app.serializers.task import TaskSerializer, WorkerSerializer  # noqa
 from pulpcore.app.serializers.user import UserSerializer  # noqa

--- a/platform/pulpcore/app/settings.py
+++ b/platform/pulpcore/app/settings.py
@@ -114,7 +114,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
     'DEFAULT_PAGINATION_CLASS': 'pulpcore.app.pagination.UUIDPagination',
     'PAGE_SIZE': 100,
-    'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',)
+    # 'DEFAULT_PERMISSION_CLASSES': ('rest_framework.permissions.IsAuthenticated',)
 }
 
 

--- a/platform/pulpcore/app/viewsets/__init__.py
+++ b/platform/pulpcore/app/viewsets/__init__.py
@@ -1,7 +1,7 @@
 from pulpcore.app.viewsets.base import (GenericNamedModelViewSet, NamedModelViewSet,  # noqa
-                                        CreateDestroyReadNamedModelViewSet)  # noqa
+                                        NestedNamedModelViewSet, CreateDestroyReadNamedModelViewSet)  # noqa
 from pulpcore.app.viewsets.content import ArtifactViewSet, ContentViewSet  # noqa
-from pulpcore.app.viewsets.repository import (ImporterViewSet, PublisherViewSet,  # noqa
+from pulpcore.app.viewsets.repository import (DistributionViewSet, ImporterViewSet, PublisherViewSet,  # noqa
     RepositoryViewSet, RepositoryContentViewSet)  # noqa
 from pulpcore.app.viewsets.task import TaskViewSet, WorkerViewSet  # noqa
 from pulpcore.app.viewsets.user import UserViewSet  # noqa


### PR DESCRIPTION
This was based off of a @jortel branch. It will need to be rebased, cleaned up and tested, but demonstrates the POC for Nested Serialization.

This PR does a few things, which I plan to clean up into separate commits.
1. Allows nested serializers to populate a field that represents an objects "url parent". For example, the publisher created at repositories/r1/publishers/file/p1/ should obviously use r1 as its repository.
2. Allow doubly nested viewsets to be registered with the router in the correct order. 
3. Create a Distribution ViewSet and Serializer.

This (at least right now) seems like the best approach, because it avoids creating lots of Mixins that handle the url creation. It also avoids needing to use `reverse` or url manipulation.

There are a lot more comments necessary to explain how this should work, and a few tweaks, but in the end it should be simple. For a serializer to have a writable field that represents its url parent, the viewset must declare its parent_viewset, parent_lookup_kwargs, and maybe (TBD) a nest_prefix.