### PR TITLE
Using /var/lib/pulp/tmp instead of /var/cache/pulp

### DIFF
--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -11,10 +11,8 @@ cp .travis/pulp-smash-config.json ~/.config/pulp_smash/settings.json
 
 sudo mkdir /var/lib/pulp
 sudo mkdir /var/lib/pulp/tmp
-sudo mkdir /var/cache/pulp
 sudo mkdir /etc/pulp/
 sudo chown -R travis:travis /var/lib/pulp
-sudo chown travis:travis /var/cache/pulp
 
 if [ "$DB" = 'postgres' ]; then
   sudo cp .travis/server.postgres.yaml /etc/pulp/server.yaml

--- a/pulpcore/pulpcore/app/settings.py
+++ b/pulpcore/pulpcore/app/settings.py
@@ -202,7 +202,7 @@ _DEFAULT_PULP_SETTINGS = {
         }
     },
     'server': {
-        'working_directory': '/var/cache/pulp',
+        'working_directory': '/var/lib/pulp/tmp',
     },
     'content': {
         'web_server': 'django',

--- a/pulpcore/pulpcore/etc/pulp/server.yaml
+++ b/pulpcore/pulpcore/etc/pulp/server.yaml
@@ -83,7 +83,7 @@
 #                        for completion of tasks
 #
 # server:
-#   working_directory: /var/cache/pulp
+#   working_directory: /var/lib/pulp/tmp
 
 # Content Application
 #

--- a/pulpcore/pulpcore/tasking/celery_app.py
+++ b/pulpcore/pulpcore/tasking/celery_app.py
@@ -126,7 +126,7 @@ def initialize_worker(sender, instance, **kwargs):
     In such cases, any Pulp tasks that were running or waiting on this worker will show incorrect
     state. Any reserved_resource reservations associated with the previous worker will also be
     removed along with the setting of online=False on the worker record in the database itself.
-    The working directory specified in /etc/pulp/server.conf (/var/cache/pulp/<worker_name>)
+    The working directory specified in /etc/pulp/server.conf (/var/lib/pulp/tmp/<worker_name>)
     by default is removed and recreated. This is called early in the worker start process,
     and later when it's fully online. If there is no previous work to cleanup, this method still
     runs, but has no effect on the database.


### PR DESCRIPTION
fixes #3406
https://pulp.plan.io/issues/3406