### PR TITLE
Fields: created & last_updated moved to Model.

### DIFF
--- a/pulpcore/pulpcore/app/models/base.py
+++ b/pulpcore/pulpcore/app/models/base.py
@@ -11,7 +11,9 @@ class Model(models.Model):
     behavior.
 
     Fields:
-        id: UUID ID Primary Key Field
+        id (models.UUIDField): UUID ID Primary Key Field
+        created (models.DateTimeField): Created timestamp UTC.
+        last_updated (models.DateTimeField): Last updated timestamp UTC.
 
     References:
 
@@ -20,10 +22,9 @@ class Model(models.Model):
         * https://www.postgresql.org/docs/current/static/datatype-uuid.html
 
     """
-    # ...we have zero interest in using a mongo-specific datatype (ObjectId) as
-    # the django PK, but it is possible to convert ObjectIds to UUIDs if we want to
-    # maintain PKs from mongo to postgres.
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    created = models.DateTimeField(auto_now_add=True)
+    last_updated = models.DateTimeField(auto_now=True, blank=True, null=True)
 
     class Meta:
         abstract = True

--- a/pulpcore/pulpcore/app/models/publication.py
+++ b/pulpcore/pulpcore/app/models/publication.py
@@ -16,7 +16,6 @@ class Publication(Model):
 
     Fields:
         complete (models.BooleanField): State tracking; for internal use. Indexed.
-        created (models.DatetimeField): When the publication was created UTC.
 
     Relations:
         publisher (models.ForeignKey): The publisher that created the publication.
@@ -39,7 +38,6 @@ class Publication(Model):
     """
 
     complete = models.BooleanField(db_index=True, default=False)
-    created = models.DateTimeField(auto_now_add=True)
 
     publisher = models.ForeignKey('Publisher', on_delete=models.CASCADE)
     repository_version = models.ForeignKey('RepositoryVersion', on_delete=models.CASCADE)

--- a/pulpcore/pulpcore/app/models/repository.py
+++ b/pulpcore/pulpcore/app/models/repository.py
@@ -108,7 +108,6 @@ class Importer(MasterModel):
         return get_tls_path(self, name)
 
     name = models.TextField(db_index=True, unique=True)
-    last_updated = models.DateTimeField(auto_now=True, blank=True, null=True)
 
     feed_url = models.TextField()
     validate = models.BooleanField(default=True)
@@ -157,7 +156,6 @@ class Publisher(MasterModel):
     TYPE = 'publisher'
 
     name = models.TextField(db_index=True, unique=True)
-    last_updated = models.DateTimeField(auto_now=True, blank=True, null=True)
 
     auto_publish = models.BooleanField(default=True)
     last_published = models.DateTimeField(blank=True, null=True)
@@ -182,7 +180,6 @@ class Exporter(MasterModel):
     TYPE = 'exporter'
 
     name = models.CharField(max_length=255, db_index=True, unique=True)
-    last_updated = models.DateTimeField(auto_now=True, blank=True, null=True)
     last_export = models.DateTimeField(blank=True, null=True)
 
     class Meta:
@@ -239,7 +236,6 @@ class RepositoryVersion(Model):
         number (models.PositiveIntegerField): A positive integer that uniquely identifies a version
             of a specific repository. Each new version for a repo should have this field set to
             1 + the most recent version.
-        created (models.DateTimeField): When the version was created.
         action  (models.TextField): The action that produced the version.
         complete (models.BooleanField): If true, the RepositoryVersion is visible. This field is set
             to true when the task that creates the RepositoryVersion is complete.
@@ -250,7 +246,6 @@ class RepositoryVersion(Model):
     """
     repository = models.ForeignKey(Repository)
     number = models.PositiveIntegerField(db_index=True)
-    created = models.DateTimeField(auto_now_add=True)
     complete = models.BooleanField(db_index=True, default=False)
 
     class Meta:
@@ -271,7 +266,7 @@ class RepositoryVersion(Model):
             >>> repository_version = ...
             >>>
             >>> for content in repository_version.content:
-            >>>     content = content.case()  # optional downcast.
+            >>>     content = content.cast()  # optional downcast.
             >>>     ...
             >>>
             >>> for content in FileContent.objects.filter(pk__in=repository_version.content):


### PR DESCRIPTION
Related to https://pulp.plan.io/issues/3337, the FileContent needed to be ordered by a `created` field.  This seemed generally useful for other plugins for the same reason.  Then, considered that a `created` timestamp would be useful on most models.  So, why not add it to `Model`.  Along the same line of thinking, why not add `last_updated` while we're at it.  Should be generally useful for filtering/search and troubleshooting.

There are some concerns within the django community regarding *auto_now* and *auto_now_add* but I suggest we make this change independently of that.  We should be revisited and fix on all models as needed.