### PR TITLE
Create a new jwt reset endpoint instead of a user field

### DIFF
--- a/docs/integration_guide/rest_api/authentication.rst
+++ b/docs/integration_guide/rest_api/authentication.rst
@@ -86,7 +86,14 @@ To achieve ability to invalidate all user's tokens each user have their own secr
 used to sign their tokens. The change of the secret will lead to invalidation of all user's
 tokens. The change is independent on password.
 
-You can reset user secret to random by setting ``reset_jwt_secret`` on user API endpoint to True.
+You can reset user secret to random by calling the jwt reset endpoint:
+
+
+ * **method:** ``post``
+ * **path:** ``api/v3/users/<username>/jwt_reset/``
+ * response list:
+    * **code:** ``200`` - jwt reset
+    * **code:** ``400`` - invalid credentials
 
 If you have enabled ``JWT_AUTH.JWT_ALLOW_SETTING_USER_SECRET`` you can set the user's secret
 via user API endpoint.

--- a/platform/pulpcore/app/models/auth.py
+++ b/platform/pulpcore/app/models/auth.py
@@ -88,3 +88,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         :rtype: str
         """
         return self.get_full_name()
+
+    def jwt_reset(self):
+        self.jwt_secret = gen_random_jwt_secret()
+        self.save()

--- a/platform/pulpcore/app/serializers/user.py
+++ b/platform/pulpcore/app/serializers/user.py
@@ -70,12 +70,6 @@ class UserSerializer(ModelSerializer):
         ],
     )
 
-    reset_jwt_secret = serializers.BooleanField(
-        help_text=_("Reset user JWT secret."),
-        required=False,
-        write_only=True,
-    )
-
     def __init__(self, *args, **kwargs):
         """
         Remove ability to read/set jwt_secret if disabled in settings.
@@ -85,15 +79,7 @@ class UserSerializer(ModelSerializer):
         if not settings.JWT_AUTH.get("JWT_ALLOW_SETTING_USER_SECRET"):
             self.fields.pop('jwt_secret')
 
-    def validate(self, data):
-        """
-        If reset_jwt_secret is True generate user random jwt secret.
-        """
-        if data["reset_jwt_secret"]:
-            data["jwt_secret"] = User.gen_random_jwt_secret()
-        return data
-
     class Meta:
         model = User
         fields = ModelSerializer.Meta.fields + (
-            'username', 'is_superuser', 'password', 'jwt_secret', 'reset_jwt_secret')
+            'username', 'is_superuser', 'password', 'jwt_secret')

--- a/platform/pulpcore/app/viewsets/user.py
+++ b/platform/pulpcore/app/viewsets/user.py
@@ -1,3 +1,6 @@
+from rest_framework import decorators
+from rest_framework.response import Response
+
 from pulpcore.app.models import User
 from pulpcore.app.serializers import UserSerializer
 from pulpcore.app.viewsets import NamedModelViewSet
@@ -8,3 +11,10 @@ class UserViewSet(NamedModelViewSet):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     lookup_field = 'username'
+
+    @decorators.detail_route(methods=('post',))
+    def jwt_reset(self, request, username):
+        user = self.get_object()
+        user.jwt_reset()
+        serializer = self.get_serializer(user)
+        return Response(serializer.data)


### PR DESCRIPTION
Creating a new endpoint for resetting jwts instead of having a field on
user to reset them. This also fixes user creation which is currently
broken.

fixes #3075
https://pulp.plan.io/issues/3075