### PR TITLE
Fix defaulting of value to blank string when not specified

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -2,7 +2,7 @@ from gettext import gettext as _
 import itertools
 
 from django_filters.rest_framework import filters, filterset
-from django_filters import CharFilter
+from django_filters import Filter
 from rest_framework import decorators, mixins, serializers
 
 from pulpcore.app import tasks
@@ -119,7 +119,7 @@ class ExporterFilter(filterset.FilterSet):
         ]
 
 
-class RepositoryVersionContentFilter(CharFilter):
+class RepositoryVersionContentFilter(Filter):
     """
     Filter used to get the repository versions where some given content can be found.
 


### PR DESCRIPTION
If content is not passed in, the filter still gets run with a blank
string for some reason. Extending Filter instead of CharFilter seems to
fix this.

fixes #3502
https://pulp.plan.io/issues/3502