### PR TITLE
WorkingDirectory refactored.

### DIFF
--- a/plugin/pulpcore/plugin/tasking.py
+++ b/plugin/pulpcore/plugin/tasking.py
@@ -15,7 +15,6 @@ class Task:
 
     Attributes:
         id (str): The task identifier.
-
     """
 
     def __init__(self):


### PR DESCRIPTION
Updated the `__enter__()` to create the directory.  I think this is more appropriate since the physical directory's lifespan coincides with the duration of the context.  Since the directory is deleted when exiting the context I liked the symmetry of it being created when entering the context.  The create method is more appropriate as an instance method.

Minor class refactoring.

File plugin pr: https://github.com/pulp/pulp_file/pull/31