### PR TITLE
Add the missing makemigrations Pypi install step

### DIFF
--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -89,6 +89,7 @@ PyPI Installation
 
 8. Run Django Migrations::
 
+   $ pulp-manager makemigrations
    $ pulp-manager migrate --noinput auth
    $ pulp-manager migrate --noinput
    $ pulp-manager reset-admin-password --password admin


### PR DESCRIPTION
The Pypi installation instructions missed the makemigrations step.

Fixes #3362
https://pulp.plan.io/issues/3362