### PR TITLE
Add REST API autodocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ django.setup()
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.extlinks', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary',
-              'napoleon_django', 'sphinx.ext.napoleon']
+              'napoleon_django', 'sphinx.ext.napoleon', 'sphinxcontrib.swaggerdoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/contributing/3.0-development/rest-api.rst
+++ b/docs/contributing/3.0-development/rest-api.rst
@@ -481,11 +481,10 @@ custom filter based on the `BaseInFilter`.
 Documenting
 -----------
 
-By default, the docstring of a ViewSet is used to generate that view's "description" value,
-which is what DRF presents to API users as that endpoint's documentation. Individual fields
-are documented largely automatically based on the Serializer field type, but using the "help_text"
-kwarg when defining serializer fields lets us add a user-friendly string that is then included
-in the API endpoint.
+By default, the docstring of a CRUD method on a ViewSet is used to generate that endpoint's
+description. Individual parameters and responses are documented largely automatically based
+on the Serializer field type, but using the "help_text" kwarg when defining serializer fields
+lets us add a user-friendly string that is then included in the API endpoint.
 
 ViewSets can override the ``get_view_description`` method to customize the source and formatting
 of the description field, if desired. Serializer fields should set their ``help_text`` value for
@@ -501,18 +500,14 @@ a browsable site of API docs, listed here:
 
 http://www.django-rest-framework.org/topics/documenting-your-api/#endpoint-documentation
 
-Between "DRF Docs" and "Django REST Swagger", DRF Docs exists to continue the functionality
-of Django REST Swagger, called "Django REST Docs". Being based on
-`Swagger <http://swagger.io>`_, Django REST Swagger give us access to a lot of handy
-API-related tools, including dynamic and static API documentation, and rudimentary client
-autogeneration.
+Because "DRF Docs" and "Django REST Swagger" do not generate documentation for responses,
+Pulp is generating its REST API with `drf-openapi <https://github.com/limdauto/drf_openapi/>`_
+until either DRF supports OpenAPI, or until CoreAPI supports response documentation.
 
-Additionally, the "coreapi" project (which can be used to dynamically generate API clients)
-supports generating OpenAPI schemas, which can be consumed by tools like ``swagger-codegen``
-to generate static API documentation, potentially alleviating the need to include DRF Docs
-or Django REST Swagger as a dependency:
+You can access the live REST API docs at `http://pulpserver/api/v3/docs/` by installing the
+pulpcore's doc_requirements.txt file::
 
-http://www.django-rest-framework.org/topics/api-clients/#codecs
+  $ pip3 install pulpcore/doc_requirements.txt
 
 
 Glossary

--- a/docs/integration_guide/rest_api/index.rst
+++ b/docs/integration_guide/rest_api/index.rst
@@ -5,3 +5,13 @@ REST API Reference
    :maxdepth: 3
 
    authentication
+
+
+pulpcore REST API
+-----------------
+
+Each instance of Pulp hosts dynamically generated API documentation located at `http://pulpserver/api/v3/docs/`
+if `drf_openapi` is installed. This documentation includes the installed pulp plugin endpoints and is a more
+complete version of the API documented below.
+
+.. swaggerv2doc:: http://localhost:8000/api/v3/docs/?format=openapi

--- a/docs/plugins/plugin-writer/basics.rst
+++ b/docs/plugins/plugin-writer/basics.rst
@@ -108,3 +108,29 @@ Non fatal exceptions should be recorded with the
 :meth:`~pulpcore.plugin.tasking.Task.append_non_fatal_error` method. These non-fatal exceptions
 will be returned in a :attr:`~pulpcore.app.models.Task.non_fatal_errors` attribute on the resulting
 :class:`~pulpcore.app.models.Task` object.
