### PR TITLE
Consistent names in server.yaml

### DIFF
--- a/.travis/server.yaml
+++ b/.travis/server.yaml
@@ -1,4 +1,4 @@
-databases:
+DATABASES:
   default:
     ENGINE: django.db.backends.postgresql_psycopg2
     NAME: pulp

--- a/docs/installation/configuration-files.rst
+++ b/docs/installation/configuration-files.rst
@@ -13,7 +13,7 @@ SECRET_KEY
 ^^^^^^^^^^
 
     In order to get a pulp server up and running a `Django SECRET_KEY
-    <https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-SECRET_KEY>`_ *must* be
+    <https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-secret_key>`_ *must* be
     provided in server.yaml. It is highly recommend that this SECRET_KEY be enclosed in single quotes,
     so yaml string escaping does not to be dealt with.
 
@@ -46,10 +46,10 @@ logging
          handlers: ["myCustomHandler"]
          level: DEBUG
 
-content
+CONTENT
 ^^^^^^^
 
-web_server
+WEB_SERVER
   Defines the type of web server that is running the content application.
   When set to `django`, the content is streamed.
   When set to `apache`, the `X-SENDFILE` header is injected which delegates

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -132,9 +132,9 @@ is named ``postgresql-server``.
 The default PostgreSQL user and database name in the provided server.yaml file is ``pulp``. Unless you plan to
 customize the configuration of your Pulp installation, you will need to create this user with the proper permissions
 and also create the ``pulp`` database owned by the ``pulp`` user. If you do choose to customize your installation,
-the database options can be configured in the `databases` section of your server.yaml settings file.
+the database options can be configured in the `DATABASES` section of your server.yaml settings file.
 See the `Django database settings documentation <https://docs.djangoproject.com/en/1.11/ref/settings/#databases>`_
-for more information on setting the `databases` values in server.yaml.
+for more information on setting the `DATABASES` values in server.yaml.
 
 After installing and configuring PostgreSQL, you should configure it to start at boot, and then start it::
 

--- a/pulpcore/pulpcore/app/serializers/fields.py
+++ b/pulpcore/pulpcore/app/serializers/fields.py
@@ -173,8 +173,8 @@ class BaseURLField(serializers.CharField):
     """
 
     def to_representation(self, value):
-        if settings.CONTENT['host']:
-            host = settings.CONTENT['host']
+        if settings.CONTENT['HOST']:
+            host = settings.CONTENT['HOST']
         else:
             host = self.context['request'].get_host()
         return ''.join([host, reverse('content-app'), value])

--- a/pulpcore/pulpcore/app/settings.py
+++ b/pulpcore/pulpcore/app/settings.py
@@ -162,7 +162,7 @@ STATIC_URL = '/static/'
 # /etc/pulp/ is missing or if it does not have values for every setting
 _DEFAULT_PULP_SETTINGS = {
     # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-    'databases': {
+    'DATABASES': {
         'default': {
             'ENGINE': 'django.db.backends.postgresql_psycopg2',
             'NAME': 'pulp',
@@ -197,21 +197,21 @@ _DEFAULT_PULP_SETTINGS = {
             },
         }
     },
-    'server': {
-        'working_directory': '/var/lib/pulp/tmp',
+    'SERVER': {
+        'WORKING_DIRECTORY': '/var/lib/pulp/tmp',
     },
-    'content': {
-        'web_server': 'django',
-        'host': None,
+    'CONTENT': {
+        'WEB_SERVER': 'django',
+        'HOST': None,
     },
-    'redis': {
-        'host': '127.0.0.1',
-        'port': 6379,
-        'password': ''
+    'REDIS': {
+        'HOST': '127.0.0.1',
+        'PORT': 6379,
+        'PASSWORD': ''
     },
-    'profiling': {
-        'enabled': False,
-        'directory': '/var/lib/pulp/c_profiles'
+    'PROFILING': {
+        'ENABLED': False,
+        'DIRECTORY': '/var/lib/pulp/c_profiles'
     }
 }
 

--- a/pulpcore/pulpcore/app/views/content.py
+++ b/pulpcore/pulpcore/app/views/content.py
@@ -199,7 +199,7 @@ class ContentView(View):
             django.http.HttpResponseForbidden: on forbidden.
 
         """
-        server = settings.CONTENT['web_server']
+        server = settings.CONTENT['WEB_SERVER']
 
         try:
             path = request.path.strip('/')

--- a/pulpcore/pulpcore/etc/pulp/server.yaml
+++ b/pulpcore/pulpcore/etc/pulp/server.yaml
@@ -4,15 +4,15 @@
 
 # Django Settings
 #
-# `allowed_hosts`: A list of strings representing the host/domain names that
+# `ALLOWED_HOSTS`: A list of strings representing the host/domain names that
 # Pulp can serve. This is a security measure to prevent HTTP Host header
 # attacks. A value beginning with a period can be used as a sub-domain wildcard.
 # The default is the host's FQDN.
 #
-# allowed_hosts:
+# ALLOWED_HOSTS:
 #   - pulp.example.com
 
-# `databases`: An associative array (dictionary) of databases to use. For the
+# `DATABASES`: An associative array (dictionary) of databases to use. For the
 # full list of configuration options, refer to the Django database documentation
 # shipped with your version of Django, or online at
 # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
@@ -20,7 +20,7 @@
 # By default, Pulp will use a Postgresql database. The following configuration can be configured to
 # use another Django supported database.
 #
-databases:
+DATABASES:
   default:
     CONN_MAX_AGE: 0
     ENGINE: django.db.backends.postgresql_psycopg2
@@ -73,38 +73,38 @@ databases:
 
 # Redis configuration
 #
-# `redis`: Redis provides the basis for the Pulp tasking system. For security ensure your Redis
+# `REDIS`: Redis provides the basis for the Pulp tasking system. For security ensure your Redis
 # deployment can only be reached via trusted network endpoints per https://redis.io/topics/security.
 # Pulp does support password based authenticated from the client. For encrypted communication
 # of Redis traffic over untrusted networks Redis recommends spiped.
 #
-# redis:
-#   host: 127.0.0.1
-#   port: 6379
-#   password:
+# REDIS:
+#   HOST: 127.0.0.1
+#   PORT: 6379
+#   PASSWORD:
 
 # Server configuration
 #
-# `server`: Server behavior configuration of pulp.
-#   `working_directory`: Path for pulp workers to create temporary directories
+# `SERVER`: Server behavior configuration of pulp.
+#   `WORKING_DIRECTORY`: Path for pulp workers to create temporary directories
 #                        for completion of tasks
 #
-# server:
-#   working_directory: /var/lib/pulp/tmp
+# SERVER:
+#   WORKING_DIRECTORY: /var/lib/pulp/tmp
 
 # Content Application
 #
-# `content`: The content serving application.
-#   `web_server`: The type of web server.  Must be: (django|apache|nginx).
+# `CONTENT`: The content serving application.
+#   `WEB_SERVER`: The type of web server.  Must be: (django|apache|nginx).
 #                 When set to 'apache', the X-SENDFILE header is injected which delegates
 #                 streaming the content to Apache.  Requires: mod_xsendfile to be installed.
 #                 When set to 'nginx', the X-Accel-Redirect header is injected which delegates
 #                 streaming the content to NGINX.
-#   `host`: The host name or IP and an optional port number for the Content App. (e.g.
+#   `HOST`: The host name or IP and an optional port number for the Content App. (e.g.
 #           example.com:8000) This value should be specified only if the Content App is served on
 #           a host that's different from the REST API. The default value is the same as the host
 #           used to serve the REST API.
 #
-# content:
-#   web_server: django
-#   host: pulp.example.com
+# CONTENT:
+#   WEB_SERVER: django
+#   HOST: pulp.example.com

--- a/pulpcore/pulpcore/tasking/connection.py
+++ b/pulpcore/pulpcore/tasking/connection.py
@@ -8,6 +8,6 @@ def get_redis_connection():
     global _conn
 
     if _conn is None:
-        _conn = Redis(host=settings.REDIS['host'], port=settings.REDIS['port'],
-                      password=settings.REDIS['password'])
+        _conn = Redis(host=settings.REDIS['HOST'], port=settings.REDIS['PORT'],
+                      password=settings.REDIS['PASSWORD'])
     return _conn

--- a/pulpcore/pulpcore/tasking/services/storage.py
+++ b/pulpcore/pulpcore/tasking/services/storage.py
@@ -33,7 +33,7 @@ class WorkerDirectory:
         Returns:
             str: The absolute path to a worker's root directory.
         """
-        root = settings.SERVER['working_directory']
+        root = settings.SERVER['WORKING_DIRECTORY']
         path = os.path.join(root, hostname)
         return path
 

--- a/pulpcore/tests/test_settings.py
+++ b/pulpcore/tests/test_settings.py
@@ -48,11 +48,11 @@ class TestLoadSettings(TestCase):
     def test_settings_file(self):
         """Assert loading a file merges the file settings with the default"""
         override = """
-        allowed_hosts:
+        ALLOWED_HOSTS:
           - subdomains.all.the.way.down.www.example.com
         """
         expected = pulp_settings._DEFAULT_PULP_SETTINGS.copy()
-        expected['allowed_hosts'] = ['subdomains.all.the.way.down.www.example.com']
+        expected['ALLOWED_HOSTS'] = ['subdomains.all.the.way.down.www.example.com']
 
         mocked_open = mock.mock_open(read_data=override)
         with mock.patch('pulpcore.app.settings.open', mocked_open, create=True):


### PR DESCRIPTION
The naming convention for yaml is lowercase snake.
We had some all-uppercase names mixed in, now made consistent.

fixes #3589
https://pulp.plan.io/issues/3589