### PR TITLE
Increase asyncio parallelization

### DIFF
--- a/plugin/pulpcore/plugin/download/asyncio/file.py
+++ b/plugin/pulpcore/plugin/download/asyncio/file.py
@@ -39,7 +39,7 @@ class FileDownloader(BaseDownloader):
         """
         with open(self._path, 'r') as f_handle:
             while True:
-                chunk = await f_handle.read(1024)
+                chunk = await f_handle.read(1024 * 1024)
                 if not chunk:
                     self.finalize()
                     break  # the reading is done

--- a/plugin/pulpcore/plugin/download/asyncio/group.py
+++ b/plugin/pulpcore/plugin/download/asyncio/group.py
@@ -74,7 +74,7 @@ class GroupDownloader:
         self.urls = defaultdict(list)  # dict with url as the key and a lists of Groups as the value
         self.loop = asyncio.get_event_loop()
 
-    def schedule_from_iterator(self, group_iterator, parallel_group_limit=50):
+    def schedule_from_iterator(self, group_iterator, parallel_group_limit=100):
         """
         Schedule groups to be downloaded using an iterator provided by the user.
 

--- a/plugin/pulpcore/plugin/download/asyncio/http.py
+++ b/plugin/pulpcore/plugin/download/asyncio/http.py
@@ -109,7 +109,7 @@ class HttpDownloader(BaseDownloader):
         if self.headers_ready_callback:
             self.headers_ready_callback(response.headers)
         while True:
-            chunk = await response.content.read(1024)
+            chunk = await response.content.read(1024 * 1024)
             if not chunk:
                 self.finalize()
                 break  # the download is done


### PR DESCRIPTION
The chunk size is a lot bigger, and increasing the default count of
downloaders in parallel for the group downloader.