### PR TITLE
Prevent duplicate relateive paths within a publication.

### DIFF
--- a/pulpcore/pulpcore/app/models/publication.py
+++ b/pulpcore/pulpcore/app/models/publication.py
@@ -143,8 +143,11 @@ class PublishedArtifact(PublishedFile):
     content_artifact = models.ForeignKey('ContentArtifact', on_delete=models.CASCADE)
 
     class Meta:
-        unique_together = ('publication', 'content_artifact')
         default_related_name = 'published_artifact'
+        unique_together = (
+            ('publication', 'content_artifact'),
+            ('publication', 'relative_path')
+        )
 
 
 class PublishedMetadata(PublishedFile):
@@ -161,8 +164,11 @@ class PublishedMetadata(PublishedFile):
     file = models.FileField(upload_to=_storage_path, max_length=255)
 
     class Meta:
-        unique_together = ('publication', 'file')
         default_related_name = 'published_metadata'
+        unique_together = (
+            ('publication', 'file'),
+            ('publication', 'relative_path')
+        )
 
 
 class Distribution(Model):


### PR DESCRIPTION
https://pulp.plan.io/issues/3605

I would have added as: `PublishedFile.Meta.unique_together = (publication, relative_path)` but django does not deal with it properly.  This seems to be a know flaw[1] in django.

I would have mentioned the _new_ restriction in the plugin writer's docs but did not find an appropriate place.

[1] https://code.djangoproject.com/ticket/16732