### PR TITLE
Raise a ValidationError when undefined attributes are passed to an endpoint.

### DIFF
--- a/pulpcore/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/pulpcore/app/serializers/__init__.py
@@ -3,7 +3,7 @@
 # - all can import directly from base and fields if needed
 from pulpcore.app.serializers.base import (DetailRelatedField, GenericKeyValueRelatedField,  # noqa
     ModelSerializer, MasterModelSerializer, DetailIdentityField, DetailRelatedField,
-    view_name_for_model, viewset_for_model)
+    view_name_for_model, viewset_for_model, validate_unknown_fields)
 from pulpcore.app.serializers.fields import (BaseURLField, ContentRelatedField,  # noqa
                                              LatestVersionField)
 from pulpcore.app.serializers.content import ContentSerializer, ArtifactSerializer  # noqa

--- a/pulpcore/pulpcore/app/serializers/content.py
+++ b/pulpcore/pulpcore/app/serializers/content.py
@@ -87,6 +87,8 @@ class ArtifactSerializer(base.ModelSerializer):
             :class:`rest_framework.exceptions.ValidationError`: When the expected file size or any
                 of the checksums don't match their actual values.
         """
+        super().validate(data)
+
         if 'size' in data:
             if data['file'].size != int(data['size']):
                 raise serializers.ValidationError(_("The size did not match actual size of file."))

--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -16,6 +16,7 @@ from pulpcore.app.serializers import (
     MasterModelSerializer,
     ModelSerializer,
 )
+from pulpcore.app.serializers import validate_unknown_fields
 from rest_framework_nested.relations import (NestedHyperlinkedIdentityField,
                                              NestedHyperlinkedRelatedField)
 from rest_framework_nested.serializers import NestedHyperlinkedModelSerializer
@@ -183,6 +184,9 @@ class RepositoryPublishURLSerializer(serializers.Serializer):
     )
 
     def validate(self, data):
+        if hasattr(self, 'initial_data'):
+            validate_unknown_fields(self.initial_data, self.fields)
+
         repository = data.pop('repository', None)
         repository_version = data.get('repository_version')
         if not repository and not repository_version:
@@ -314,6 +318,8 @@ class DistributionSerializer(ModelSerializer):
         return self._validate_path_overlap(path)
 
     def validate(self, data):
+        super().validate(data)
+
         if 'publisher' in data:
             publisher = data['publisher']
         elif self.instance:

--- a/pulpcore/tests/serializers/test_base.py
+++ b/pulpcore/tests/serializers/test_base.py
@@ -1,7 +1,9 @@
 from unittest import TestCase, mock
 
+from rest_framework import serializers
+
 from pulpcore.app import models
-from pulpcore.app.serializers import base
+from pulpcore.app.serializers import base, validate_unknown_fields
 
 
 class TestViewNameForModel(TestCase):
@@ -18,3 +20,82 @@ class TestViewNameForModel(TestCase):
         Given an unknown viewset (in this case a Mock()), this should raise LookupError.
         """
         self.assertRaises(LookupError, base.view_name_for_model, mock.Mock(), 'foo')
