### PR TITLE
Redact last_override_config

### DIFF
--- a/docs/user-guide/release-notes/2.16.x.rst
+++ b/docs/user-guide/release-notes/2.16.x.rst
@@ -2,6 +2,17 @@
 Pulp 2.16 Release Notes
 =======================
 
+Pulp 2.16.2
+===========
+
+This is a security fix for CVE-2018-1090 which leaks security info via the `last_override_config` on
+importers and distributors serialized via the Rest API. See `issue 3521 <https://github.com/pulp/pulp/pull/3513>`_
+for more information. With this release, that field no longer reports the information saved in the
+database. Instead it will always show as::
+
+    'last_override_config': {}
+
+
 Pulp 2.16.0
 ===========
 

--- a/server/pulp/server/webservices/views/serializers/__init__.py
+++ b/server/pulp/server/webservices/views/serializers/__init__.py
@@ -415,10 +415,14 @@ class ImporterSerializer(ModelSerializer):
 
     def to_representation(self, *args):
         """
-        `id` field has been removed from the db, but we add it back in for backwards compatibility.
+        Modify serializer in two ways:
+
+        - `id` field has been removed from the db, but we add it back in for backwards compatibility
+        - Redact data from `last_override_config` for security reasons.
         """
         representation = super(ImporterSerializer, self).to_representation(*args)
         representation['id'] = representation['importer_type_id']
+        representation['last_override_config'] = {}  # CVE https://pulp.plan.io/issues/3521
         return representation
 
 
@@ -443,6 +447,14 @@ class Distributor(ModelSerializer):
                     'distributor_id': instance['distributor_id']}
         )
         return href
+
+    def to_representation(self, *args):
+        """
+        Redacts data from `last_override_config` for security reasons.
+        """
+        representation = super(Distributor, self).to_representation(*args)
+        representation['last_override_config'] = {}  # CVE https://pulp.plan.io/issues/3521
+        return representation
 
 
 class User(ModelSerializer):


### PR DESCRIPTION
This commit resolvs CVE-2018-1090 by redacting all data from
last_override_config. It does not modify what is saved in the database.
It also adds a release note for the 2.16.2 release.

https://pulp.plan.io/issues/3521
closes #3521