### PR TITLE
Set a 20 second timeout for sqlite

### DIFF
--- a/.travis/server.sqlite.yaml
+++ b/.travis/server.sqlite.yaml
@@ -1,1 +1,6 @@
+databases:
+  default:
+    OPTIONS:
+      timeout: 20
+
 DEBUG: True

--- a/pulpcore/pulpcore/app/settings.py
+++ b/pulpcore/pulpcore/app/settings.py
@@ -5,7 +5,7 @@ Never import this module directly, instead `from django.conf import settings`, s
 https://docs.djangoproject.com/en/1.8/topics/settings/#using-settings-in-python-code
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.8/ref/settings/
+https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
@@ -20,7 +20,7 @@ import yaml
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -128,7 +128,7 @@ REST_FRAMEWORK = {
 AUTH_USER_MODEL = 'pulp_app.User'
 
 # Password validation
-# https://docs.djangoproject.com/en/1.9/ref/settings/#auth-password-validators
+# https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
     {
@@ -147,7 +147,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.9/topics/i18n/
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -161,14 +161,14 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.9/howto/static-files/
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
 
 # A set of default settings to use if the configuration file in
 # /etc/pulp/ is missing or if it does not have values for every setting
 _DEFAULT_PULP_SETTINGS = {
-    # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+    # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
     'databases': {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
@@ -177,7 +177,7 @@ _DEFAULT_PULP_SETTINGS = {
             'CONN_MAX_AGE': 0,
         },
     },
-    # https://docs.djangoproject.com/en/1.8/ref/settings/#logging and
+    # https://docs.djangoproject.com/en/1.11/ref/settings/#logging and
     # https://docs.python.org/3/library/logging.config.html
     'logging': {
         'version': 1,

--- a/pulpcore/pulpcore/etc/pulp/server.yaml
+++ b/pulpcore/pulpcore/etc/pulp/server.yaml
@@ -15,16 +15,18 @@
 # `databases`: An associative array (dictionary) of databases to use. For the
 # full list of configuration options, refer to the Django database documentation
 # shipped with your version of Django, or online at
-# https://docs.djangoproject.com/en/1.8/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 #
 # By default, Pulp will use a sqlite3 database. If your environment is used in production
 # consider configuring Postgresql or another Django supported database.
 #
-# databases:
-#   default:
-#     CONN_MAX_AGE: 0
-#     ENGINE: django.db.backends.sqlite3
-#     NAME: /var/lib/pulp/sqlite3.db
+databases:
+  default:
+    CONN_MAX_AGE: 0
+    ENGINE: django.db.backends.sqlite3
+    NAME: /var/lib/pulp/sqlite3.db
+    OPTIONS:
+      timeout: 20
 #     USER:
 #     PASSWORD:
 #     HOST:


### PR DESCRIPTION
https://pulp.plan.io/issues/3456

We can't specify it in settings.py because it is a database-specific option.  Therefore it needs to be specified in the server.yaml file.  Unfortunately this means that server.yaml will be providing some settings even on a default installation.