### PR TITLE
Specify which OperationPostponedResponse in docstring

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -169,7 +169,8 @@ class RepositoryVersionViewSet(GenericNamedModelViewSet,
             number (str): the "number" attribute for the version
 
         Returns:
-            OperationPostponedResponse: a response with information about the queued task
+            pulpcore.app.response.OperationPostponedResponse: a response with information
+                about the queued task
         """
         version = self.get_object()
         async_result = tasks.repository.delete_version.apply_async_with_reservation(


### PR DESCRIPTION
Doc builder was failing with: more than one target found for cross-reference
'OperationPostponedResponse': pulpcore.plugin.viewsets.OperationPostponedResponse,
pulpcore.app.response.OperationPostponedResponse