### PR TITLE
Problem: async update and delete code is duplicated

### DIFF
--- a/pulpcore/pulpcore/app/apps.py
+++ b/pulpcore/pulpcore/app/apps.py
@@ -94,11 +94,13 @@ class PulpPluginAppConfig(apps.AppConfig):
     def import_viewsets(self):
         # circular import avoidance
         from pulpcore.app.viewsets import (GenericNamedModelViewSet, NamedModelViewSet,
-                                           CreateDestroyReadNamedModelViewSet)
+                                           CreateDestroyReadNamedModelViewSet,
+                                           CreateReadAsyncUpdateDestroyNamedModelViewset)
         # These viewsets are used as base classes for actual model viewsets and
         # should not be registered
         base_viewsets = [GenericNamedModelViewSet, NamedModelViewSet,
-                         CreateDestroyReadNamedModelViewSet]
+                         CreateDestroyReadNamedModelViewSet,
+                         CreateReadAsyncUpdateDestroyNamedModelViewset]
         self.named_viewsets = {}
         if module_has_submodule(self.module, VIEWSETS_MODULE_NAME):
             # import the viewsets module and track any interesting viewsets

--- a/pulpcore/pulpcore/app/tasks/__init__.py
+++ b/pulpcore/pulpcore/app/tasks/__init__.py
@@ -1,1 +1,1 @@
-from pulpcore.app.tasks import importer, orphan, publisher, repository  # noqa
+from pulpcore.app.tasks import base, importer, orphan, publisher, repository  # noqa

--- a/pulpcore/pulpcore/app/tasks/base.py
+++ b/pulpcore/pulpcore/app/tasks/base.py
@@ -1,0 +1,56 @@
+from celery import shared_task
+from django.http import QueryDict
+
+from pulpcore.tasking.tasks import UserFacingTask
+from pulpcore.app.apps import get_plugin_config
+
+
+@shared_task(base=UserFacingTask)
+def general_update(instance_id, app_label, serializer_name, *args, **kwargs):
+    """
+    Update a model
+
+    The model instance is identified using the app_label, id, and serializer name. The serializer is
+    used to perform validation.
+
+    Args:
+        id (str): the id of the model
+        app_label (str): the Django app label of the plugin that provides the model
+        serializer_name (str): name of the serializer class for the model
+        data (dict): dictionary whose keys represent the fields of the model and their corresponding
+            values.
+        partial (bool): When true, only the fields specified in the data dictionary are updated.
+            When false, any fields missing from the data dictionary are assumed to be None and
+            their values are updated as such.
+
+    Raises:
+        :class:`rest_framework.exceptions.ValidationError`: When serializer instance can't be saved
+            due to validation error. This theoretically should never occur since validation is
+            performed before the task is dispatched.
+    """
+    data = kwargs.pop('data', None)
+    partial = kwargs.pop('partial', False)
+    serializer_class = get_plugin_config(app_label).named_serializers[serializer_name]
+    instance = serializer_class.Meta.model.objects.get(id=instance_id).cast()
+    data_querydict = QueryDict('', mutable=True)
+    data_querydict.update(data)
+    serializer = serializer_class(instance, data=data_querydict, partial=partial)
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+
+
+@shared_task(base=UserFacingTask)
+def general_delete(instance_id, app_label, serializer_name):
+    """
+    Delete a model
+
+    The model instance is identified using the app_label, id, and serializer name.
+
+    Args:
+        id (str): the id of the model
+        app_label (str): the Django app label of the plugin that provides the model
+        serializer_name (str): name of the serializer class for the model
+    """
+    serializer_class = get_plugin_config(app_label).named_serializers[serializer_name]
+    instance = serializer_class.Meta.model.objects.get(id=instance_id).cast()
+    instance.delete()

--- a/pulpcore/pulpcore/app/tasks/importer.py
+++ b/pulpcore/pulpcore/app/tasks/importer.py
@@ -2,55 +2,13 @@ from gettext import gettext as _
 import logging
 
 from celery import shared_task
-from django.http import QueryDict
 
 from pulpcore.app import models
-from pulpcore.app.apps import get_plugin_config
 from pulpcore.tasking.services import storage
 from pulpcore.tasking.tasks import UserFacingTask
 
 
 log = logging.getLogger(__name__)
-
-
-@shared_task(base=UserFacingTask)
-def update(importer_pk, app_label, serializer_name, data=None, partial=False):
-    """
-    Update an :class:`~pulp.app.models.Importer`
-
-    Args:
-        importer_pk (str): the PK of the importer
-        app_label (str): the Django app label of the plugin that provides the importer
-        serializer_name (str): name of the serializer class for the importer
-        data (dict): dictionary whose keys represent the fields of the importer that need to be
-            updated with the corresponding values.
-        partial (bool): When true, only the fields specified in the data dictionary are updated.
-            When false, any fields missing from the data dictionary are assumed to be None and
-            their values are updated as such.
-
-    Raises:
-        :class:`rest_framework.exceptions.ValidationError`: When serializer instance can't be saved
-            due to validation error. This theoretically should never occur since validation is
-            performed before the task is dispatched.
-    """
-    importer = models.Importer.objects.get(pk=importer_pk).cast()
-    data_querydict = QueryDict('', mutable=True)
-    data_querydict.update(data or {})
-    serializer_class = get_plugin_config(app_label).named_serializers[serializer_name]
-    serializer = serializer_class(importer, data=data_querydict, partial=partial)
-    serializer.is_valid(raise_exception=True)
-    serializer.save()
-
-
-@shared_task(base=UserFacingTask)
-def delete(importer_pk):
-    """
-    Delete an :class:`~pulpcore.app.models.Importer`
-
-    Args:
-        importer_pk (str): the PK of the importer
-    """
-    models.Importer.objects.filter(pk=importer_pk).delete()
 
 
 @shared_task(base=UserFacingTask)

--- a/pulpcore/pulpcore/app/viewsets/__init__.py
+++ b/pulpcore/pulpcore/app/viewsets/__init__.py
@@ -1,5 +1,6 @@
 from pulpcore.app.viewsets.base import (GenericNamedModelViewSet, NamedModelViewSet,  # noqa
-                                        CreateDestroyReadNamedModelViewSet)  # noqa
+                                        CreateDestroyReadNamedModelViewSet,
+                                        CreateReadAsyncUpdateDestroyNamedModelViewset)  # noqa
 from pulpcore.app.viewsets.content import ArtifactViewSet, ContentViewSet  # noqa
 from pulpcore.app.viewsets.repository import (DistributionViewSet,  # noqa
                                               ImporterViewSet,


### PR DESCRIPTION
Solution: add general update and delete tasks and viewsets

This patch creates two new tasks that are used by both the publisher viewset and the importer viewset.
This patch also introduces a new base viewset. Both the importer and publisher viewset inherit from it.

closes #3038
https://pulp.plan.io/issues/3038