### PR TITLE
Fix importer update and sync; publisher update and publish.

### DIFF
--- a/pulpcore/pulpcore/app/tasks/publisher.py
+++ b/pulpcore/pulpcore/app/tasks/publisher.py
@@ -16,66 +16,64 @@ log = getLogger(__name__)
 
 
 @shared_task(base=UserFacingTask)
-def update(publisher_id, app_label, serializer_name, data=None, partial=False):
+def update(publisher_pk, app_label, serializer_name, data=None, partial=False):
     """
     Update an instance of a :class:`~pulpcore.app.models.Publisher`
 
     Args:
-        publisher_id (str): id of the publisher instance
+        publisher_pk (str): The publisher PK.
         app_label (str): the Django app label of the plugin that provides the publisher
         serializer_name (str): name of the serializer class for this publisher
         data (dict): Data to update on the publisher. keys are field names, values are new values.
         partial (bool): When true, update only the specified fields. When false, omitted fields
             are set to None.
+
     Raises:
         :class:`rest_framework.exceptions.ValidationError`: When serializer instance can't be saved
             due to validation error. This theoretically should never occur since validation is
             performed before the task is dispatched.
     """
-    instance = models.Publisher.objects.get(id=publisher_id).cast()
+    publisher = models.Publisher.objects.get(pk=publisher_pk).cast()
     data_querydict = QueryDict("", mutable=True)
-    data_querydict.update(data)
+    data_querydict.update(data or {})
     # The publisher serializer class is different for each plugin
     serializer_class = get_plugin_config(app_label).named_serializers[serializer_name]
-    serializer = serializer_class(instance, data=data_querydict, partial=partial)
+    serializer = serializer_class(publisher, data=data_querydict, partial=partial)
     serializer.is_valid(raise_exception=True)
     serializer.save()
 
 
 @shared_task(base=UserFacingTask)
-def delete(repo_name, publisher_name):
+def delete(publisher_pk):
     """
     Delete a :class:`~pulpcore.app.models.Publisher`
 
-    :param repo_name:       the name of a repository
-    :type  repo_name:       str
-    :param publisher_name:  the name of a publisher
-    :type  publisher_name:  str
+    Args:
+        publisher_pk (str): The publisher PK.
     """
-    models.Publisher.objects.filter(name=publisher_name, repository__name=repo_name).delete()
+    models.Publisher.objects.filter(pk=publisher_pk).delete()
 
 
 @shared_task(base=UserFacingTask)
-def publish(repo_name, publisher_name):
+def publish(publisher_pk):
     """
     Call publish on the publisher defined by a plugin.
 
-    A working directory is prepared, the plugin's publish is called, and then working directory is
-    removed.
+    A working directory is prepared, the plugin's publish is called, and then
+    working directory is removed.
 
     Args:
-        repo_name (str): unique name to specify the repository.
-        publisher_name (str): name to specify the Publisher.
+        publisher_pk (str): The publisher PK.
     """
-    publisher = models.Publisher.objects.get(
-        name=publisher_name,
-        repository__name=repo_name).cast()
-    log.warn(
-        _('Publishing: repository=%(r)s, publisher=%(p)s'),
+    publisher = models.Publisher.objects.get(pk=publisher_pk).cast()
+
+    log.info(
+        _('Publishing: repository=%(repository)s, publisher=%(publisher)s'),
         {
-            'r': repo_name,
-            'p': publisher_name
+            'repository': publisher.repository.name,
+            'publisher': publisher.name
         })
+
     with transaction.atomic():
         publication = models.Publication(publisher=publisher)
         publisher.publication = publication
@@ -89,10 +87,9 @@ def publish(repo_name, publisher_name):
                     publisher=publisher,
                     auto_updated=True)
                 distributions.update(publication=publication)
-    log.warn(
-        _('Publication: %(p)s created'),
-        {
-            'p': publication.pk
-        })
 
-    # TODO: Replace WARN w/ INFO or DEBUG.
+    log.info(
+        _('Publication: %(publication)s created'),
+        {
+            'publication': publication.pk
+        })

--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -125,34 +125,35 @@ class ImporterViewSet(NamedModelViewSet):
     queryset = Importer.objects.all()
     filter_class = ImporterFilter
 
