### PR TITLE
Add repo_id index to applicability collection

### DIFF
--- a/server/pulp/server/db/model/consumer.py
+++ b/server/pulp/server/db/model/consumer.py
@@ -181,6 +181,9 @@ class RepoProfileApplicability(Model):
     unique_indices = (
         ('profile_hash', 'repo_id'),
     )
+    search_indices = (
+        ('repo_id',),
+    )
 
     def __init__(self, profile_hash, repo_id, profile, applicability, _id=None, **kwargs):
         """


### PR DESCRIPTION
Search by repo_id is used to queue applicability tasks.
If there are many consumer profiles in a collection, cursor may timeout.

closes #3133
https://pulp.plan.io/issues/3133