### PR TITLE
Fix progress save() throttling.

### DIFF
--- a/platform/pulpcore/app/models/progress.py
+++ b/platform/pulpcore/app/models/progress.py
@@ -84,10 +84,10 @@ class ProgressReport(Model):
         if self._using_context_manager and self._last_save_time:
             if now - self._last_save_time >= datetime.timedelta(milliseconds=BATCH_INTERVAL):
                 super(ProgressReport, self).save(*args, **kwargs)
+                self._last_save_time = now
         else:
             super(ProgressReport, self).save(*args, **kwargs)
-
-        self._last_save_time = now
+            self._last_save_time = now
 
     def __enter__(self):
         """


### PR DESCRIPTION
https://pulp.plan.io/issues/3003

The `_last_save_time` was being updated even when not actually saved.  Calling save() repeatedly within 500 ms resulted the progress never actually getting saved.