### PR TITLE
Fix doc build (warning) errors

### DIFF
--- a/docs/contributing/platform_api/tasking.rst
+++ b/docs/contributing/platform_api/tasking.rst
@@ -24,11 +24,6 @@ pulp.tasking.services.manage_workers
 
 .. automodule:: pulpcore.tasking.services.manage_workers
 
-pulp.tasking.services.scheduler
--------------------------------
-
-.. automodule:: pulpcore.tasking.services.scheduler
-
 pulp.tasking.services.storage
 -----------------------------
 

--- a/docs/plugins/index.rst
+++ b/docs/plugins/index.rst
@@ -30,15 +30,15 @@ Let us know when the plugin is ready and we will be happy to add it to the list 
      - Install with RPM
 
    * - File 
-     - `File docs <https://github.com/pulp/pulp_file/blob/master/README.rst>`_
-     - `File source <https://github.com/pulp/pulp_file>`_
-     - `File tracker <https://pulp.plan.io/projects/pulp_file?jump=welcome>`_
+     - `File plug-in docs <https://github.com/pulp/pulp_file/blob/master/README.rst>`_
+     - `File plug-in source <https://github.com/pulp/pulp_file>`_
+     - `File plug-in tracker <https://pulp.plan.io/projects/pulp_file?jump=welcome>`_
      - Yes
      - No
 
    * - Example
-     - `File docs <https://github.com/pulp/pulp_example/blob/master/README.rst>`_
-     - `File source <https://github.com/pulp/pulp_example>`_
-     - `File tracker <https://pulp.plan.io/projects/pulp_example?jump=welcome>`_
+     - `Example plug-in docs <https://github.com/pulp/pulp_example/blob/master/README.rst>`_
+     - `Example plug-in source <https://github.com/pulp/pulp_example>`_
+     - `Example plug-in tracker <https://pulp.plan.io/projects/pulp_example?jump=welcome>`_
      - Yes
      - No

--- a/docs/plugins/plugin-api/asyncio.rst
+++ b/docs/plugins/plugin-api/asyncio.rst
@@ -243,8 +243,7 @@ descendants of BaseDownloader.
 .. autoclass:: pulpcore.plugin.download.asyncio.BaseDownloader
     :members:
 
-.. autoclass:: pulpcore.plugin.download.asyncio.attach_url_to_exception
-    :members:
+.. autofunction:: pulpcore.plugin.download.asyncio.attach_url_to_exception
 
 .. _validation-exceptions:
 

--- a/docs/plugins/plugin-api/futures.rst
+++ b/docs/plugins/plugin-api/futures.rst
@@ -66,6 +66,7 @@ Events
 During the download flow, predefined events are raised.  This provides an opportunity for external
 objects to participate in the download flow without having to subclass the download object.
 This is intended to support common customizations such as:
+
  * Progress reporting.
  * Error handling.
  * Digest calculation.
@@ -121,13 +122,13 @@ Settings
 
 Common settings are abstracted to provide consistency across download objects.
 
-.. autoclass:: pulpcore.download.SSL
+.. autoclass:: pulpcore.plugin.download.futures.SSL
     :members:
 
-.. autoclass:: pulpcore.download.User
+.. autoclass:: pulpcore.plugin.download.futures.User
     :members:
 
-.. autoclass:: pulpcore.download.Timeout
+.. autoclass:: pulpcore.plugin.download.futures.Timeout
     :members:
 
 

--- a/docs/plugins/plugin-api/index.rst
+++ b/docs/plugins/plugin-api/index.rst
@@ -17,9 +17,3 @@ Plugin API reaches stability with v1.0. For the latest version of the Plugin API
 
 .. automodule:: pulpcore.plugin
     :imported-members:
-
-.. automodule:: pulpcore.plugin.cataloger
-
-.. automodule:: pulpcore.plugin.profiler
-
-.. automodule:: pulpcore.plugin.tasking

