### PR TITLE
Pins pulp to DRF 3.6.4

### DIFF
--- a/platform/setup.py
+++ b/platform/setup.py
@@ -8,7 +8,7 @@ requirements = [
     'coreapi',
     'Django>=1.8,<2',
     'django-filter',
-    'djangorestframework',
+    'djangorestframework==3.6.4',
     'drf-nested-routers',
     'psycopg2',
     'PyYAML',


### PR DESCRIPTION
Pulp needs updates to be compatible with 3.7.0. This should be undone
with issue: https://pulp.plan.io/issues/3057

re #3057