### PR TITLE
Fix call to httpie

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -28,7 +28,7 @@ fi
 if [ -z $PULP_SMASH_PR_NUMBER ]; then
   pip install git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
 else
-  export PULP_SMASH_SHA=$(http https://api.github.com/repos/PulpQE/pulp-smash/pulls/$PULP_SMASH_PR_NUMBER | jq -r '.merge_commit_sha')
+  export PULP_SMASH_SHA=$(curl https://api.github.com/repos/PulpQE/pulp-smash/pulls/$PULP_SMASH_PR_NUMBER | jq -r '.merge_commit_sha')
   cd ../
   git clone https://github.com/PulpQE/pulp-smash.git
   cd pulp-smash


### PR DESCRIPTION
Error from Travis: `The program 'http' is currently not installed. To run 'http' please ask your administrator to install the package 'httpie'.`

Testing against the following PRs:

Required PR: https://github.com/pulp/pulp_file/pull/65
Required PR: https://github.com/PulpQE/pulp-smash/pull/770