### PR TITLE
Remove pulp's custom FileField serializer

### DIFF
--- a/pulpcore/pulpcore/app/models/repository.py
+++ b/pulpcore/pulpcore/app/models/repository.py
@@ -61,11 +61,11 @@ class Remote(MasterModel):
 
         url (models.TextField): The URL of an external content source.
         validate (models.BooleanField): If True, the plugin will validate imported files.
-        ssl_ca_certificate (models.TextField): A PEM encoded CA certificate used to validate the
+        ssl_ca_certificate (models.FileField): A PEM encoded CA certificate used to validate the
             server certificate presented by the external source.
-        ssl_client_certificate (models.TextField): A PEM encoded client certificate used
+        ssl_client_certificate (models.FileField): A PEM encoded client certificate used
             for authentication.
-        ssl_client_key (models.TextField): A PEM encoded private key used for authentication.
+        ssl_client_key (models.FileField): A PEM encoded private key used for authentication.
         ssl_validation (models.BooleanField): If True, SSL peer validation must be performed.
         proxy_url (models.TextField): The optional proxy URL.
             Format: scheme://user:password@host:port

--- a/pulpcore/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/pulpcore/app/serializers/__init__.py
@@ -4,7 +4,7 @@
 from pulpcore.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # noqa
     ModelSerializer, MasterModelSerializer, DetailIdentityField, DetailRelatedField,
     view_name_for_model, viewset_for_model)
-from pulpcore.app.serializers.fields import (BaseURLField, ContentRelatedField, FileField,  # noqa
+from pulpcore.app.serializers.fields import (BaseURLField, ContentRelatedField,  # noqa
                                              LatestVersionField)
 from pulpcore.app.serializers.content import ContentSerializer, ArtifactSerializer  # noqa
 from pulpcore.app.serializers.progress import ProgressReportSerializer  # noqa

--- a/pulpcore/pulpcore/app/serializers/fields.py
+++ b/pulpcore/pulpcore/app/serializers/fields.py
@@ -17,18 +17,6 @@ class ContentRelatedField(DetailRelatedField):
     queryset = models.Content.objects.all()
 
 
-class FileField(serializers.CharField):
-    """
-    Serializer Field for model.FileField and REST API passing file content.
-    """
-
-    def to_internal_value(self, data):
-        return models.FileContent(data)
-
-    def to_representation(self, value):
-        return str(value)
-
-
 class ContentArtifactsField(serializers.DictField):
     """
     A serializer field for the 'artifacts' ManyToManyField on the Content model.

--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -11,7 +11,6 @@ from pulpcore.app.serializers import (
     BaseURLField,
     DetailIdentityField,
     DetailRelatedField,
-    FileField,
     GenericKeyValueRelatedField,
     LatestVersionField,
     MasterModelSerializer,
@@ -67,18 +66,18 @@ class RemoteSerializer(MasterModelSerializer):
         help_text='If True, the plugin will validate imported artifacts.',
         required=False,
     )
-    ssl_ca_certificate = FileField(
+    ssl_ca_certificate = serializers.FileField(
         help_text='A PEM encoded CA certificate used to validate the server '
                   'certificate presented by the remote server.',
         write_only=True,
         required=False,
     )
-    ssl_client_certificate = FileField(
+    ssl_client_certificate = serializers.FileField(
         help_text='A PEM encoded client certificate used for authentication.',
         write_only=True,
         required=False,
     )
-    ssl_client_key = FileField(
+    ssl_client_key = serializers.FileField(
         help_text='A PEM encoded private key used for authentication.',
         write_only=True,
         required=False,


### PR DESCRIPTION
serializer.fields.FileField currently does not work since models.FileContent
was removed. This PR removes this custom field, and starts using
drf's FileField serializer.