### PR TITLE
Prevent query matching all content/artifact when not criteria included.

### DIFF
--- a/plugin/pulpcore/plugin/changeset/iterator.py
+++ b/plugin/pulpcore/plugin/changeset/iterator.py
@@ -73,7 +73,7 @@ class ContentIterator(Iterable):
         Returns:
             Q: The built query.
         """
-        q = Q()
+        q = Q(pk=None)
         for c in content:
             q |= Q(**c.key)
         return q
@@ -170,7 +170,7 @@ class ArtifactIterator(Iterable):
         Returns:
             Q: The built query.
         """
-        q = Q()
+        q = Q(pk=None)
         for artifact in (a for a in artifacts if not isinstance(a, NopPendingArtifact)):
             q |= artifact.artifact_q()
         return q

--- a/plugin/pulpcore/plugin/changeset/model.py
+++ b/plugin/pulpcore/plugin/changeset/model.py
@@ -348,7 +348,7 @@ class PendingArtifact(Pending):
         Returns:
             django.db.models.Q: A query to get the actual artifact.
         """
-        q = Q()
+        q = Q(pk=None)
         for field in Artifact.RELIABLE_DIGEST_FIELDS:
             digest = getattr(self._model, field)
             if digest:


### PR DESCRIPTION
https://pulp.plan.io/issues/3524

An empty `Q` object passed to `Model.objects.filter()` results in matching everything.  The PK will never be NULL so initializing the `Q(pk=None)` assures that when nothing else is added to the query, it will match nothing.  For the `Artifact` query, it means that when none of the digests are added to the query, it won't match everything.  Same for `Content` to be safe.