### PR TITLE
Fixes workers crashing on restart edge case

### DIFF
--- a/server/test/unit/server/async/test_tasks.py
+++ b/server/test/unit/server/async/test_tasks.py
@@ -211,7 +211,8 @@ class TestDeleteWorker(ResourceReservationTests):
                                                       {'task_id': mock_task_id_b}]
         tasks._delete_worker('worker1')
 
-        self.mock_cancel.assert_has_calls([mock.call(mock_task_id_a), mock.call(mock_task_id_b)])
+        self.mock_cancel.assert_has_calls([mock.call(mock_task_id_a, revoke_task=False),
+                                           mock.call(mock_task_id_b, revoke_task=False)])
 
 
 class TestReleaseResource(unittest.TestCase):


### PR DESCRIPTION
Fixes an issue where workers would crash when
attempting to revoke() a previously running task
on startup. If the user sends SIGKILL to the
worker while running a task, the worker will
attempt to mark the task as stale when restarted.
This causes a hang for yet-unknown reasons. Calling
revoke() is not necessary when a dead worker is being
cleaned up because all work goes through dedicated
queues which disappear when the worker does. We
leave revoke() active only when a task is being
cancelled outside of worker cleanup.

closes #2835
https://pulp.plan.io/issues/2835