### PR TITLE
"Get the Source" Instructions Omit Working Branch

### DIFF
--- a/docs/contributing/dev-setup/source.rst
+++ b/docs/contributing/dev-setup/source.rst
@@ -14,9 +14,13 @@ You will need ``pulp/devel`` and ``pulp/pulp`` at a minimum::
     $ git clone https://github.com/pulp/devel.git
     $ git clone https://github.com/pulp/pulp.git
 
+The current base branch on each of these repositories is the 3.0-dev branch.
+
 If you want to use the ``plugin`` role, you'll need to clone the corresponding plugin repository.::
 
     $ git clone https://github.com/pulp/pulp_file.git
+
+The current base branch on this repository is the master branch.
 
 If your playbook includes optional :ref:`ansible-roles`, you may require additional repositories::
 


### PR DESCRIPTION
The guide made no mention of a working branch and now provides those for
each repository mentioned.

fixes #3506
https://pulp.plan.io/issues/3506