### PR TITLE
Fixing error for repository version create

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/base.py
+++ b/pulpcore/pulpcore/app/viewsets/base.py
@@ -183,6 +183,18 @@ class GenericNamedModelViewSet(viewsets.GenericViewSet):
                 filters[parent_lookup] = self.kwargs[key]
             return parent_field, get_object_or_404(self.parent_viewset.queryset, **filters)
 
+    def get_parent_object(self):
+        """
+        For nested ViewSets, retrieve the nested parent implied by the url.
+
+        Returns:
+            Model: parent model object
+        Raises:
+            django.http.Http404: When the parent implied by the url does not exist. Synchronous
+                                 use should allow this to bubble up and return a 404.
+        """
+        return self.get_parent_field_and_object()[1]
+
 
 class NamedModelViewSet(mixins.CreateModelMixin,
                         mixins.RetrieveModelMixin,

--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -262,20 +262,20 @@ class RepositoryVersionViewSet(GenericNamedModelViewSet,
         """
         add_content_units = []
         remove_content_units = []
-        version = self.get_object()
+        repository = self.get_parent_object()
 
         if 'add_content_units' in request.data:
-            for url in request.data['add_content_units'].split(','):
+            for url in request.data['add_content_units']:
                 content = self.get_resource(url, Content)
                 add_content_units.append(content.pk)
 
         if 'remove_content_units' in request.data:
-            for url in request.data['remove_content_units'].split(','):
+            for url in request.data['remove_content_units']:
                 content = self.get_resource(url, Content)
                 remove_content_units.append(content.pk)
 
         result = tasks.repository.add_and_remove.apply_async_with_reservation(
-            [version.repository],
+            [repository],
             kwargs={
                 'repository_pk': repository_pk,
                 'add_content_units': add_content_units,


### PR DESCRIPTION
The multi-resource locking change used version to lock on when creating
repository versions but of course there's no version. It should lock on
repository.