### PR TITLE
Fix exception when deleting consumer

### DIFF
--- a/server/pulp/server/agent/direct/pulpagent.py
+++ b/server/pulp/server/agent/direct/pulpagent.py
@@ -122,7 +122,12 @@ class Consumer(object):
                 authenticator=context.authenticator,
                 wait=0)
             consumer = agent.Consumer()
-            consumer.unregister()
+            try:
+                consumer.unregister()
+            except NotFound:
+                # cover the case where cleanup may find that the queue
+                # has already been deleted
+                pass
 
     @staticmethod
     def bind(context, bindings, options):


### PR DESCRIPTION
Fix NotFound exception if consumer is deleted when
its queue is gone.

closes #3069
https://pulp.plan.io/issues/3069