### PR TITLE
Register plugin provided urls.py

### DIFF
--- a/pulpcore/pulpcore/app/apps.py
+++ b/pulpcore/pulpcore/app/apps.py
@@ -7,6 +7,7 @@ from pulpcore.exceptions.plugin import MissingPlugin
 
 VIEWSETS_MODULE_NAME = 'viewsets'
 SERIALIZERS_MODULE_NAME = 'serializers'
+URLS_MODULE_NAME = 'urls'
 
 
 def pulp_plugin_configs():
@@ -61,6 +62,9 @@ class PulpPluginAppConfig(apps.AppConfig):
         # when this app becomes ready.
         self.viewsets_module = None
 
+        # Module containing urlpatterns
+        self.urls_module = None
+
         # Mapping of model names to viewsets (viewsets unrelated to models are excluded)
         self.named_viewsets = None
         # Mapping of serializer names to serializers
@@ -69,6 +73,7 @@ class PulpPluginAppConfig(apps.AppConfig):
     def ready(self):
         self.import_viewsets()
         self.import_serializers()
+        self.import_urls()
 
     def import_serializers(self):
         # circular import avoidance
@@ -110,6 +115,14 @@ class PulpPluginAppConfig(apps.AppConfig):
                 except TypeError:
                     # obj isn't a class, issubclass exploded but obj can be safely filtered out
                     continue
+
+    def import_urls(self):
+        """
+        If a plugin defines a urls.py, include it.
+        """
+        if module_has_submodule(self.module, URLS_MODULE_NAME) and self.name != "pulpcore.app":
+            urls_module_name = '%s.%s' % (self.name, URLS_MODULE_NAME)
+            self.urls_module = import_module(urls_module_name)
 
 
 class PulpAppConfig(PulpPluginAppConfig):

--- a/pulpcore/pulpcore/app/urls.py
+++ b/pulpcore/pulpcore/app/urls.py
@@ -98,9 +98,13 @@ class ViewSetNode:
 
 
 all_viewsets = []
+plugin_patterns = []
+# Iterate over each app, including pulpcore and the plugins.
 for app_config in pulp_plugin_configs():
     for viewset in app_config.named_viewsets.values():
         all_viewsets.append(viewset)
+    if app_config.urls_module:
+        plugin_patterns.append(app_config.urls_module)
 
 sorted_by_depth = sorted(all_viewsets, key=lambda vs: vs._get_nest_depth())
 vs_tree = ViewSetNode()
@@ -139,3 +143,7 @@ urlpatterns.append(url(r'^api/v3/$', schema_view))
 all_routers = [root_router] + vs_tree.register_with(root_router)
 for router in all_routers:
     urlpatterns.append(url(r'^api/v3/', include(router.urls)))
+
+# If plugins define a urls.py, include them into the root namespace.
+for plugin_pattern in plugin_patterns:
+    urlpatterns.append(url(r'', include(plugin_pattern)))


### PR DESCRIPTION
If plugins define a urls.py, register it. This allows the plugin writer
to register views at arbitrary endpoints, allowing them to implement a
Live API.

fixes #3560
https://pulp.plan.io/issues/3560

To demonstrate how this is used, this PR is a proof of concept.
https://github.com/pulp/pulp_file/pull/66