### PR TITLE
RepositoryVersion.complete should be indexed.

### DIFF
--- a/pulpcore/pulpcore/app/models/repository.py
+++ b/pulpcore/pulpcore/app/models/repository.py
@@ -265,7 +265,7 @@ class RepositoryVersion(Model):
     repository = models.ForeignKey(Repository)
     number = models.PositiveIntegerField(db_index=True)
     created = models.DateTimeField(auto_now_add=True)
-    complete = models.BooleanField(default=False)
+    complete = models.BooleanField(db_index=True, default=False)
 
     class Meta:
         default_related_name = 'versions'


### PR DESCRIPTION
`RepositoryVersions` is sometimes queried solely by (complete=True).  Adding an index to prevent full table scan.