### PR TITLE
Set the href_writable on RepositoryRelatedFields

### DIFF
--- a/platform/pulpcore/app/serializers/__init__.py
+++ b/platform/pulpcore/app/serializers/__init__.py
@@ -5,12 +5,14 @@ from pulpcore.app.serializers.base import (DetailRelatedField, GenericKeyValueRe
     ModelSerializer, MasterModelSerializer, DetailIdentityField, DetailRelatedField,
     DetailNestedHyperlinkedRelatedField, DetailNestedHyperlinkedIdentityField, viewset_for_model,
     DetailWritableNestedUrlRelatedField)
-from pulpcore.app.serializers.fields import (ContentRelatedField, RepositoryRelatedField,  # noqa
-    FileField)
+from pulpcore.app.serializers.fields import (ContentRelatedField, FileField,  # noqa
+                                             HrefWritableRepositoryRelatedField)
 from pulpcore.app.serializers.consumer import ConsumerSerializer  # noqa
 from pulpcore.app.serializers.content import ContentSerializer, ArtifactSerializer  # noqa
 from pulpcore.app.serializers.progress import ProgressReportSerializer  # noqa
-from pulpcore.app.serializers.repository import (DistributionSerializer, ImporterSerializer, PublisherSerializer,  # noqa
-    RepositorySerializer, RepositoryContentSerializer)  # noqa
+from pulpcore.app.serializers.repository import (DistributionSerializer,  # noqa
+                                                 ImporterSerializer,
+                                                 PublisherSerializer, RepositorySerializer,
+                                                 RepositoryContentSerializer)
 from pulpcore.app.serializers.task import TaskSerializer, WorkerSerializer  # noqa
 from pulpcore.app.serializers.user import UserSerializer  # noqa

--- a/platform/pulpcore/app/serializers/base.py
+++ b/platform/pulpcore/app/serializers/base.py
@@ -320,18 +320,11 @@ class DetailNestedHyperlinkedIdentityField(_DetailFieldMixin, NestedHyperlinkedI
     pass
 
 
-class WritableNestedUrlRelatedField(NestedHyperlinkedRelatedField):
+class DetailWritableNestedUrlRelatedField(_DetailFieldMixin, NestedHyperlinkedRelatedField):
     """
     This field supports a special attribute, `href_writable`. Fields that carry this flag represent
     a nested parent, which is the model determined by the url parameters instead of request body
     parameters.
+    read_only should be passed as a kwarg to this field.
     """
-    def __init__(self, *args, **kwargs):
-        # rest_framework.fields.Field.__init__ sets self.read_only, so we have to inject this kwarg.
-        kwargs['read_only'] = True
-        self.href_writable = True
-        super().__init__(*args, **kwargs)
-
-
-class DetailWritableNestedUrlRelatedField(_DetailFieldMixin, WritableNestedUrlRelatedField):
-    pass
+    href_writable = True

--- a/platform/pulpcore/app/serializers/fields.py
+++ b/platform/pulpcore/app/serializers/fields.py
@@ -16,13 +16,15 @@ class ContentRelatedField(DetailRelatedField):
     queryset = models.Content.objects.all()
 
 
-class RepositoryRelatedField(serializers.HyperlinkedRelatedField):
+class HrefWritableRepositoryRelatedField(serializers.HyperlinkedRelatedField):
     """
-    A serializer field with the correct view_name and lookup_field to link to a repository.
+    A serializer field for a repository that is the parent in a nested relationship.
+    It has the href_writable field set so the repository is determined by url parameters.
+    read_only should passed as a kwarg to this field.
     """
     view_name = 'repositories-detail'
     lookup_field = 'name'
-    queryset = models.Repository.objects.all()
+    href_writable = True
 
 
 class FileField(serializers.CharField):

--- a/platform/pulpcore/app/serializers/repository.py
+++ b/platform/pulpcore/app/serializers/repository.py
@@ -5,7 +5,8 @@ from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
 
 from pulpcore.app import models
 from pulpcore.app.serializers import (MasterModelSerializer, ModelSerializer,
-                                      RepositoryRelatedField, GenericKeyValueRelatedField,
+                                      HrefWritableRepositoryRelatedField,
+                                      GenericKeyValueRelatedField,
                                       DetailWritableNestedUrlRelatedField,
                                       ContentRelatedField,
                                       FileField,
@@ -136,7 +137,7 @@ class ImporterSerializer(MasterModelSerializer, NestedHyperlinkedModelSerializer
         read_only=True
     )
 
-    repository = RepositoryRelatedField()
+    repository = HrefWritableRepositoryRelatedField(read_only=True)
 
     class Meta:
         abstract = True
@@ -163,7 +164,7 @@ class PublisherSerializer(MasterModelSerializer, NestedHyperlinkedModelSerialize
         help_text=_('Timestamp of the most recent update of the publisher configuration.'),
         read_only=True
     )
-    repository = RepositoryRelatedField()
+    repository = HrefWritableRepositoryRelatedField(read_only=True)
 
     auto_publish = serializers.BooleanField(
         help_text=_('An indicaton that the automatic publish may happen when'
@@ -217,6 +218,7 @@ class DistributionSerializer(ModelSerializer):
     publisher = DetailWritableNestedUrlRelatedField(
         parent_lookup_kwargs={'repository_name': 'repository__name'},
         lookup_field='name',
+        read_only=True
     )
 
     class Meta:
@@ -230,7 +232,11 @@ class RepositoryContentSerializer(serializers.ModelSerializer):
     # RepositoryContentSerizlizer should not have it's own _href, so it subclasses
     # rest_framework.serializers.ModelSerializer instead of pulpcore.app.serializers.ModelSerializer
     content = ContentRelatedField()
-    repository = RepositoryRelatedField()
+    repository = serializers.HyperlinkedRelatedField(
+        view_name='repositories-detail',
+        lookup_field='name',
+        queryset=models.Repository.objects.all()
+    )
 
     class Meta:
         model = models.RepositoryContent


### PR DESCRIPTION
The parent repo will now be determined by the url instead of by
request parameters.

closes #2985
https://pulp.plan.io/issues/2985