### PR TITLE
Fix the api schema route

### DIFF
--- a/platform/pulpcore/app/urls.py
+++ b/platform/pulpcore/app/urls.py
@@ -114,10 +114,10 @@ urlpatterns = [
     url(r'^api/v3/jwt/', obtain_jwt_token),
 ]
 
+schema_view = get_schema_view(title='Pulp API')
+
+urlpatterns.append(url(r'^api/v3/$', schema_view))
+
 all_routers = [root_router] + vs_tree.register_with(root_router)
 for router in all_routers:
     urlpatterns.append(url(r'^api/v3/', include(router.urls)))
-
-schema_view = get_schema_view(title='Pulp API')
-
-urlpatterns.append(url(r'^api/v3/', schema_view))


### PR DESCRIPTION
The issue was that we were mapping all `/api/v3/*` routes to the api schema which meant that all routes that didn't match another route displayed the api schema. 

It also caused some weird behaviors where we saw some 406s instead of 404. 

I also needed to move the route above the other routers because they assigned `/api/v3/` to a route which returns a list of resources.

fixes #3063
https://pulp.plan.io/issues/3063