### PR TITLE
UnicodeDecodeError in comments provided with SSL cert/key

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -360,7 +360,10 @@ class Importer(AutoRetryDocument):
                 misc.mkdir(os.path.dirname(self._pki_path))
                 os.mkdir(self._pki_path, 0700)
             with os.fdopen(os.open(path, os.O_WRONLY | os.O_CREAT, 0600), 'w') as pem_file:
-                pem_file.write(self.config[config_key].encode('utf-8'))
+                if type(self.config[config_key]) is unicode:
+                    pem_file.write(self.config[config_key].encode('utf-8'))
+                else:
+                    pem_file.write(self.config[config_key])
 
 
 signals.pre_delete.connect(Importer.pre_delete, sender=Importer)


### PR DESCRIPTION
Writing SSL certs/key to file that contain non-ascii characters
raises a UnicodeDecodeError in Pulp, since Python 2 by default
decodes objects as 'ascii'.

closes #3253
https://pulp.plan.io/issues/3253