+
+
+Documenting your API
+--------------------
+
+Each instance of Pulp optionally hosts dynamically generated API documentation located at
+`http://pulpserver/api/v3/docs/` if you install `drf-openapi <https://github.com/limdauto/drf_openapi/>`_.
+
+The API endpoint description is generated from the docstring on the CRUD methods on a ViewSet.
+
+Individual parameters and responses are documented automatically based on the Serializer field type.
+A field's description is generated from the "help_text" kwarg when defining serializer fields.
+
+Response status codes can be generated through the `Meta` class on the serializer:
+
+.. code-block:: python
+
+    from rest_framework.status import HTTP_400_BAD_REQUEST
+
+    class SnippetSerializerV1(serializers.Serializer):
+        title = serializers.CharField(required=False, allow_blank=True, max_length=100)
+
+        class Meta:
+            error_status_codes = {
+                HTTP_400_BAD_REQUEST: 'Bad Request'
+            }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ psycopg2
 celery
 coreapi
 drf-nested-routers
+sphinxcontrib-swaggerdoc

--- a/pulpcore/doc_requirements.txt
+++ b/pulpcore/doc_requirements.txt
@@ -1,0 +1,1 @@
+-e git+https://github.com/limdauto/drf_openapi.git@54d24fb#egg=drf_openapi

--- a/pulpcore/pulpcore/apidocs/views.py
+++ b/pulpcore/pulpcore/apidocs/views.py
@@ -1,0 +1,29 @@
+from rest_framework import response, permissions
+from drf_openapi.views import SchemaView
+from drf_openapi.entities import OpenApiSchemaGenerator
+
+
+class DocView(SchemaView):
+    """
+    REST API live documentation endpoint.
+
+    Subclasses drf_openapi.views.SchemaView to provide a publicly accessible
+    REST API documentation endpoint.
+    """
+
+    permission_classes = (permissions.AllowAny,)
+
+    def get(self, request, version):
+        """
+        Override to mark schemas as public.
+
+        :param request:
+        :param version:
+        :return:
+        """
+        generator = OpenApiSchemaGenerator(
+            version=version,
+            url=self.url,
+            title=self.title
+        )
+        return response.Response(generator.get_schema(request, public=True))

--- a/pulpcore/pulpcore/app/urls.py
+++ b/pulpcore/pulpcore/app/urls.py
@@ -1,8 +1,11 @@
 """pulp URL Configuration"""
+from contextlib import suppress
+from importlib import import_module
+
 from django.conf.urls import url, include
+
 from rest_framework.schemas import get_schema_view
 from rest_framework_nested import routers
-
 from rest_framework_jwt.views import obtain_jwt_token
 
 from pulpcore.app.apps import pulp_plugin_configs
@@ -113,6 +116,13 @@ urlpatterns = [
     url(r'^api/v3/status/', StatusView.as_view()),
     url(r'^api/v3/jwt/', obtain_jwt_token),
 ]
+
+# if drf_openapi is installed add live docs route
+with suppress(ImportError):
+    import_module('drf_openapi')
+    from pulpcore.apidocs.views import DocView
+    urlpatterns.append(url(r'^api/(?P<version>(v3))/docs/',
+                           DocView.as_view(title='Pulp API Docs'), name='api_schema'))
 
 schema_view = get_schema_view(title='Pulp API')
 


### PR DESCRIPTION
- [x] drf_openapi permissions fix https://github.com/limdauto/drf_openapi/pull/48/commits/0fe66013e4b0b28e5be36e56839796e595ad0a1c
- [x] sphinxcontrib-swaggerdoc response generation fix https://github.com/unaguil/sphinx-swaggerdoc/pull/16
- [x] drf_openapi drf 3.7 compat fix https://github.com/limdauto/drf_openapi/pull/77 <- this will fix the travis failure
- [x] drf_openapi public versions fix https://github.com/limdauto/drf_openapi/pull/79
~~drf_openapi new PyPI release with ^ fixes~~ <- done with optional dep
~~update jjb jobs to separate pulp3 and pulp2 doc builds~~ <- do after merge to avoid building all the doc builder scaffolding 
~~update jjb jobs to separate pulp3 and pulp2 pr-doc builds~~