-    def update(self, request, repository_name, name, partial=False):
+    def update(self, request, repository_pk, name, partial=False):
         importer = self.get_object()
         serializer = self.get_serializer(importer, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         app_label = importer._meta.app_label
         async_result = tasks.importer.update.apply_async_with_reservation(
-            tags.RESOURCE_REPOSITORY_TYPE, repository_name,
-            args=(importer.id, app_label, serializer.__class__.__name__),
-            kwargs={'data': request.data, 'partial': partial}
+            tags.RESOURCE_REPOSITORY_TYPE, repository_pk,
+            kwargs={'importer_pk': importer.pk,
+                    'app_label': app_label,
+                    'serializer_name': serializer.__class__.__name__,
+                    'data': request.data,
+                    'partial': partial}
         )
         return OperationPostponedResponse([async_result], request)
 
-    def destroy(self, request, repository_name, name):
+    def destroy(self, request, repository_pk, name):
         importer = self.get_object()
         async_result = tasks.importer.delete.apply_async_with_reservation(
-            tags.RESOURCE_REPOSITORY_TYPE, repository_name,
-            kwargs={'repo_name': repository_name,
-                    'importer_name': importer.name}
+            tags.RESOURCE_REPOSITORY_TYPE, repository_pk,
+            kwargs={'importer_pk': importer.pk}
         )
         return OperationPostponedResponse([async_result], request)
 
     @decorators.detail_route(methods=('post',))
-    def sync(self, request, repository_name, name):
+    def sync(self, request, repository_pk, name):
         importer = self.get_object()
         async_result = tasks.importer.sync.apply_async_with_reservation(
-            tags.RESOURCE_REPOSITORY_TYPE, repository_name,
-            kwargs={'repo_name': repository_name,
-                    'importer_name': importer.name}
+            tags.RESOURCE_REPOSITORY_TYPE, repository_pk,
+            kwargs={'importer_pk': importer.pk}
         )
         return OperationPostponedResponse([async_result], request)
 
@@ -168,35 +169,36 @@ class PublisherViewSet(NamedModelViewSet):
     queryset = Publisher.objects.all()
     filter_class = PublisherFilter
 
-    def update(self, request, repository_name, name, partial=False):
-        instance = self.get_object()
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+    def update(self, request, repository_pk, name, partial=False):
+        publisher = self.get_object()
+        serializer = self.get_serializer(publisher, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
-        app_label = instance._meta.app_label
+        app_label = publisher._meta.app_label
         async_result = tasks.publisher.update.apply_async_with_reservation(
-            tags.RESOURCE_REPOSITORY_TYPE, repository_name,
-            args=(instance.id, app_label, serializer.__class__.__name__),
-            kwargs={'data': request.data, 'partial': partial}
+            tags.RESOURCE_REPOSITORY_TYPE, repository_pk,
+            kwargs={'publisher_pk': publisher.pk,
+                    'app_label': app_label,
+                    'serializer_name': serializer.__class__.__name__,
+                    'data': request.data,
+                    'partial': partial}
         )
         return OperationPostponedResponse([async_result], request)
 
-    def destroy(self, request, repository_name, name):
+    def destroy(self, request, repository_pk, name):
         publisher = self.get_object()
         async_result = tasks.publisher.delete.apply_async_with_reservation(
-            tags.RESOURCE_REPOSITORY_TYPE, repository_name,
-            kwargs={'repo_name': repository_name,
-                    'publisher_name': publisher.name}
+            tags.RESOURCE_REPOSITORY_TYPE, repository_pk,
+            kwargs={'publisher_pk': publisher.pk}
         )
 
         return OperationPostponedResponse([async_result], request)
 
     @decorators.detail_route(methods=('post',))
-    def publish(self, request, repository_name, name):
+    def publish(self, request, repository_pk, name):
         publisher = self.get_object()
         async_result = tasks.publisher.publish.apply_async_with_reservation(
-            tags.RESOURCE_REPOSITORY_TYPE, repository_name,
-            kwargs={'repo_name': repository_name,
-                    'publisher_name': publisher.name}
+            tags.RESOURCE_REPOSITORY_TYPE, repository_pk,
+            kwargs={'publisher_pk': publisher.pk}
         )
         return OperationPostponedResponse([async_result], request)
 


### PR DESCRIPTION
https://pulp.plan.io/issues/3138?next_issue_id=3137

Changes:
- Aligns task arguments with calls from viewsets.
- Passes task arguments as kwargs for consistency and readability.
- Update task arguments to be based on PKs.  More will be needed when importer/publisher URLs concerted to PKs.

