### PR TITLE
Change how workers are represented

### DIFF
--- a/pulpcore/pulpcore/app/serializers/status.py
+++ b/pulpcore/pulpcore/app/serializers/status.py
@@ -48,8 +48,16 @@ class StatusSerializer(serializers.Serializer):
         many=True
     )
 
-    known_workers = WorkerSerializer(
-        help_text=_("List of celery workers known to the application"),
+    online_workers = WorkerSerializer(
+        help_text=_("List of online celery workers known to the application. An online worker is "
+                    "actively heartbeating and can respond to new work"),
+        many=True
+    )
+
+    missing_workers = WorkerSerializer(
+        help_text=_("List of missing celery workers known to the application. A missing worker is "
+                    "a worker that was online, but has now stopped heartbeating and has "
+                    "potentially died"),
         many=True
     )
 

--- a/pulpcore/pulpcore/app/serializers/task.py
+++ b/pulpcore/pulpcore/app/serializers/task.py
@@ -119,13 +119,12 @@ class WorkerSerializer(ModelSerializer):
         read_only=True
     )
 
-    gracefully_stopped = serializers.BooleanField(
-        help_text=_('True when the worker was shut down properly, False when the worker is \
-            online, or if it crashed (determined by timestamp).'),
+    missing = serializers.BooleanField(
+        help_text=_('True if the worker is considerd missing, otherwise False'),
         read_only=True
     )
 
     class Meta:
         model = models.Worker
         fields = ModelSerializer.Meta.fields + ('name', 'last_heartbeat',
-                                                'online', 'gracefully_stopped')
+                                                'online', 'missing')

--- a/pulpcore/pulpcore/app/views/status.py
+++ b/pulpcore/pulpcore/app/views/status.py
@@ -36,13 +36,19 @@ class StatusView(APIView):
         db_status = {'connected': self._get_db_conn_status()}
 
         try:
-            workers = Worker.objects.online_workers()
+            online_workers = Worker.objects.online_workers()
         except Exception:
-            workers = None
+            online_workers = None
+
+        try:
+            missing_workers = Worker.objects.missing_workers()
+        except Exception:
+            missing_workers = None
 
         data = {
             'versions': versions,
-            'known_workers': workers,
+            'online_workers': online_workers,
+            'missing_workers': missing_workers,
             'database_connection': db_status,
             'messaging_connection': broker_status
         }

--- a/pulpcore/pulpcore/tasking/services/worker_watcher.py
+++ b/pulpcore/pulpcore/tasking/services/worker_watcher.py
@@ -85,7 +85,7 @@ def check_celery_processes():
             'missing for more than %d seconds') % TASKING_CONSTANTS.PULP_PROCESS_TIMEOUT_INTERVAL
     _logger.debug(msg)
 
-    for worker in Worker.objects.missing_workers():
+    for worker in Worker.objects.dirty_workers():
         msg = _("Worker '%s' has gone missing, removing from list of workers") % worker.name
         _logger.error(msg)
 


### PR DESCRIPTION
* Don't serialize the 'gracefully_shutdown' field
* Create a new 'missing' property and serialize it
* In the status API, list both online and missing workers