### PR TITLE
Allowing publication to be unset on distributions

### DIFF
--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -211,7 +211,8 @@ class DistributionSerializer(ModelSerializer):
         required=False,
         help_text=_('The publication being served as defined by this distribution'),
         queryset=models.Publication.objects.exclude(complete=False),
-        view_name='publications-detail'
+        view_name='publications-detail',
+        allow_null=True
     )
     repository = serializers.HyperlinkedRelatedField(
         required=False,


### PR DESCRIPTION
The problem is you can create distributions without publications but you can't unset a publication on a distribution once it is set.

fixes #3671
https://pulp.plan.io/issues/3671