### PR TITLE
Problem: repository URI is mutable

### DIFF
--- a/pulpcore/pulpcore/app/serializers/fields.py
+++ b/pulpcore/pulpcore/app/serializers/fields.py
@@ -23,7 +23,6 @@ class HrefWritableRepositoryRelatedField(serializers.HyperlinkedRelatedField):
     read_only should passed as a kwarg to this field.
     """
     view_name = 'repositories-detail'
-    lookup_field = 'name'
     href_writable = True
 
 

--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -21,11 +21,8 @@ from rest_framework_nested.relations import (NestedHyperlinkedRelatedField,
 
 
 class RepositorySerializer(ModelSerializer):
-    # _href is normally provided by the base class, but Repository's
-    # "name" lookup field means _href must be explicitly declared.
     _href = serializers.HyperlinkedIdentityField(
-        view_name='repositories-detail',
-        lookup_field='name',
+        view_name='repositories-detail'
     )
     name = serializers.CharField(
         help_text=_('A unique name for this repository.'),
@@ -51,16 +48,15 @@ class RepositorySerializer(ModelSerializer):
         required=False
     )
     importers = DetailNestedHyperlinkedRelatedField(many=True, read_only=True,
-                                                    parent_lookup_kwargs={'repository_name':
-                                                                          'repository__name'},
+                                                    parent_lookup_kwargs={'repository_pk':
+                                                                          'repository__pk'},
                                                     lookup_field='name')
     publishers = DetailNestedHyperlinkedRelatedField(many=True, read_only=True,
-                                                     parent_lookup_kwargs={'repository_name':
-                                                                           'repository__name'},
+                                                     parent_lookup_kwargs={'repository_pk':
+                                                                           'repository__pk'},
                                                      lookup_field='name')
     content = serializers.HyperlinkedIdentityField(
         view_name='repositories-content',
-        lookup_field='name'
     )
 
     content_summary = serializers.DictField(
@@ -82,7 +78,7 @@ class ImporterSerializer(MasterModelSerializer, NestedHyperlinkedModelSerializer
     class. Please import from `pulpcore.plugin.serializers` rather than from this module directly.
     """
     _href = DetailNestedHyperlinkedIdentityField(
-        lookup_field='name', parent_lookup_kwargs={'repository_name': 'repository__name'},
+        lookup_field='name', parent_lookup_kwargs={'repository_pk': 'repository__pk'},
     )
     name = serializers.CharField(
         help_text=_('A name for this importer, unique within the associated repository.')
@@ -172,7 +168,7 @@ class PublisherSerializer(MasterModelSerializer, NestedHyperlinkedModelSerialize
     class. Please import from `pulpcore.plugin.serializers` rather than from this module directly.
     """
     _href = DetailNestedHyperlinkedIdentityField(
-        lookup_field='name', parent_lookup_kwargs={'repository_name': 'repository__name'},
+        lookup_field='name', parent_lookup_kwargs={'repository_pk': 'repository__pk'},
     )
     name = serializers.CharField(
         help_text=_('A name for this publisher, unique within the associated repository.')
@@ -196,7 +192,7 @@ class PublisherSerializer(MasterModelSerializer, NestedHyperlinkedModelSerialize
         many=True,
         read_only=True,
         parent_lookup_kwargs={'publisher_name': 'publisher__name',
-                              'repository_name': 'publisher__repository__name'},
+                              'repository_pk': 'publisher__repository__pk'},
         view_name='distributions-detail',
         lookup_field='name'
     )
@@ -218,7 +214,7 @@ class PublisherSerializer(MasterModelSerializer, NestedHyperlinkedModelSerialize
 class DistributionSerializer(ModelSerializer):
     _href = NestedHyperlinkedIdentityField(
         lookup_field='name',
-        parent_lookup_kwargs={'repository_name': 'publisher__repository__name',
+        parent_lookup_kwargs={'repository_pk': 'publisher__repository__pk',
                               'publisher_name': 'publisher__name'},
         view_name='distributions-detail'
     )
@@ -251,7 +247,7 @@ class DistributionSerializer(ModelSerializer):
         help_text=_('The publication is distributed using HTTPS.')
     )
     publisher = DetailWritableNestedUrlRelatedField(
-        parent_lookup_kwargs={'repository_name': 'repository__name'},
+        parent_lookup_kwargs={'repository_pk': 'repository__pk'},
         lookup_field='name',
         read_only=True
     )
@@ -271,7 +267,6 @@ class RepositoryContentSerializer(ModelSerializer):
     content = ContentRelatedField()
     repository = serializers.HyperlinkedRelatedField(
         view_name='repositories-detail',
-        lookup_field='name',
         queryset=models.Repository.objects.all()
     )
 

--- a/pulpcore/pulpcore/app/tests/viewsets/test_base.py
+++ b/pulpcore/pulpcore/app/tests/viewsets/test_base.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from django.test import TestCase
 
 from pulpcore.app import models, viewsets
@@ -9,11 +11,12 @@ class TestGetQuerySet(TestCase):
         Using ImporterViewSet as an example, tests to make sure the correct lookup
         is being added to the queryset based on its "parent_lookup_kwargs" value.
         """
+        pk = uuid4()
         viewset = viewsets.ImporterViewSet()
-        viewset.kwargs = {'repository_name': 'foo'}
+        viewset.kwargs = {'repository_pk': pk}
         queryset = viewset.get_queryset()
 
-        expected = models.Importer.objects.filter(repository__name='foo')
+        expected = models.Importer.objects.filter(repository__pk=pk)
 
         self.assertQuerysetEqual(queryset, expected)
 

--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -27,20 +27,19 @@ class RepositoryViewSet(NamedModelViewSet):
     queryset = Repository.objects.all()
     serializer_class = RepositorySerializer
     endpoint_name = 'repositories'
-    lookup_field = 'name'
     router_lookup = 'repository'
     pagination_class = NamePagination
     filter_class = RepositoryFilter
 
     @decorators.detail_route()
-    def content(self, request, name):
+    def content(self, request, pk):
         repo = self.get_object()
         paginator = UUIDPagination()
         page = paginator.paginate_queryset(repo.content, request)
         serializer = ContentSerializer(page, many=True, context={'request': request})
         return paginator.get_paginated_response(serializer.data)
 
-    def update(self, request, name, partial=False):
+    def update(self, request, pk, partial=False):
         """
         Generates a Task to update a :class:`~pulpcore.app.models.Repository`
         """
@@ -55,7 +54,7 @@ class RepositoryViewSet(NamedModelViewSet):
         )
         return OperationPostponedResponse([async_result], request)
 
-    def destroy(self, request, name):
+    def destroy(self, request, pk):
         """
         Generates a Task to delete a :class:`~pulpcore.app.models.Repository`
         """
@@ -121,7 +120,7 @@ class ImporterViewSet(NamedModelViewSet):
     router_lookup = 'importer'
     lookup_field = 'name'
     parent_viewset = RepositoryViewSet
-    parent_lookup_kwargs = {'repository_name': 'repository__name'}
+    parent_lookup_kwargs = {'repository_pk': 'repository__pk'}
     serializer_class = ImporterSerializer
     queryset = Importer.objects.all()
     filter_class = ImporterFilter
@@ -164,7 +163,7 @@ class PublisherViewSet(NamedModelViewSet):
     lookup_field = 'name'
     parent_viewset = RepositoryViewSet
     router_lookup = 'publisher'
-    parent_lookup_kwargs = {'repository_name': 'repository__name'}
+    parent_lookup_kwargs = {'repository_pk': 'repository__pk'}
     serializer_class = PublisherSerializer
     queryset = Publisher.objects.all()
     filter_class = PublisherFilter
@@ -210,7 +209,7 @@ class DistributionViewSet(NamedModelViewSet):
     nest_prefix = 'publishers'
     parent_viewset = PublisherViewSet
     parent_lookup_kwargs = {'publisher_name': 'publisher__name',
-                            'repository_name': 'publisher__repository__name'}
+                            'repository_pk': 'publisher__repository__pk'}
 
 
 class RepositoryContentViewSet(NamedModelViewSet):


### PR DESCRIPTION
Solution: use repository id in the URL instead of name

This patch switches repository URI from `/api/v3/repositories/<name>/` to
`/api/v3/repositories/<pk>/`.

closes #3101
https://pulp.plan.io/issues/3101