### PR TITLE
Mask logged password.

### DIFF
--- a/plugin/pulpcore/plugin/download/futures/settings.py
+++ b/plugin/pulpcore/plugin/download/futures/settings.py
@@ -141,9 +141,10 @@ class User(Settings):
 
     def __str__(self):
         description = _('User: name={n} password={p}')
+        password = '*' * len(self.password or '')
         return description.format(
             n=self.name,
-            p=self.password)
+            p=password)
 
 
 class Timeout(Settings):


### PR DESCRIPTION
https://pulp.plan.io/issues/3015

Masking the password is better than omitting it all together because it provides more information for troubleshooting.  Manly, that a password was specified vs. left blank.