### PR TITLE
makemigrations explicitly

### DIFF
--- a/platform/pulpcore/app/db-reset.sh
+++ b/platform/pulpcore/app/db-reset.sh
@@ -27,6 +27,8 @@ python manage.py reset_db --noinput
 # in for the platform app, at which point we can declare this dependency in the
 # migration itself:
 # https://docs.djangoproject.com/en/1.8/topics/migrations/#dependencies
+python manage.py makemigrations pulp_file
+python manage.py makemigrations pulp_app
 python manage.py migrate --noinput auth
 python manage.py migrate --noinput
 python manage.py reset-admin-password --password admin


### PR DESCRIPTION
By explicitly making migrations for each app, we are able to work
around an issue where tables are created in the wrong order. This
is a temporary fix and will not be necessary once migrations are
committed to source control.

https://pulp.plan.io/issues/3012
closes #3012