### PR TITLE
Fix incorrect queue name suffix with Celery 4

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -4,6 +4,7 @@ import os
 import random
 import shutil
 import uuid
+from celery import __version__ as celery_version
 from collections import namedtuple
 from gettext import gettext as _
 from hashlib import sha256
@@ -423,7 +424,8 @@ class Worker(AutoRetryDocument):
         :return: The name of the queue that this Worker is uniquely subcribed to.
         :rtype:  basestring
         """
-        return "%(name)s.dq" % {'name': self.name}
+        queue_name = "%(name)s.dq2" if celery_version.startswith('4') else "%(name)s.dq"
+        return queue_name % {'name': self.name}
 
 
 class MigrationTracker(AutoRetryDocument):


### PR DESCRIPTION
The queue suffix is dependent on celery version. Celery 4 uses ".dq2"
so we need to handle that case when we recreate the queue name as
part of the detail view.