### PR TITLE
Adds finalize() to BaseDownloader

### DIFF
--- a/plugin/pulpcore/plugin/download/asyncio/file.py
+++ b/plugin/pulpcore/plugin/download/asyncio/file.py
@@ -41,8 +41,7 @@ class FileDownloader(BaseDownloader):
             while True:
                 chunk = await f_handle.read(1024)
                 if not chunk:
-                    self.validate_size()
-                    self.validate_digests()
+                    self.finalize()
                     break  # the reading is done
                 self.handle_data(chunk)
             return DownloadResult(path=self._path, artifact_attributes=self.artifact_attributes,

--- a/plugin/pulpcore/plugin/download/asyncio/http.py
+++ b/plugin/pulpcore/plugin/download/asyncio/http.py
@@ -91,8 +91,7 @@ class HttpDownloader(BaseDownloader):
         while True:
             chunk = await response.content.read(1024)
             if not chunk:
-                self.validate_size()
-                self.validate_digests()
+                self.finalize()
                 break  # the download is done
             self.handle_data(chunk)
         return DownloadResult(path=self.path, artifact_attributes=self.artifact_attributes,


### PR DESCRIPTION
- reworks the file-object creation to be simpler
- adds finalize()
- switches FileDownloader, HttpDownloader to use it
- adds docs

https://pulp.plan.io/issues/2951
re #2951