--- a/docs/plugins/plugin-writer/first-plugin.rst
+++ b/docs/plugins/plugin-writer/first-plugin.rst
@@ -134,10 +134,11 @@ One of the ways to perform synchronization:
   ``on_demand`` or ``background`` download policy), feel free to skip this step.
 * Save all artifact and content data in one transaction:
 
-  * in case of downloaded content, create an instance of :class:`~pulpcore.plugin.models
-      .Artifact`. Set the `file` field to the absolute path of the downloaded file. Pulp will
-      move the file into place when the Artifact is saved.
-    which refers to a downloaded file on a filesystem and contains calculated checksums for it.
+  * in case of downloaded content, create an instance of
+    :class:`~pulpcore.plugin.models .Artifact`. Set the `file` field to the
+    absolute path of the downloaded file. Pulp will move the file into place
+    when the Artifact is saved. The Artifact refers to a downloaded file on a
+    filesystem and contains calculated checksums for it.
   * in case of downloaded content, update the :class:`~pulpcore.plugin.models.ContentArtifact` with
     a reference to the created :class:`~pulpcore.plugin.models.Artifact`.
   * create and save an instance of the :class:`~pulpcore.plugin.models.RepositoryContent` to

--- a/docs/plugins/plugin-writer/index.rst
+++ b/docs/plugins/plugin-writer/index.rst
@@ -23,6 +23,7 @@ the plugin writing process.
    first-plugin
    basics
    releasing
+   cli
 
 The Pulp :doc:`../plugin-api/index` is versioned separately from the Pulp Core and consists
 of everything importable within the :mod:`pulpcore.plugin` namespace. When writing plugins, care should

--- a/plugin/pulpcore/plugin/changeset/model.py
+++ b/plugin/pulpcore/plugin/changeset/model.py
@@ -32,6 +32,8 @@ class Pending:
     @property
     def settled(self):
         """
+        Check settled status.
+
         Returns:
             bool: All matters are settled.  See: _settled.
         """
@@ -65,8 +67,8 @@ class PendingContent(Pending):
     Represents content that is contained within the remote repository.
 
     Attributes:
-        model (pulpcore.plugin.Content): A content model instance.
-        changeset (pulpcore.plugin.ChangeSet): A changeset.
+        model (pulpcore.plugin.models.Content): A content model instance.
+        changeset (pulpcore.plugin.changeset.ChangeSet): A changeset.
             Set by the ContentIterator.
         artifacts (set): The set of related `PendingArtifact`.
 
@@ -126,6 +128,8 @@ class PendingContent(Pending):
     @property
     def model(self):
         """
+        The model attribute getter.
+
         Returns:
             pulpcore.plugin.models.Content: The pending model.
         """
@@ -134,6 +138,8 @@ class PendingContent(Pending):
     @property
     def stored_model(self):
         """
+        The stored model attribute getter.
+
         Returns:
             pulpcore.plugin.models.Content: The stored model.
         """
@@ -142,7 +148,10 @@ class PendingContent(Pending):
     @stored_model.setter
     def stored_model(self, model):
         """
+        The stored model attribute getter.
+
         Notes:
+
           - The artifacts are matched by `relative_path` and their
             their stored_model set.
 
@@ -254,6 +263,8 @@ class PendingArtifact(Pending):
     @property
     def model(self):
         """
+        The model getter.
+
         Returns:
             pulpcore.plugin.models.Artifact: The pending model.
         """
@@ -262,6 +273,8 @@ class PendingArtifact(Pending):
     @property
     def stored_model(self):
         """
+        The stored model getter.
+
         Returns:
             pulpcore.plugin.models.Artifact: The stored model.
         """
@@ -270,14 +283,18 @@ class PendingArtifact(Pending):
     @stored_model.setter
     def stored_model(self, model):
         """
+        The stored model setter.
+
         Args:
