### PR TITLE
Problem: GroupDownloader skips some downloads

### DIFF
--- a/plugin/pulpcore/plugin/download/asyncio/group.py
+++ b/plugin/pulpcore/plugin/download/asyncio/group.py
@@ -167,9 +167,9 @@ class GroupDownloader:
                                                      exception=error)
                 for group in self.urls[download_result.url]:
                     group.handle_download_result(download_result)
-                group = self._find_and_remove_done_group()
-                if group:
-                    return group
+            group = self._find_and_remove_done_group()
+            if group:
+                return group
         finished_group = self._find_and_remove_done_group()
         if finished_group:
             return finished_group


### PR DESCRIPTION
Solution: process all finished downloads before checking if any Group is done

closes #3021
https://pulp.plan.io/issues/3021