### PR TITLE
Fix case where queue_name property returns None.dq

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -424,6 +424,9 @@ class Worker(AutoRetryDocument):
         :return: The name of the queue that this Worker is uniquely subcribed to.
         :rtype:  basestring
         """
+        if not self.name:
+            return ""
+
         queue_name = "%(name)s.dq2" if celery_version.startswith('4') else "%(name)s.dq"
         return queue_name % {'name': self.name}
 


### PR DESCRIPTION
The queue_name property does not handle the case where the worker name
is None.