### PR TITLE
Remove ability to delete a content unit used by a repo version

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/content.py
+++ b/pulpcore/pulpcore/app/viewsets/content.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 
-from pulpcore.app.models import Artifact, Content, ContentArtifact
+from pulpcore.app.models import Artifact, Content, ContentArtifact, RepositoryContent
 from pulpcore.app.serializers import ArtifactSerializer, ContentSerializer
 from pulpcore.app.viewsets import CreateDestroyReadNamedModelViewSet
 
@@ -60,6 +60,23 @@ class ContentViewSet(CreateDestroyReadNamedModelViewSet):
 
         headers = self.get_success_headers(serializer.data)
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
+    def destroy(self, request, pk):
+        """
+        Remove Content unit only if it is not associated with a repository version
+        """
+        repository_content_set = RepositoryContent.objects.filter(content__pk=pk)
+
+        if repository_content_set:
+            msg = (_('The Content unit cannot be deleted because it is associated with a repository'
+                   ' version, which is immutable. Repository: ') +
+                   repository_content_set[0].repository.name)
+            data = {'detail': msg}
+            return Response(data, status=status.HTTP_409_CONFLICT)
+        else:
+            instance = self.get_object()
+            self.perform_destroy(instance)
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class ArtifactViewSet(CreateDestroyReadNamedModelViewSet):


### PR DESCRIPTION
Remove ability to delete a content unit used by a
repo version

You should not be able to delete a unit of content that is used by a
repo version so that ability has been removed.

fixes #3418
https://pulp.plan.io/issues/3418