### PR TITLE
Fix docs/make.bat pip&git induced coflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     packages:
       - graphviz
 install:
-    - "pip install flake8 sphinx sphinxcontrib-swaggerdoc celery sphinxcontrib-swaggerdoc 'django<2' git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml"
+    - "pip install flake8 sphinx sphinxcontrib-swaggerdoc celery sphinxcontrib-swaggerdoc 'django<2' sphinx_rtd_theme pyyaml"
     # setup plantuml
     - wget "https://fossies.org/linux/dmelt/lib/graph/plantuml.jar" -O plantuml.jar
     - sudo mkdir -p /opt/plantuml


### PR DESCRIPTION
The installation required a custom commit from sphinx_rtd_theme
git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26

The pip however started to get issues pulling that in:

```
$ pip install flake8 sphinx sphinxcontrib-swaggerdoc celery sphinxcontrib-swaggerdoc 'django<2' git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26 pyyaml
Collecting git+https://github.com/snide/sphinx_rtd_theme.git@abfa98539a2bfc44198a9ca8c2f16efe84cc4d26
  Cloning https://github.com/snide/sphinx_rtd_theme.git (to abfa98539a2bfc44198a9ca8c2f16efe84cc4d26) to /tmp/pip-drCLVI-build
  Could not find a tag or branch 'abfa98539a2bfc44198a9ca8c2f16efe84cc4d26', assuming commit.
error: Your local changes to the following files would be overwritten by checkout:
	docs/make.bat
Please commit your changes or stash them before you switch branches.
Aborting
Command "git checkout -q abfa98539a2bfc44198a9ca8c2f16efe84cc4d26" failed with error code 1 in /tmp/pip-drCLVI-build
```

This patch replaces custom commit with straight package install that seems to workaround the issue (at least for now).