+
+
+class TestValidateUnknownFields(TestCase):
+    def test_unknown_field(self):
+        """
+        Test disjoint sets of `initial_data` with a single field and `defined_fields`.
+        """
+        initial_data = {'unknown1': 'unknown'}
+        defined_fields = {'field1': 1, 'field2': 2}
+
+        self.assertRaises(serializers.ValidationError, validate_unknown_fields,
+                          initial_data, defined_fields)
+
+    def test_unknown_fields(self):
+        """
+        Test disjoint sets of `initial_data` with multiple fields and `defined_fields`.
+        """
+        initial_data = {'unknown1': 'unknown', 'unknown2': 'unknown',
+                        'unknown3': 'unknown'}
+        defined_fields = {'field1': 1, 'field2': 2}
+
+        self.assertRaises(serializers.ValidationError, validate_unknown_fields,
+                          initial_data, defined_fields)
+
+    def test_mixed_initial_data(self):
+        """
+        Test where `defined_fields` is a proper subset of the `initial_data`.
+        """
+        initial_data = {'field1': 1, 'field2': 2, 'unknown1': 'unknown',
+                        'unknown2': 'unknown', 'unknown3': 'unknown'}
+        defined_fields = {'field1': 1, 'field2': 2}
+        self.assertRaises(serializers.ValidationError, validate_unknown_fields,
+                          initial_data, defined_fields)
+
+    def test_mixed_incomplete_initial_data(self):
+        """
+        Test where `initial_data` and `defined_fields` are intersecting sets.
+        """
+        initial_data = {'field2': 2, 'unknown1': 'unknown',
+                        'unknown2': 'unknown', 'unknown3': 'unknown'}
+        defined_fields = {'field1': 1, 'field2': 2}
+        self.assertRaises(serializers.ValidationError, validate_unknown_fields,
+                          initial_data, defined_fields)
+
+    def test_empty_defined_fields(self):
+        """
+        Test an empty `defined_fields`.
+        """
+        initial_data = {'field2': 2, 'unknown1': 'unknown',
+                        'unknown2': 'unknown', 'unknown3': 'unknown'}
+        defined_fields = {}
+        self.assertRaises(serializers.ValidationError, validate_unknown_fields,
+                          initial_data, defined_fields)
+
+    def test_validate_no_unknown_fields(self):
+        """
+        Test where the `initial_data` is equal to `defined_fields`.
+        """
+        initial_data = {'field1': 1, 'field2': 2}
+        defined_fields = {'field1': 1, 'field2': 2}
+        try:
+            validate_unknown_fields(initial_data, defined_fields)
+        except serializers.ValidationError:
+            self.fail("validate_unknown_fields() failed improperly.")
+
+    def test_validate_no_unknown_fields_no_side_effects(self):
+        """
+        Test validation success where the `initial_data` is equal to `defined_fields`
+        and that `initial_data` and `defined_fields` are not mutated.
+        """
+        initial_data = {'field1': 1, 'field2': 2}
+        defined_fields = {'field1': 1, 'field2': 2}
+        try:
+            validate_unknown_fields(initial_data, defined_fields)
+        except serializers.ValidationError:
+            self.fail("validate_unknown_fields() failed improperly.")
+
+        self.assertEqual(initial_data, {'field1': 1, 'field2': 2})
+        self.assertEqual(defined_fields, {'field1': 1, 'field2': 2})

--- a/pulpcore/tests/serializers/test_repository.py
+++ b/pulpcore/tests/serializers/test_repository.py
@@ -40,6 +40,21 @@ class TestRepositoryPublishURLSerializer(TestCase):
         with self.assertRaises(serializers.ValidationError):
             serializer.validate({})
 
+    @mock.patch('pulpcore.app.serializers.repository.models.RepositoryVersion')
+    def test_validate_repository_only_unknown_field(self, mock_version):
+        mock_repo = mock.MagicMock()
+        data = {'repository': mock_repo, 'unknown_field': 'unknown'}
+        serializer = RepositoryPublishURLSerializer(data=data)
+        with self.assertRaises(serializers.ValidationError):
+            serializer.validate(data)
+
+    def test_validate_repository_version_only_unknown_field(self):
+        mock_version = mock.MagicMock()
+        data = {'repository_version': mock_version, 'unknown_field': 'unknown'}
+        serializer = RepositoryPublishURLSerializer(data=data)
+        with self.assertRaises(serializers.ValidationError):
+            serializer.validate(data)
+
 
 class TestDistributionPath(TestCase):
     def test_overlap(self):


### PR DESCRIPTION
refs: https://pulp.plan.io/issues/2970

# TODO
- [x] https://github.com/pulp/pulp_file/pull/96/
- [x] Tests, yo