### PR TITLE
Remove usage of the Django 'six' module

### DIFF
--- a/pulpcore/pulpcore/app/serializers/user.py
+++ b/pulpcore/pulpcore/app/serializers/user.py
@@ -2,7 +2,6 @@ from gettext import gettext as _
 
 from django.core import validators
 from django.contrib.auth.hashers import make_password
-from django.utils import six
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
@@ -19,10 +18,9 @@ class PasswordSerializer(serializers.CharField):
         # We're lenient with allowing basic numerics to be coerced into strings,
         # but other types should fail. Eg. unclear if booleans should represent as `true` or `True`,
         # and composites such as lists are likely user error.
-        if isinstance(data, bool) or \
-                not isinstance(data, six.string_types + six.integer_types + (float,)):
+        if not isinstance(data, (str, int, float)):
             self.fail('invalid')
-        value = six.text_type(make_password(data))
+        value = str(make_password(data))
         return value
 
 


### PR DESCRIPTION
The 'six' module is intended to make writing code that works on both
Python 2 and 3 easier. Without Python 2 support, it just makes our code
more opaque.

Also removed some superflous logic.