### PR TITLE
Adhering to Github Community Standards

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+## Code of Conduct
+
+Please be sure you have read our Code of Conduct here:
+https://pulpproject.org/conduct/
+
+Thank you for keeping our community a welcoming one!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## Contributing
+
+We have provided detailed documentation for ways in which you can
+contribute to Pulp here:
+https://docs.pulpproject.org/en/3.0/nightly/contributing/index.html
+
+This documentation includes:
+
+* Suggestions of how to contribute
+* How we track bugs
+* Ways to get in touch with other contributors who can advise you
+* A contribution checklist
+* A developer guide
+
+Join us!  We look forward to hearing from you.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,23 @@
+### Pull Requests
+
+Please be sure you have read our documentation regarding contributing
+here:
+https://docs.pulpproject.org/en/3.0/nightly/contributing/index.html
+
+There you can read a Contribution Checklist and learn more about
+appropriate branches and rebasing among other things.
+
+Once you are ready to create a pull request:
+
+- [ ] For properly formatting commit messages, please see the
+documentation here:
+https://docs.pulpproject.org/en/3.0/nightly/contributing/git.html#commit-message
+- [ ] Once you have created your pull request, please add a link to
+your pull request into the notes/comments for the relevant bug in the
+issue tracker and change the status to POST.
+- [ ] Continuous integration tests will be automatically triggered
+by your pull request.  You can see the status of these tests on the
+page for your pull request.  If there are failures, please try to
+fix them and update your pull request.
+
+Thank you so much for contributing to Pulp!


### PR DESCRIPTION
Github community standards expect a Code of Conduct, Contributing
guidelines, and a pull request template which have now been added.

fixes #3599
https://pulp.plan.io/issues/3599