### PR TITLE
Fix adding/removing content units to a version

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -264,13 +264,14 @@ class RepositoryVersionViewSet(GenericNamedModelViewSet,
         """
         add_content_units = []
         remove_content_units = []
+
         if 'add_content_units' in request.data:
-            for url in request.data['add_content_units']:
+            for url in request.data['add_content_units'].split(','):
                 content = self.get_resource(url, Content)
                 add_content_units.append(content.pk)
 
         if 'remove_content_units' in request.data:
-            for url in request.data['remove_content_units']:
+            for url in request.data['remove_content_units'].split(','):
                 content = self.get_resource(url, Content)
                 remove_content_units.append(content.pk)
 


### PR DESCRIPTION
Looks like add_content_units and remove_content_units parameters are
strings. This splits them up.