### PR TITLE
Uses smaller Changeset batches

### DIFF
--- a/plugin/pulpcore/plugin/changeset/iterator.py
+++ b/plugin/pulpcore/plugin/changeset/iterator.py
@@ -93,8 +93,8 @@ class ContentIterator(Iterable):
             dict: A dictionary of {model_class: [content,]}
                 Each content is: PendingContent.
         """
-        # should be < 1000 as higher values may hit the sqlite expression tree size limit
-        for batch in BatchIterator(self.content, 800):
+        # should be < 400 as higher values may hit the sqlite expression tree size limit
+        for batch in BatchIterator(self.content, 400):
             collated = {}
             for content in batch:
                 _list = collated.setdefault(type(content.model), list())


### PR DESCRIPTION
This resolves an issue where sqlite was emitting 'Too Many SQL
Variables' error when mirroring parts of Galaxy.

re #3499
https://pulp.plan.io/issues/3499