### PR TITLE
Fix dependencies for source installation

### DIFF
--- a/plugin/setup.py
+++ b/plugin/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'pulpcore==3.0.0b3',
+    'pulpcore',
     'aiohttp',
     'aiofiles',
     'backoff',
@@ -14,7 +14,7 @@ setup(
     name='pulpcore-plugin',
     description='Pulp Plugin API',
     long_description=long_description,
-    version='0.1.0b2',
+    version='0.1.0b3',
     license='GPLv2+',
     packages=find_packages(exclude=['test']),
     author='Pulp Team',

--- a/pulpcore/setup.py
+++ b/pulpcore/setup.py
@@ -14,7 +14,7 @@ requirements = [
     'PyYAML',
     'rq',
     'setuptools',
-    'pulpcore-common==3.0.0b2'
+    'pulpcore-common'
 ]
 
 setup(


### PR DESCRIPTION
pulpcore is currently at 3.0.0b4, pulpcore-plugin requires 3.0.0b3,
so the editable installation fails and it falls back to installing from
PyPI. So the developer installation will not actually be a developer
installation.