### PR TITLE
Refer to RabbitMQ as the default broker

### DIFF
--- a/pulpcore/pulpcore/app/settings.py
+++ b/pulpcore/pulpcore/app/settings.py
@@ -211,9 +211,9 @@ _DEFAULT_PULP_SETTINGS = {
     'broker': {
         'url': 'amqp://guest@localhost//',
         'celery_require_ssl': False,
-        'ssl_ca_certificate': '/etc/pki/pulp/qpid/ca.crt',
-        'ssl_client_key': '/etc/pki/pulp/qpid/client.crt',
-        'ssl_client_certificate': '/etc/pki/pulp/qpid/client.crt',
+        'ssl_ca_certificate': '/etc/pki/pulp/broker/ca.crt',
+        'ssl_client_key': '/etc/pki/pulp/broker/client.crt',
+        'ssl_client_certificate': '/etc/pki/pulp/broker/client.crt',
         'login_method': None
     },
     'profiling': {

--- a/pulpcore/pulpcore/etc/pulp/server.yaml
+++ b/pulpcore/pulpcore/etc/pulp/server.yaml
@@ -64,16 +64,16 @@
 
 # Broker configuration
 #
-# `broker`: Broker configuration for Pulp. By default, Pulp uses the Qpid
+# `broker`: Broker configuration for Pulp. By default, Pulp uses the RabbitMQ
 # broker without SSL. It is possible to change this by providing a different
 # broker string. The remaining options are used to configure SSL settings.
 #
 # broker:
-#   url: qpid://localhost/
+#   url: amqp://localhost/
 #   celery_require_ssl: False
-#   ssl_ca_certificate: /etc/pki/pulp/qpid/ca.crt
-#   ssl_client_key: /etc/pki/pulp/qpid/client.crt
-#   ssl_client_certificate: /etc/pki/pulp/qpid/client.crt
+#   ssl_ca_certificate: /etc/pki/pulp/broker/ca.crt
+#   ssl_client_key: /etc/pki/pulp/broker/client.crt
+#   ssl_client_certificate: /etc/pki/pulp/broker/client.crt
 #   login_method:
 
 # Server configuration


### PR DESCRIPTION
Since Pulp still won't run with vanilla qpid broker[1] it seems reasonable
to refer to the RabbitMQ as the default broker instead.

Fixes #3366
https://pulp.plan.io/issues/3366

[1] https://github.com/celery/kombu/pull/810