### PR TITLE
Last version href erroneously returns incomplete versions

### DIFF
--- a/pulpcore/pulpcore/app/serializers/fields.py
+++ b/pulpcore/pulpcore/app/serializers/fields.py
@@ -145,7 +145,7 @@ class LatestVersionField(NestedHyperlinkedRelatedField):
                 are no versions, returns None
         """
         try:
-            version = obj.latest()
+            version = obj.exclude(complete=False).latest()
         except obj.model.DoesNotExist:
             return None
 


### PR DESCRIPTION
The `_latest_version_href` field on repos can point to repo versions where complete is False.