### PR TITLE
Use Python3-style 'super()' instead of Python2-style

### DIFF
--- a/docs/extensions/napoleon_django/docstring.py
+++ b/docs/extensions/napoleon_django/docstring.py
@@ -78,8 +78,7 @@ class DjangoGoogleDocstring(GoogleDocstring):
         # django-ness is added to the class before _parse runs. Thus, self._initialized.
         # See _parse below for how this attr gets used to delay parsing.
         self._initialized = False
-        super(DjangoGoogleDocstring, self).__init__(
-            docstring, config, app, what, name, obj, options)
+        super().__init__(docstring, config, app, what, name, obj, options)
         self._sections.update({
             'fields': self._parse_fields_section,
             'relations': self._parse_relations_section,
@@ -89,7 +88,7 @@ class DjangoGoogleDocstring(GoogleDocstring):
 
     def _parse(self):
         if self._initialized:
-            return super(DjangoGoogleDocstring, self)._parse()
+            return super()._parse()
 
     def _parse_fields_section(self, section):
         return self._parse_django_section(section, 'field')

--- a/pulpcore/pulpcore/app/apps.py
+++ b/pulpcore/pulpcore/app/apps.py
@@ -53,7 +53,7 @@ class PulpPluginAppConfig(apps.AppConfig):
     # own model importing method.
 
     def __init__(self, app_name, app_module):
-        super(PulpPluginAppConfig, self).__init__(app_name, app_module)
+        super().__init__(app_name, app_module)
 
         # Module containing viewsets eg. <module 'pulp_plugin.app.viewsets'
         # from 'pulp_plugin/app/viewsets.pyc'>. Set by import_viewsets().

--- a/pulpcore/pulpcore/app/models/base.py
+++ b/pulpcore/pulpcore/app/models/base.py
@@ -89,7 +89,7 @@ class MasterModel(Model):
         # to filter for specific detail model types across master's relations.
         if not self.type:
             self.type = self.TYPE
-        return super(MasterModel, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     def cast(self):
         """Return a "Detail" model instance of this master-detail pair.
@@ -128,7 +128,7 @@ class MasterModel(Model):
         # similar to Model's __str__, but type-aware
         cast = self.cast()
         if cast is self:
-            return super(MasterModel, self).__str__()
+            return super().__str__()
 
         try:
             return '<{} (type={}): {}>'.format(self._meta.object_name, cast.TYPE, cast.name)

--- a/pulpcore/pulpcore/app/models/fields.py
+++ b/pulpcore/pulpcore/app/models/fields.py
@@ -21,7 +21,7 @@ class ArtifactFileField(FileField):
         Returns:
             Field's value just before saving.
         """
-        file = super(FileField, self).pre_save(model_instance, add)
+        file = super().pre_save(model_instance, add)
         if file and file._committed and add:
             file._file = TemporaryDownloadedFile(open(file.name, 'rb'))
             file._committed = False

--- a/pulpcore/pulpcore/app/models/progress.py
+++ b/pulpcore/pulpcore/app/models/progress.py
@@ -85,10 +85,10 @@ class ProgressReport(Model):
 
         if self._using_context_manager and self._last_save_time:
             if now - self._last_save_time >= datetime.timedelta(milliseconds=BATCH_INTERVAL):
-                super(ProgressReport, self).save(*args, **kwargs)
+                super().save(*args, **kwargs)
                 self._last_save_time = now
         else:
-            super(ProgressReport, self).save(*args, **kwargs)
+            super().save(*args, **kwargs)
             self._last_save_time = now
 
     def __enter__(self):

--- a/pulpcore/pulpcore/app/response.py
+++ b/pulpcore/pulpcore/app/response.py
@@ -34,4 +34,4 @@ class OperationPostponedResponse(Response):
             task = {"_href": reverse('tasks-detail', args=[result.task_id], request=request),
                     "task_id": result.task_id}
             tasks.append(task)
-        super(OperationPostponedResponse, self).__init__(data=tasks, status=202)
+        super().__init__(data=tasks, status=202)

--- a/pulpcore/pulpcore/app/serializers/base.py
+++ b/pulpcore/pulpcore/app/serializers/base.py
@@ -92,7 +92,7 @@ class GenericKeyValueRelatedField(serializers.DictField):
     def to_representation(self, value):
         # The field being represented isn't a dict, but the mapping attr is,
         # so value.mapping is the actual value that needs to be represented.
-        return super(GenericKeyValueRelatedField, self).to_representation(value.mapping)
+        return super().to_representation(value.mapping)
 
 
 class ModelSerializer(serializers.HyperlinkedModelSerializer):
@@ -120,7 +120,7 @@ class ModelSerializer(serializers.HyperlinkedModelSerializer):
         # pop related fields out of validated data
         generic_field_mappings = self._generic_field_mappings(validated_data)
 
-        instance = super(ModelSerializer, self).create(validated_data)
+        instance = super().create(validated_data)
 
         # populate related fields
         self._populate_generic_fields(instance, generic_field_mappings)
@@ -131,7 +131,7 @@ class ModelSerializer(serializers.HyperlinkedModelSerializer):
         # pop related fields out of validated data
         generic_field_mappings = self._generic_field_mappings(validated_data)
 
-        instance = super(ModelSerializer, self).update(instance, validated_data)
+        instance = super().update(instance, validated_data)
 
         # populate related fields
         self._populate_generic_fields(instance, generic_field_mappings)
@@ -267,7 +267,7 @@ class _DetailFieldMixin:
             # needs to have it set before being called. Unfortunately, a model instance
             # is required to derive this value, so we can't make a view_name property.
             view_name = MatchingNullViewName()
-        super(_DetailFieldMixin, self).__init__(view_name, **kwargs)
+        super().__init__(view_name, **kwargs)
 
     def _view_name(self, obj):
         # this is probably memoizeable based on the model class if we want to get cachey
@@ -284,7 +284,7 @@ class _DetailFieldMixin:
     def get_url(self, obj, view_name, *args, **kwargs):
         # ignore the passed in view name and return the url to the cast unit, not the generic unit
         view_name = self._view_name(obj)
-        return super(_DetailFieldMixin, self).get_url(obj, view_name, *args, **kwargs)
+        return super().get_url(obj, view_name, *args, **kwargs)
 
 
 class DetailIdentityField(_DetailFieldMixin, serializers.HyperlinkedIdentityField):
@@ -310,7 +310,7 @@ class DetailRelatedField(_DetailFieldMixin, serializers.HyperlinkedRelatedField)
     """
     def get_object(self, *args, **kwargs):
         # return the cast object, not the generic contentunit
-        return super(DetailRelatedField, self).get_object(*args, **kwargs).cast()
+        return super().get_object(*args, **kwargs).cast()
 
     def use_pk_only_optimization(self):
         """

--- a/pulpcore/pulpcore/app/viewsets/content.py
+++ b/pulpcore/pulpcore/app/viewsets/content.py
@@ -90,7 +90,7 @@ class ArtifactViewSet(CreateDestroyReadNamedModelViewSet):
         Remove Artifact only if it is not associated with any Content.
         """
         try:
-            return super(ArtifactViewSet, self).destroy(request, pk)
+            return super().destroy(request, pk)
         except models.ProtectedError:
             msg = _('The Artifact cannot be deleted because it is associated with Content.')
             data = {'detail': msg}

--- a/pulpcore/pulpcore/exceptions/base.py
+++ b/pulpcore/pulpcore/exceptions/base.py
@@ -57,7 +57,7 @@ class ResourceImmutableError(PulpException):
         Args:
             model (pulpcore.app.models.Model): that the user is trying to update
         """
-        super(ResourceImmutableError, self).__init__("PLP0003")
+        super().__init__("PLP0003")
         self.model = model
 
     def __str__(self):

--- a/pulpcore/pulpcore/exceptions/http.py
+++ b/pulpcore/pulpcore/exceptions/http.py
@@ -19,7 +19,7 @@ class MissingResource(PulpException):
         :param resources: keyword arguments of resource_type=resource_id
         :type resources: dict
         """
-        super(MissingResource, self).__init__("PLP0001")
+        super().__init__("PLP0001")
         self.resources = resources
 
     def __str__(self):

--- a/pulpcore/pulpcore/exceptions/plugin.py
+++ b/pulpcore/pulpcore/exceptions/plugin.py
@@ -14,7 +14,7 @@ class MissingPlugin(PulpException):
         :param resources: keyword arguments of resource_type=resource_id
         :type resources: dict
         """
-        super(MissingPlugin, self).__init__("PLP0002")
+        super().__init__("PLP0002")
         self.plugin_app_label = plugin_app_label
 
     def __str__(self):

--- a/pulpcore/pulpcore/tasking/tasks.py
+++ b/pulpcore/pulpcore/tasking/tasks.py
@@ -231,7 +231,7 @@ class UserFacingTask(PulpTask):
             An AsyncResult instance as returned by Celery's apply_async
         """
 
-        async_result = super(UserFacingTask, self).apply_async(args=args, kwargs=kwargs, **options)
+        async_result = super().apply_async(args=args, kwargs=kwargs, **options)
 
         # Set the parent attribute if being dispatched inside of a Task
         parent_arg = self._get_parent_arg()
@@ -270,7 +270,7 @@ class UserFacingTask(PulpTask):
             self.pr = cProfile.Profile()
             self.pr.enable()
 
-        return super(UserFacingTask, self).__call__(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
 
     def on_success(self, retval, task_id, args, kwargs):
         """


### PR DESCRIPTION
Specifying ```super(ClassName, self)``` is not necessary in Python 3