### PR TITLE
Fixing problems with bad hostnames

### DIFF
--- a/pulpcore/pulpcore/app/serializers/base.py
+++ b/pulpcore/pulpcore/app/serializers/base.py
@@ -169,8 +169,8 @@ class ModelSerializer(serializers.HyperlinkedModelSerializer):
             django.core.exceptions.ValidationError: if the relative path is invalid
 
         """
-        base = "{}://{}".format(self.context['request'].scheme,
-                                self.context['request'].get_host())
+        # in order to use django's URLValidator we need to construct a full url
+        base = "http://localhost"  # use a scheme/hostname we know are valid
         validate = URLValidator()
         validate(urljoin(base, path))
 


### PR DESCRIPTION
Looks like django requires certain features of hostnames like a "." so
using `get_host()` was not a good idea. Using a known valid hostname
instead.

fixes #3476
https://pulp.plan.io/issues/3476