### PR TITLE
Lenthen relative path for content artifacts

### DIFF
--- a/pulpcore/pulpcore/app/models/content.py
+++ b/pulpcore/pulpcore/app/models/content.py
@@ -136,7 +136,7 @@ class ContentArtifact(Model):
     """
     artifact = models.ForeignKey(Artifact, on_delete=models.PROTECT, null=True)
     content = models.ForeignKey(Content, on_delete=models.CASCADE)
-    relative_path = models.CharField(max_length=64)
+    relative_path = models.CharField(max_length=256)
 
     class Meta:
         unique_together = ('content', 'relative_path')


### PR DESCRIPTION
Some filenames by themselves are longer than 64 chars, for example:
`scipy-1.0.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl`