### PR TITLE
Only validate hash algorithms that the user can upload on the model.

### DIFF
--- a/pulpcore/pulpcore/app/serializers/content.py
+++ b/pulpcore/pulpcore/app/serializers/content.py
@@ -94,19 +94,21 @@ class ArtifactSerializer(base.ModelSerializer):
             data['size'] = data['file'].size
 
         for algorithm in hashlib.algorithms_guaranteed:
-            digest = data['file'].hashers[algorithm].hexdigest()
+            if algorithm in models.Artifact.DIGEST_FIELDS:
+                digest = data['file'].hashers[algorithm].hexdigest()
 
-            if algorithm in data and digest != data[algorithm]:
-                raise serializers.ValidationError(_("The %s checksum did not match.") % algorithm)
-            else:
-                data[algorithm] = digest
-            if algorithm in UNIQUE_ALGORITHMS:
-                validator = UniqueValidator(models.Artifact.objects.all(),
-                                            message=_("{0} checksum must be "
-                                                      "unique.").format(algorithm))
-                validator.field_name = algorithm
-                validator.instance = None
-                validator(digest)
+                if algorithm in data and digest != data[algorithm]:
+                    raise serializers.ValidationError(_("The %s checksum did not match.")
+                                                      % algorithm)
+                else:
+                    data[algorithm] = digest
+                if algorithm in UNIQUE_ALGORITHMS:
+                    validator = UniqueValidator(models.Artifact.objects.all(),
+                                                message=_("{0} checksum must be "
+                                                          "unique.").format(algorithm))
+                    validator.field_name = algorithm
+                    validator.instance = None
+                    validator(digest)
         return data
 
     class Meta:


### PR DESCRIPTION
Issue 3316 is cause because hashlib.algorithms_guaranteed contains shake_128 and shake_256 in python 3.6. These have variable length digests and need a length value passed in. 
Since the user shouldn't be passing in any algorithms not stored on the artifact model, only check those hashes.

fixes #3316
https://pulp.plan.io/issues/3316


