### PR TITLE
Fix traceback on rapid dispatch of multiple syncs

### DIFF
--- a/platform/pulpcore/tasking/tasks.py
+++ b/platform/pulpcore/tasking/tasks.py
@@ -72,8 +72,8 @@ def _queue_reserved_task(name, inner_task_id, resource_id, inner_args, inner_kwa
     while True:
         # Find a worker who already has this reservation, it is safe to send this work to them
         try:
-            worker = ReservedResource.objects.get(resource=resource_id).worker
-        except ReservedResource.DoesNotExist:
+            worker = ReservedResource.objects.filter(resource=resource_id)[0].worker
+        except IndexError:
             pass
         else:
             break


### PR DESCRIPTION
We need to be using a queryset for ReservedResources, not "get()".

closes #3056
https://pulp.plan.io/issues/3056