### PR TITLE
Update views docstring to not expose internal details

### DIFF
--- a/pulpcore/pulpcore/app/views/status.py
+++ b/pulpcore/pulpcore/app/views/status.py
@@ -25,13 +25,6 @@ class StatusView(APIView):
         """
         Returns app information including the version, known workers, database connection status,
         and messaging connection status
-
-        Args:
-            request (rest_framework.request.Request): container representing request state
-            format (str): requested format of the status response (e.g. json)
-
-        Returns:
-            rest_framework.response.Response: container for the response information
         """
         versions = [{'component': 'pulpcore', 'version': get_distribution("pulpcore").version}]
         broker_status = {'connected': self._get_broker_conn_status()}

--- a/pulpcore/pulpcore/app/viewsets/content.py
+++ b/pulpcore/pulpcore/app/viewsets/content.py
@@ -49,20 +49,6 @@ class ContentViewSet(CreateDestroyReadNamedModelViewSet):
 
     @transaction.atomic
     def create(self, request):
-        """
-        Create a new Content instance from a JSON payload in the request.
-
-        Args:
-            request (:class:`rest_framework.request.Request`): request containing JSON payload with
-                information about the content being created.
-
-        Returns:
-            :class:`rest_framework.response.Response` with a 201 status code.
-
-        Raises:
-            :class:`rest_framework.exceptions.ValidationError` when artifact URLs are not valid or
-                the relative paths start with a '/'.
-        """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         artifacts = serializer.validated_data.pop('artifacts')
@@ -84,17 +70,7 @@ class ArtifactViewSet(CreateDestroyReadNamedModelViewSet):
 
     def destroy(self, request, pk):
         """
-        Remove :class:`~pulpcore.app.models.Artifact` only if it is not associated with any
-        `~pulpcore.app.models.Content`
-
-        Args:
-            request (:class:`rest_framework.request.Request`): request containing JSON payload
-                with information about the artifact being deleted.
-            pk (:class:`uuid.UUID`): Unique id of the artifact being deleted.
-
-        Returns:
-            :class:`rest_framework.response.Response` with a 204 status code in case of
-                successful deletion, 409 status code if deletion is not allowed.
+        Remove Artifact only if it is not associated with any Content.
         """
         try:
             return super(ArtifactViewSet, self).destroy(request, pk)

--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -44,7 +44,7 @@ class RepositoryViewSet(NamedModelViewSet):
 
     def update(self, request, pk, partial=False):
         """
-        Generates a Task to update a :class:`~pulpcore.app.models.Repository`
+        Generates a Task to update a Repository
         """
         instance = self.get_object()
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
@@ -59,7 +59,7 @@ class RepositoryViewSet(NamedModelViewSet):
 
     def destroy(self, request, pk):
         """
-        Generates a Task to delete a :class:`~pulpcore.app.models.Repository`
+        Generates a Task to delete a Repository
         """
         repo = self.get_object()
         async_result = tasks.repository.delete.apply_async_with_reservation(
@@ -162,15 +162,7 @@ class RepositoryVersionViewSet(GenericNamedModelViewSet,
 
     def destroy(self, request, repository_pk, number):
         """
-        Queues a task to handle deletion.
-        Args:
-            request (rest_framework.request.Request): the current HTTP request being handled
-            repository_pk (UUID): primary key for a Repository associated with the version
-            number (str): the "number" attribute for the version
-
-        Returns:
-            pulpcore.app.response.OperationPostponedResponse: a response with information
-                about the queued task
+        Queues a task to handle deletion of a RepositoryVersion
         """
         version = self.get_object()
         async_result = tasks.repository.delete_version.apply_async_with_reservation(


### PR DESCRIPTION
The docstring in our views and viewsets is exposed to users through our
REST API schema documentation. This updates our docstring to be more
user friendly. For more info see:

http://www.django-rest-framework.org/api-guide/schemas/#schemas-as-documentation