### PR TITLE
UnicodeEncodeError in comments provided with SSL cert/key/CA

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -359,7 +359,10 @@ class Importer(AutoRetryDocument):
                 misc.mkdir(os.path.dirname(self._pki_path))
                 os.mkdir(self._pki_path, 0700)
             with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, 0600), 'w') as pem_file:
-                pem_file.write(self.config[config_key].encode('utf-8'))
+                if type(self.config[config_key]) is unicode:
+                    pem_file.write(self.config[config_key].encode('utf-8'))
+                else:
+                    pem_file.write(self.config[config_key])
 
 
 signals.pre_delete.connect(Importer.pre_delete, sender=Importer)


### PR DESCRIPTION
As Python by default decodes objects as 'ascii', a decoding error
was being raised in Satellite. This is a hotfix to resolve that.