### PR TITLE
Add basic unit tests policy

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -10,5 +10,6 @@ Contributing Guide
    git
    new_contributors
    style_guide
+   unit_tests
    language_guide
    build_guide

--- a/docs/contributing/unit_tests.rst
+++ b/docs/contributing/unit_tests.rst
@@ -1,0 +1,9 @@
+.. _tests: https://github.com/pulp/pulp/blob/3.0-dev/tests/
+
+Unit Tests
+==========
+
+New code is highly encouraged to have basic unit tests that demonstrate its functionality. A Pull
+Request that has failing unit tests cannot be merged.
+
+The unit tests for both `pulpcore` and `pulpcore-plugin` live in the tests_ folder.


### PR DESCRIPTION
This policy is a starting point based feedback via pulp-dev. The
language adopted was shared via pulp-dev for comment.