### PR TITLE
Set parsers explicitly for Artifact Viewset

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/content.py
+++ b/pulpcore/pulpcore/app/viewsets/content.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 from django.db import models, transaction
 from django_filters.rest_framework import filterset
 from rest_framework import status, mixins
+from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.response import Response
 
 from pulpcore.app.models import Artifact, Content, ContentArtifact
@@ -33,6 +34,7 @@ class ArtifactViewSet(NamedModelViewSet,
     queryset = Artifact.objects.all()
     serializer_class = ArtifactSerializer
     filter_class = ArtifactFilter
+    parser_classes = (MultiPartParser, FormParser)
 
     def destroy(self, request, pk):
         """


### PR DESCRIPTION
Uploading files cannot be done using JSON, this
disable support for the application/json media_type,
Because a file upload is required to create an artifact.

This does not need to be done for Remotes, because
files on a remote is optional.

closes #3622
https://pulp.plan.io/issues/3622