### PR TITLE
Make compatible with Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,22 +7,34 @@ python:
     - "3.5"
     - "3.6"
 env:
-  - DB=sqlite TEST=pulp
-  - DB=sqlite TEST=pulp_file
-  - DB=postgres TEST=pulp
-  - DB=postgres TEST=pulp_file
+  - DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=sqlite TEST=pulp
+  - DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=sqlite TEST=pulp_file
+  - DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=postgres TEST=pulp
+  - DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=postgres TEST=pulp_file
+  - DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=sqlite TEST=pulp
+  - DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=sqlite TEST=pulp_file
+  - DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=postgres TEST=pulp
+  - DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=postgres TEST=pulp_file
   - TEST=docs
 matrix:
   fast_finish: true
   allow_failures:
     - python: "3.5"
-      env: DB=sqlite TEST=pulp_file
+      env: DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=sqlite TEST=pulp_file
     - python: "3.5"
-      env: DB=postgres TEST=pulp_file
+      env: DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=postgres TEST=pulp_file
+    - python: "3.5"
+      env: DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=sqlite TEST=pulp_file
+    - python: "3.5"
+      env: DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=postgres TEST=pulp_file
     - python: "3.6"
-      env: DB=sqlite TEST=pulp_file
+      env: DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=sqlite TEST=pulp_file
     - python: "3.6"
-      env: DB=postgres TEST=pulp_file
+      env: DJANGO_MIN=1.11.1 DJANGO_MAX=2.0 DB=postgres TEST=pulp_file
+    - python: "3.6"
+      env: DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=sqlite TEST=pulp_file
+    - python: "3.6"
+      env: DJANGO_MIN=2.0 DJANGO_MAX=3.0 DB=postgres TEST=pulp_file
 addons:
     # postgres versions provided by el7 RHSCL (lowest supportable version)
     postgresql: "9.5"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -2,6 +2,7 @@
 set -v
 
 # dev_requirements should not be needed for testing; don't install them to make sure
+pip install "Django>=$DJANGO_MIN,<$DJANGO_MAX"
 pip install -r test_requirements.txt
 pushd common/ && pip install -e . && popd
 pushd pulpcore/ && pip install -e . && popd

--- a/pulpcore/pulpcore/app/fields.py
+++ b/pulpcore/pulpcore/app/fields.py
@@ -4,7 +4,6 @@ Custom Django fields provided by pulpcore
 import json
 
 from django.db import models
-from django.utils.translation import six
 
 
 class JSONField(models.TextField):
@@ -24,7 +23,7 @@ class JSONField(models.TextField):
         Returns:
             Python representation of ``value``
         """
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             return self.to_python(value)
         return value
 
@@ -65,5 +64,5 @@ class JSONField(models.TextField):
         Returns:
             str: JSON Serialized value
         """
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_db_prep_value(value, None)

--- a/pulpcore/pulpcore/app/models/repository.py
+++ b/pulpcore/pulpcore/app/models/repository.py
@@ -205,9 +205,11 @@ class RepositoryContent(Model):
     content = models.ForeignKey('Content', on_delete=models.CASCADE,
                                 related_name='version_memberships')
     repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
-    version_added = models.ForeignKey('RepositoryVersion', related_name='added_memberships')
+    version_added = models.ForeignKey('RepositoryVersion', related_name='added_memberships',
+                                      on_delete=models.CASCADE)
     version_removed = models.ForeignKey('RepositoryVersion', null=True,
-                                        related_name='removed_memberships')
+                                        related_name='removed_memberships',
+                                        on_delete=models.CASCADE)
 
     class Meta:
         unique_together = (('repository', 'content', 'version_added'),
@@ -243,7 +245,7 @@ class RepositoryVersion(Model):
 
         repository (models.ForeignKey): The associated repository.
     """
-    repository = models.ForeignKey(Repository)
+    repository = models.ForeignKey(Repository, on_delete=models.CASCADE)
     number = models.PositiveIntegerField(db_index=True)
     complete = models.BooleanField(db_index=True, default=False)
 

--- a/pulpcore/pulpcore/app/models/task.py
+++ b/pulpcore/pulpcore/app/models/task.py
@@ -36,7 +36,7 @@ class ReservedResource(Model):
     resource = models.TextField(unique=True, blank=False)
 
     tasks = models.ManyToManyField("Task", related_name="reserved_resources")
-    worker = models.ForeignKey("Worker", on_delete=models.CASCADE, related_name="reservations")
+    worker = models.ForeignKey("Worker", related_name="reservations", on_delete=models.CASCADE)
 
 
 class WorkerManager(models.Manager):
@@ -260,8 +260,10 @@ class Task(Model):
     non_fatal_errors = JSONField(default=list)
     error = JSONField(null=True)
 
-    parent = models.ForeignKey("Task", null=True, related_name="spawned_tasks")
-    worker = models.ForeignKey("Worker", null=True, related_name="tasks")
+    parent = models.ForeignKey("Task", null=True, related_name="spawned_tasks",
+                               on_delete=models.SET_NULL)
+    worker = models.ForeignKey("Worker", null=True, related_name="tasks",
+                               on_delete=models.SET_NULL)
 
     @staticmethod
     def current():

--- a/pulpcore/pulpcore/app/tests/fields/test_jsonfield.py
+++ b/pulpcore/pulpcore/app/tests/fields/test_jsonfield.py
@@ -29,6 +29,6 @@ class TestJSONField(TestCase):
 
     def test_value_to_string(self):
         """Assert the value returned by value_to_string matches a json-serialized version of obj"""
-        with patch('pulpcore.app.fields.JSONField._get_val_from_obj', return_value=self.obj):
+        with patch('pulpcore.app.fields.JSONField.value_from_object', return_value=self.obj):
             new_obj = self.json_field.value_to_string(object())
             self.assertEquals(self.obj_json, new_obj)

--- a/pulpcore/setup.py
+++ b/pulpcore/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 requirements = [
     'celery',
     'coreapi',
-    'Django>=1.8,<2',
+    'Django>=1.11',
     'django-filter',
     'djangorestframework',
     'drf-nested-routers',


### PR DESCRIPTION
Fix a few issues which prevented Pulp from working with Django 2.0

* Changed requirement string
* Added ```on_delete``` behavior on all ForeignKey field types, required by Django 2 (needs to be double checked)
* Removed reference to ```six```

closes #3453
https://pulp.plan.io/issues/3453