### PR TITLE
Moar coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
-cover_pylib = 0
-branch = False
-source = pulpcore
+concurrency = multiprocessing
+parallel = true
 
 omit =
   /*/tests/*


### PR DESCRIPTION
Adds a coverage report for:
* pulp-smash-workers
* pulp-smash-webservers

Also it renames the existing unittest coverage report to 'unittests'.