### PR TITLE
Stop ignoring PEP8 W391

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,7 +2,6 @@ pycodestyle:
     max-line-length: 100  # Default is 79 in PEP8
     ignore:  # Errors and warnings to ignore
         - E401 # multiple imports on one line
-        - W391 # blank line at the end of file (complains on empty __init__.py files)
     exclude:
         - "./docs/*"
         - "./playpen/*"

--- a/flake8.cfg
+++ b/flake8.cfg
@@ -1,6 +1,5 @@
 [flake8]
 exclude = ./docs/*, ./playpen/*, */build/*, */backports/*
 # E401: multiple imports on one line
-# W391: blank line at end of file (sadly, it will complain on empty __init__.py files)
-ignore = E401,W391
+ignore = E401
 max-line-length = 100


### PR DESCRIPTION
PEP8 seems to handle empty files just fine with regards to W391.