### PR TITLE
UnicodeEncodeError in comments provided with SSL cert/key/CA

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -359,7 +359,7 @@ class Importer(AutoRetryDocument):
                 misc.mkdir(os.path.dirname(self._pki_path))
                 os.mkdir(self._pki_path, 0700)
             with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, 0600), 'w') as pem_file:
-                pem_file.write(self.config[config_key])
+                pem_file.write(self.config[config_key].encode('utf-8'))
 
 
 signals.pre_delete.connect(Importer.pre_delete, sender=Importer)
@@ -919,7 +919,7 @@ class FileContentUnit(ContentUnit):
         """
         try:
             self.import_content(path, location)
-        except:
+        except (ImportError, exceptions.PulpCodedException):
             self.clean_orphans()
             raise
 
@@ -1295,6 +1295,7 @@ class Distributor(AutoRetryDocument):
         :type document: Distributor
         """
         document.last_updated = dateutils.now_utc_datetime_with_tzinfo()
+
 
 signals.pre_save.connect(Distributor.pre_save_signal, sender=Distributor)
 

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -993,11 +993,11 @@ class TestImporter(unittest.TestCase):
                 importer.save()
 
                 with open(importer.tls_ca_cert_path) as ca_file:
-                    self.assertEqual(ca_file.read(), 'CA Cert')
+                    self.assertEqual(ca_file.read().decode('utf-8'), 'CA Cert')
                 with open(importer.tls_client_cert_path) as client_file:
-                    self.assertEqual(client_file.read(), 'Client Cert')
+                    self.assertEqual(client_file.read().decode('utf-8'), 'Client Cert')
                 with open(importer.tls_client_key_path) as key_file:
-                    self.assertEqual(key_file.read(), 'Client Key')
+                    self.assertEqual(key_file.read().decode('utf-8'), 'Client Key')
         finally:
             shutil.rmtree(temp_path)
         written_importer = model.Importer.objects.get(repo_id='coolcars')
@@ -1132,7 +1132,7 @@ class TestImporter(unittest.TestCase):
                 self.assertEqual(os.stat(importer.tls_ca_cert_path)[stat.ST_MODE],
                                  stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR)
                 with open(importer.tls_ca_cert_path) as ca_file:
-                    self.assertEqual(ca_file.read(), 'CA Cert')
+                    self.assertEqual(ca_file.read().decode('utf-8'), 'CA Cert')
         finally:
             shutil.rmtree(temp_path)
 
@@ -1159,7 +1159,7 @@ class TestImporter(unittest.TestCase):
                 self.assertEqual(os.stat(importer.tls_ca_cert_path)[stat.ST_MODE],
                                  stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR)
                 with open(importer.tls_ca_cert_path) as ca_file:
-                    self.assertEqual(ca_file.read(), 'CA Cert')
+                    self.assertEqual(ca_file.read().decode('utf-8'), 'CA Cert')
         finally:
             shutil.rmtree(temp_path)
 


### PR DESCRIPTION
This is an additional fix needed in Pulp apart from
https://github.com/pulp/nectar/pull/63, since Pulp writes
out the SSL certs to a different path than nectar

closes #2960