### PR TITLE
Adds 429 Retry Support

### DIFF
--- a/docs/plugins/plugin-api/download.rst
+++ b/docs/plugins/plugin-api/download.rst
@@ -61,10 +61,10 @@ the downloader's `run()` method when the download is complete.
 .. autoclass:: pulpcore.plugin.download.DownloadResult
     :no-members:
 
-.. _configuring-from-an-remote:
+.. _configuring-from-a-remote:
 
-Configuring from an Remote
-----------------------------
+Configuring from a Remote
+-------------------------
 
 When fetching content during a sync, the remote has settings like SSL certs, SSL validation, basic
 auth credentials, and proxy settings. Downloaders commonly want to use these settings while
@@ -90,17 +90,25 @@ supported urls.
     remote instance share an `aiohttp` session, which provides a connection pool, connection
     reusage and keep-alives shared across all downloaders produced by a single remote.
 
+
+.. _automatic-retry:
+
+Automatic Retry
+---------------
+
+The :class:`~pulpcore.plugin.download.HttpDownloader` will automatically retry 10 times if the
+server responds with one of the following error codes:
+
+* 429 - Too Many Requests
+
+
 .. _exception-handling:
 
 Exception Handling
 ------------------
 
-All downloaders are expected to handle recoverable errors automatically. For example, the
-:class:`~pulpcore.plugin.download.HttpDownloader` is expected to retry if a server is too
-busy or if a redirect occurs.
-
 Unrecoverable errors of several types can be raised during downloading. One example is a
-:ref:`validation exception <validation-exceptions>` that are raised if the content downloaded fails
+:ref:`validation exception <validation-exceptions>` that is raised if the content downloaded fails
 size or digest validation. There can also be protocol specific errors such as an
 ``aiohttp.ClientResponse`` being raised when a server responds with a 400+ response such as an HTTP
 403.
@@ -119,8 +127,8 @@ recorded as a non-fatal exception on the task. Plugin writers can also choose to
 task by allowing the exception be uncaught which would mark the entire task as failed.
 
 .. note::
-    The :class:`~pulpcore.plugin.download.HttpDownloader` will raise an exception for any
-    response code that is 400 or greater.
+    The :class:`~pulpcore.plugin.download.HttpDownloader` automatically retry in some cases, but if
+    unsuccessful will raise an exception for any HTTP response code that is 400 or greater.
 
 .. _custom-download-behavior:
 

--- a/plugin/pulpcore/plugin/download/base.py
+++ b/plugin/pulpcore/plugin/download/base.py
@@ -1,11 +1,15 @@
 import asyncio
 from collections import namedtuple
 import hashlib
+import logging
 import os
 import tempfile
 
 from pulpcore.app.models import Artifact
 from .exceptions import DigestValidationError, SizeValidationError
+
+
+log = logging.getLogger(__name__)
 
 
 DownloadResult = namedtuple('DownloadResult', ['url', 'artifact_attributes', 'path', 'exception'])
@@ -40,7 +44,7 @@ def attach_url_to_exception(func):
             :class:`~pulpcore.plugin.download.BaseDownloader`
 
     Returns:
-        A function that will attach the `url` to any exception emitted by `func`
+        A coroutine that will attach the `url` to any exception emitted by `func`
     """
     async def wrapper(downloader):
         try:

--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -4,6 +4,7 @@ requirements = [
     'pulpcore',
     'aiohttp',
     'aiofiles',
+    'backoff',
 ]
 
 with open('README.rst') as f:


### PR DESCRIPTION
All retry support is provided by the 'backoff' library which also
provides an asyncio compatible interface.

This updates the docs and docstrings to call out the new retry
functionality.

https://pulp.plan.io/issues/3421
closes #3421