### PR TITLE
Add uniquenessand length validators to serializer fields.

### DIFF
--- a/platform/pulpcore/app/models/auth.py
+++ b/platform/pulpcore/app/models/auth.py
@@ -9,7 +9,6 @@ import random
 from gettext import gettext as _
 
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
-from django.core import validators
 from django.db import models
 
 
@@ -56,13 +55,6 @@ class User(AbstractBaseUser, PermissionsMixin):
         verbose_name=_('username'),
         max_length=150,
         unique=True,
-        validators=[
-            validators.RegexValidator(
-                r'^[\w.@+-]+$',
-                _('Enter a valid username. This value may contain only letters, numbers '
-                  'and @/./+/-/_ characters.'),
-                'invalid'),
-        ],
         error_messages={
             'unique': _("A user with that username already exists.")
         }

--- a/platform/pulpcore/app/serializers/consumer.py
+++ b/platform/pulpcore/app/serializers/consumer.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 
 from rest_framework import serializers
+from rest_framework.validators import UniqueValidator
 
 from pulpcore.app import models
 from pulpcore.app.serializers import GenericKeyValueRelatedField, ModelSerializer
@@ -13,7 +14,8 @@ class ConsumerSerializer(ModelSerializer):
     )
 
     name = serializers.CharField(
-        help_text=_("The consumer common name.")
+        help_text=_("The consumer common name."),
+        validators=[UniqueValidator(queryset=models.Consumer.objects.all())]
     )
 
     description = serializers.CharField(


### PR DESCRIPTION
Move username regex validator from model to serializer, since the model validation
does not run automatically on model save:
https://docs.djangoproject.com/en/dev/ref/validators/#how-validators-are-run

closes #2984
https://pulp.plan.io/issues/2984