### PR TITLE
Fix issue causing worker to be left in a broken state

### DIFF
--- a/common/pulp/common/config.py
+++ b/common/pulp/common/config.py
@@ -143,6 +143,7 @@ def parse_bool(value):
 
     return value.upper() in ('YES', 'TRUE', '1')
 
+
 def parse_header(headers):
     """
        Parses the given header into its dictionary representation.

--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -391,7 +391,8 @@ class Publisher(PublishStep):
         delete = self.get_config().get("delete", False)
 
         return not force_full and not delete and self.last_predist_last_published and \
-            ((last_deleted and last_published and last_published > last_deleted) or not last_deleted)
+            ((last_deleted and last_published and last_published > last_deleted) or
+                not last_deleted)
 
     def create_date_range_filter(self, start_date=None, end_date=None):
         """

--- a/server/pulp/server/webservices/urls.py
+++ b/server/pulp/server/webservices/urls.py
@@ -64,7 +64,7 @@ from pulp.server.webservices.views.repo_groups import (
     RepoGroupPublishView, RepoGroupResourceView, RepoGroupSearch, RepoGroupsView,
     RepoGroupUnassociateView
 )
-from pulp.server.webservices.views.repositories import(
+from pulp.server.webservices.views.repositories import (
     ContentApplicabilityRegenerationView, RepoDistributorResourceView, RepoDistributorsSearchView,
     RepoDistributorsView, RepoAssociate, RepoImporterResourceView, RepoImportersView,
     RepoImportUpload, RepoPublish, RepoPublishHistory, RepoPublishScheduleResourceView,


### PR DESCRIPTION
Mitigates an issue where workers can be left in a broken
state if they are restarted while processing a task.

Fixes only the SIGTERM shutdown case, the most common one.

re #2835
https://pulp.plan.io/issues/2835