### PR TITLE
Have get_resource() use pk and only pk if pk is provided

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/base.py
+++ b/pulpcore/pulpcore/app/viewsets/base.py
@@ -129,7 +129,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
         except Resolver404:
             raise DRFValidationError(detail=_('URI not valid: {u}').format(u=uri))
         if 'pk' in match.kwargs:
-            kwargs = match.kwargs
+            kwargs = {'pk': match.kwargs['pk']}
         else:
             kwargs = {}
             for key, value in match.kwargs.items():


### PR DESCRIPTION
We should ignore other kwargs since pk should uniquely identify the
resource. The problem we were experiencing in pulp_ansible is that we
had a pk and a role_pk. The conversion from role_pk to role_id only
happens inside the else block and so we're getting a FieldError because
role_pk doesn't exist on the model. Instead, I think we should just use
the pk kwarg and ignore the rest.