-            model (pulpcore.plugin.Artifact): The stored model.
+            model (pulpcore.plugin.models.Artifact): The stored model.
         """
         self._stored_model = model
 
     @property
     def changeset(self):
         """
+        The changeset getter.
+
         Returns:
             pulpcore.plugin.changeset.Changeset: The active changeset.
         """
@@ -286,6 +303,8 @@ class PendingArtifact(Pending):
     @property
     def importer(self):
         """
+        The importer getter.
+
         Returns:
             pulpcore.plugin.models.Importer: An importer.
         """

--- a/plugin/pulpcore/plugin/models/__init__.py
+++ b/plugin/pulpcore/plugin/models/__init__.py
@@ -13,6 +13,7 @@ from pulpcore.app.models import (  # NOQA
     Repository,
     RemoteArtifact,
     RepositoryVersion,
+    RepositoryContent,
 )
 
 

--- a/pulpcore/pulpcore/app/models/content.py
+++ b/pulpcore/pulpcore/app/models/content.py
@@ -63,7 +63,7 @@ class Artifact(Model):
         Is equal by matching digest.
 
         Args:
-            other (Artifact): A artifact to match.
+            other (pulpcore.app.models.Artifact): A artifact to match.
 
         Returns:
             bool: True when equal.

--- a/pulpcore/pulpcore/app/models/repository.py
+++ b/pulpcore/pulpcore/app/models/repository.py
@@ -227,13 +227,17 @@ class RepositoryContent(Model):
 class RepositoryVersion(Model):
     """
     A version of a repository's content set.
+
     Fields:
+
         number (models.PositiveIntegerField): A positive integer that uniquely identifies a version
             of a specific repository. Each new version for a repo should have this field set to
             1 + the most recent version.
         created (models.DateTimeField): When the version was created.
         action  (models.TextField): The action that produced the version.
+
     Relations:
+
         repository (models.ForeignKey): The associated repository.
     """
     repository = models.ForeignKey(Repository)
@@ -330,7 +334,8 @@ class RepositoryVersion(Model):
     def next(self):
         """
         Returns:
-            RepositoryVersion: The next RepositoryVersion with the same repository.
+            pulpcore.app.models.RepositoryVersion: The next RepositoryVersion with the same
+                repository.
 
         Raises:
             RepositoryVersion.DoesNotExist: if there is not a RepositoryVersion for the same

--- a/pulpcore/pulpcore/app/urls.py
+++ b/pulpcore/pulpcore/app/urls.py
@@ -21,14 +21,15 @@ class ViewSetNode:
     The structure of the tree becomes the url heirarchy when the ViewSets are registered.
 
     Example Structure:
+
         RootNode
-          ├─ some-non-nested viewset
-          └─ RepositoryViewSet (non-nested)
-                ├─ PluginPublisherViewSet
-                │   └─ DistributionViewSet
-                ├─ AnotherPluginPublisherViewSet
-                │   └─ DistributionViewSet (This node is attached to all Publisher Detail parents)
-                └─ FileImporterViewSet
+        ├─ RepositoryViewSet
+        │  ├─ PluginPublisherViewSet (non-nested)
+        │  │  └─ DistributionViewSet
+        │  ├─ AnotherPluginPublisherViewSet
+        │  │  └─ DistributionViewSet (This node is attached to all Publisher Detail parents)
+        │  └─ FileImporterViewSet
+        └─ some-non-nested viewset
     """
     def __init__(self, viewset=None):
         """


### PR DESCRIPTION
Sphinx in 1.6.6 fixed a regression that would allow doc build warnings to
pass unnoticed[1].  Thus having updated Sphinx would have broken one's
Pulp docs build.

This patch addresses the doc build warnings as well as fixes a broken link
here and there.

[1] https://github.com/sphinx-doc/sphinx/issues/3919

closes: #3275
https://pulp.plan.io/issues/3275