### PR TITLE
Problem: Distribution lacks a base URL

### DIFF
--- a/pulpcore/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/pulpcore/app/serializers/__init__.py
@@ -4,7 +4,7 @@
 from pulpcore.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # noqa
     ModelSerializer, MasterModelSerializer, DetailIdentityField, DetailRelatedField,
     viewset_for_model)
-from pulpcore.app.serializers.fields import (ContentRelatedField, FileField,  # noqa
+from pulpcore.app.serializers.fields import (BaseURLField, ContentRelatedField, FileField,  # noqa
                                              LatestVersionField)
 from pulpcore.app.serializers.content import ContentSerializer, ArtifactSerializer  # noqa
 from pulpcore.app.serializers.progress import ProgressReportSerializer  # noqa

--- a/pulpcore/pulpcore/app/serializers/fields.py
+++ b/pulpcore/pulpcore/app/serializers/fields.py
@@ -1,6 +1,7 @@
 from gettext import gettext as _
 import os
 
+from django.conf import settings
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
@@ -165,3 +166,15 @@ class LatestVersionField(NestedHyperlinkedRelatedField):
 
         """
         return instance.versions
+
+
+class BaseURLField(serializers.CharField):
+    """
+    Serializer Field for the base_url field of the Distribution.
+    """
+    def to_representation(self, value):
+        if settings.CONTENT['host']:
+            host = settings.CONTENT['host']
+        else:
+            host = self.context['request'].get_host()
+        return ''.join([host, reverse('content-app'), value])

--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -7,6 +7,7 @@ from rest_framework.validators import UniqueValidator, UniqueTogetherValidator
 
 from pulpcore.app import models
 from pulpcore.app.serializers import (
+    BaseURLField,
     DetailIdentityField,
     DetailRelatedField,
     FileField,
@@ -227,11 +228,15 @@ class DistributionSerializer(ModelSerializer):
         queryset=models.Publication.objects.all(),
         view_name='publications-detail'
     )
+    base_url = BaseURLField(
+        source='base_path', read_only=True,
+        help_text=_('The URL for accessing the publication as defined by this distribution.')
+    )
 
     class Meta:
         model = models.Distribution
         fields = ModelSerializer.Meta.fields + (
-            'name', 'base_path', 'http', 'https', 'publisher', 'publication',
+            'name', 'base_path', 'http', 'https', 'publisher', 'publication', 'base_url'
         )
 
 

--- a/pulpcore/pulpcore/app/settings.py
+++ b/pulpcore/pulpcore/app/settings.py
@@ -206,6 +206,7 @@ _DEFAULT_PULP_SETTINGS = {
     },
     'content': {
         'web_server': 'django',
+        'host': None,
     },
     'broker': {
         'url': 'amqp://guest@localhost//',

--- a/pulpcore/pulpcore/app/urls.py
+++ b/pulpcore/pulpcore/app/urls.py
@@ -111,7 +111,7 @@ for viewset in sorted_by_depth:
 root_router = routers.DefaultRouter()
 
 urlpatterns = [
-    url(r'^{}/'.format(ContentView.BASE_PATH), ContentView.as_view()),
+    url(r'^{}/'.format(ContentView.BASE_PATH), ContentView.as_view(), name='content-app'),
     url(r'^api/v3/status/', StatusView.as_view()),
 ]
 

--- a/pulpcore/pulpcore/etc/pulp/server.yaml
+++ b/pulpcore/pulpcore/etc/pulp/server.yaml
@@ -93,6 +93,11 @@
 #                 streaming the content to Apache.  Requires: mod_xsendfile to be installed.
 #                 When set to 'nginx', the X-Accel-Redirect header is injected which delegates
 #                 streaming the content to NGINX.
+#   `host`: The host name or IP and an optional port number for the Content App. (e.g.
+#           example.com:8000) This value should be specified only if the Content App is served on
+#           a host that's different from the REST API. The default value is the same as the host
+#           used to serve the REST API.
 #
 # content:
 #   web_server: django
+#   host: pulp.example.com


### PR DESCRIPTION
Solution: Add 'base_url' field to the Distribution resource

This patch adds a read only 'base_url' field to the Distribution resource. It's value is derived
from a new 'hostname' config in server.yaml and the 'base_path' of the Distribution.
for the base_url field of the Distribution resource.

closes #3185
https://pulp.plan.io/issues/3185