### PR TITLE
 Use a query param approach for multiple serializers

### DIFF
--- a/pulpcore/pulpcore/app/files.py
+++ b/pulpcore/pulpcore/app/files.py
@@ -53,6 +53,7 @@ class TemporaryDownloadedFile(TemporaryUploadedFile):
     storage backend attempts to link the file to its final location. If the final location is on a
     different physical drive, the file is copied to its final destination.
     """
+
     def __init__(self, file, name=None):
         """
         A constructor that does not create a blank temporary file.

--- a/pulpcore/pulpcore/app/models/content.py
+++ b/pulpcore/pulpcore/app/models/content.py
@@ -26,6 +26,7 @@ class Artifact(Model):
         sha384 (models.CharField): The SHA-384 checksum of the file.
         sha512 (models.CharField): The SHA-512 checksum of the file.
     """
+
     def storage_path(self, name):
         """
         Callable used by FileField to determine where the uploaded file should be stored.

--- a/pulpcore/pulpcore/app/models/fields.py
+++ b/pulpcore/pulpcore/app/models/fields.py
@@ -10,6 +10,7 @@ class ArtifactFileField(FileField):
     The field can be set as either a path to the file or File object. In both cases the file is
     moved or copied to the location specified by 'upload_to' field parameter.
     """
+
     def pre_save(self, model_instance, add):
         """
         Returns path to the file to be stored in database
@@ -20,6 +21,7 @@ class ArtifactFileField(FileField):
 
         Returns:
             Field's value just before saving.
+
         """
         file = super().pre_save(model_instance, add)
         if file and file._committed and add:

--- a/pulpcore/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/pulpcore/app/serializers/__init__.py
@@ -18,5 +18,6 @@ from pulpcore.app.serializers.repository import (DistributionSerializer,  # noqa
                                                  RepositorySerializer,
                                                  RepositorySyncURLSerializer,
                                                  RepositoryVersionSerializer)
-from pulpcore.app.serializers.task import TaskSerializer, WorkerSerializer  # noqa
+from pulpcore.app.serializers.task import (MinimalTaskSerializer, TaskSerializer,  # noqa
+                                           WorkerSerializer)
 from pulpcore.app.serializers.user import UserSerializer  # noqa

--- a/pulpcore/pulpcore/app/serializers/base.py
+++ b/pulpcore/pulpcore/app/serializers/base.py
@@ -199,34 +199,6 @@ class ModelSerializer(serializers.HyperlinkedModelSerializer):
 
         return path
 
-    def to_representation(self, instance):
-        """
-        Object instance -> Dict of primitive datatypes.
-
-        This is very similar to DRF's default to_representation implementation in
-        ModelSerializer, but checks whether a 'minimal_fields' attribute is defined,
-        and uses it when many objects are being serialized at once (i.e. many=True,
-        when the viewset is performing a 'list' action).
-        """
-        ret = OrderedDict()
-        fields = self._readable_fields
-        if self.parent and self.parent.many and hasattr(self.Meta, 'minimal_fields'):
-            fields = [field for field in fields if field.field_name in self.Meta.minimal_fields]
-
-        for field in fields:
-            try:
-                attribute = field.get_attribute(instance)
-            except SkipField:
-                continue
-
-            check_for_none = attribute.pk if isinstance(attribute, PKOnlyObject) else attribute
-            if check_for_none is None:
-                ret[field.field_name] = None
-            else:
-                ret[field.field_name] = field.to_representation(attribute)
-
-        return ret
-
     def validate(self, data):
         if hasattr(self, 'initial_data'):
             validate_unknown_fields(self.initial_data, self.fields)
@@ -267,24 +239,20 @@ class MasterModelSerializer(ModelSerializer):
     def to_representation(self, instance):
         """
         Represent a cast Detail instance as a dict of primitive datatypes
-
-        This is very similar to DRF's default to_representation implementation in
-        ModelSerializer, but makes sure to cast Detail instances and use the correct
-        serializer for rendering so that all detail fields are included. If a serializer
-        defines a 'minimal_fields' attribute, it will use these fields instead of the full set
-        of detail fields when many objects are being serialized at once (i.e. many=True,
-        when the viewset is performing a 'list' action).
         """
+
+        # This is very similar to DRF's default to_representation implementation in
+        # ModelSerializer, but makes sure to cast Detail instances and use the correct
+        # serializer for rendering so that all detail fields are included.
         ret = OrderedDict()
 
         instance = instance.cast()
         viewset = viewset_for_model(instance)()
-        serializer_class = viewset.get_serializer_class()(context=self._context)
-
-        fields = serializer_class._readable_fields
-        if self.parent and self.parent.many and hasattr(serializer_class.Meta, 'minimal_fields'):
-            fields = [field for field in fields
-                      if field.field_name in serializer_class.Meta.minimal_fields]
+        if self.parent and self.parent.many:
+            viewset.action = 'list'
+        else:
+            viewset.action = 'get'
+        fields = viewset.get_serializer_class()(context=self._context)._readable_fields
 
         for field in fields:
             try:

--- a/pulpcore/pulpcore/app/serializers/base.py
+++ b/pulpcore/pulpcore/app/serializers/base.py
@@ -248,10 +248,7 @@ class MasterModelSerializer(ModelSerializer):
 
         instance = instance.cast()
         viewset = viewset_for_model(instance)()
-        if self.parent and self.parent.many:
-            viewset.action = 'list'
-        else:
-            viewset.action = 'get'
+        viewset.request = self._context['request']
         fields = viewset.get_serializer_class()(context=self._context)._readable_fields
 
         for field in fields:

--- a/pulpcore/pulpcore/app/serializers/base.py
+++ b/pulpcore/pulpcore/app/serializers/base.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 from urllib.parse import urljoin
 
 from django.core.validators import URLValidator
+from drf_queryfields.mixins import QueryFieldsMixin
 
 from rest_framework import serializers
 from rest_framework.fields import SkipField
@@ -105,7 +106,8 @@ class GenericKeyValueRelatedField(serializers.DictField):
         return super().to_representation(value.mapping)
 
 
-class ModelSerializer(serializers.HyperlinkedModelSerializer):
+# Inheritance order matters, don't flip these
+class ModelSerializer(QueryFieldsMixin, serializers.HyperlinkedModelSerializer):
     """Base serializer for use with :class:`pulpcore.app.models.Model`
 
     This ensures that all Serializers provide values for the '_href` field, and

--- a/pulpcore/pulpcore/app/serializers/task.py
+++ b/pulpcore/pulpcore/app/serializers/task.py
@@ -89,8 +89,14 @@ class TaskSerializer(ModelSerializer):
                                                 'non_fatal_errors', 'error', 'worker', 'parent',
                                                 'spawned_tasks', 'progress_reports',
                                                 'created_resources')
-        minimal_fields = ModelSerializer.Meta.fields + ('state', 'started_at', 'finished_at',
-                                                        'worker', 'parent')
+
+
+class MinimalTaskSerializer(TaskSerializer):
+
+    class Meta:
+        model = models.Task
+        fields = ModelSerializer.Meta.fields + ('state', 'started_at', 'finished_at',
+                                                'worker', 'parent')
 
 
 class WorkerSerializer(ModelSerializer):

--- a/pulpcore/pulpcore/app/viewsets/base.py
+++ b/pulpcore/pulpcore/app/viewsets/base.py
@@ -84,6 +84,35 @@ class NamedModelViewSet(viewsets.GenericViewSet):
     parent_lookup_kwargs = {}
     schema = DefaultSchema()
 
+    def get_serializer_class(self):
+        """
+        Provides a way to customize the serializer based on the action being taken
+        (e.g. to provide a different serialization for a list view vs. a detail view)
+
+        If you do not specify a 'serializer_class', you must specify a 'serializers' dict which
+        defines a 'default' serializer, and can override that serializer on a per-action basis.
+
+        e.g. serializers = {'default': TaskSerializer, 'list': MinimalTaskSerializer}
+
+        If you define both, the 'serializer_class' attribute will be ignored and the 'serializers'
+        attribute will be used. This is because plugin viewsets may want to use multiple
+        serializers, but they inherit from basic viewsets such as Content which will have a
+        'serializer_class' attribute defined.
+        """
+        serializer_class = getattr(self, 'serializer_class', None)
+        serializers = getattr(self, 'serializers', None)
+
+        msg = _("{} must either have a 'serializer_class' attribute, or it must have a "
+                "'serializers' attribute with a 'default' key set").format(self.__class__.__name__)
+        assert serializer_class or serializers, msg
+
+        if serializers:
+            valid = isinstance(serializers, dict) and 'default' in serializers.keys()
+            assert valid, msg
+            return self.serializers.get(self.action, serializers['default'])
+
+        return serializer_class
+
     @staticmethod
     def get_resource(uri, model):
         """

--- a/pulpcore/pulpcore/app/viewsets/base.py
+++ b/pulpcore/pulpcore/app/viewsets/base.py
@@ -90,7 +90,7 @@ class NamedModelViewSet(viewsets.GenericViewSet):
 
         The default behavior is to use the "serializer_class" attribute on the viewset.
         We override that for the case where a "minimal_serializer_class" attribute is defined
-        and where the request contains a query parameter of "pretty=True".
+        and where the request contains a query parameter of "minimal=True".
 
         The intention is that ViewSets can define a second, more minimal serializer with only
         the most important fields.
@@ -102,12 +102,11 @@ class NamedModelViewSet(viewsets.GenericViewSet):
         minimal_serializer_class = getattr(self, 'minimal_serializer_class', None)
 
         if minimal_serializer_class:
-            # The content endpoints don't pass along the request to the internals
             if hasattr(self, 'request'):
-                if 'pretty' in self.request.query_params:
+                if 'minimal' in self.request.query_params:
                     # the query param is a string, and non-empty strings evaluate True,
                     # so we need to do an actual string comparison to 'true'
-                    if self.request.query_params['pretty'].lower() == 'true':
+                    if self.request.query_params['minimal'].lower() == 'true':
                         return minimal_serializer_class
 
         return self.serializer_class

--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -183,8 +183,11 @@ class RepositoryVersionFilter(filterset.FilterSet):
 
 
 class RepositoryVersionViewSet(NamedModelViewSet,
+                               mixins.CreateModelMixin,
+                               mixins.UpdateModelMixin,
                                mixins.RetrieveModelMixin,
-                               mixins.ListModelMixin):
+                               mixins.ListModelMixin,
+                               mixins.DestroyModelMixin):
     endpoint_name = 'versions'
     nest_prefix = 'repositories'
     router_lookup = 'version'

--- a/pulpcore/pulpcore/app/viewsets/task.py
+++ b/pulpcore/pulpcore/app/viewsets/task.py
@@ -38,9 +38,15 @@ class TaskViewSet(NamedModelViewSet,
                   mixins.DestroyModelMixin):
     queryset = Task.objects.all()
     endpoint_name = 'tasks'
+<<<<<<< HEAD
     serializer_class = TaskSerializer
     minimal_serializer_class = MinimalTaskSerializer
     filterset_class = TaskFilter
+=======
+    filter_class = TaskFilter
+    serializer_class = TaskSerializer
+    minimal_serializer_class = MinimalTaskSerializer
+>>>>>>> Use a query param  approach for multiple serializers
     filter_backends = (OrderingFilter, DjangoFilterBackend)
     ordering = ('-created')
 

--- a/pulpcore/pulpcore/app/viewsets/task.py
+++ b/pulpcore/pulpcore/app/viewsets/task.py
@@ -38,15 +38,9 @@ class TaskViewSet(NamedModelViewSet,
                   mixins.DestroyModelMixin):
     queryset = Task.objects.all()
     endpoint_name = 'tasks'
-<<<<<<< HEAD
-    serializer_class = TaskSerializer
-    minimal_serializer_class = MinimalTaskSerializer
-    filterset_class = TaskFilter
-=======
     filter_class = TaskFilter
     serializer_class = TaskSerializer
     minimal_serializer_class = MinimalTaskSerializer
->>>>>>> Use a query param  approach for multiple serializers
     filter_backends = (OrderingFilter, DjangoFilterBackend)
     ordering = ('-created')
 

--- a/pulpcore/pulpcore/app/viewsets/task.py
+++ b/pulpcore/pulpcore/app/viewsets/task.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from pulpcore.common import TASK_INCOMPLETE_STATES
 
 from pulpcore.app.models import Task, Worker
-from pulpcore.app.serializers import TaskSerializer, WorkerSerializer
+from pulpcore.app.serializers import MinimalTaskSerializer, TaskSerializer, WorkerSerializer
 from pulpcore.app.viewsets import NamedModelViewSet
 from pulpcore.app.viewsets.base import NAME_FILTER_OPTIONS, DATETIME_FILTER_OPTIONS
 from pulpcore.app.viewsets.custom_filters import HyperlinkRelatedFilter
@@ -39,6 +39,7 @@ class TaskViewSet(NamedModelViewSet,
     queryset = Task.objects.all()
     endpoint_name = 'tasks'
     serializer_class = TaskSerializer
+    minimal_serializer_class = MinimalTaskSerializer
     filterset_class = TaskFilter
     filter_backends = (OrderingFilter, DjangoFilterBackend)
     ordering = ('-created')

--- a/pulpcore/setup.py
+++ b/pulpcore/setup.py
@@ -8,6 +8,7 @@ requirements = [
     'Django>=1.11',
     'django-filter',
     'djangorestframework',
+    'djangorestframework-queryfields',
     'drf-nested-routers',
     'drf-yasg',
     'psycopg2-binary',

--- a/pulpcore/tests/viewsets/test_base.py
+++ b/pulpcore/tests/viewsets/test_base.py
@@ -141,7 +141,7 @@ class TestGetSerializerClass(TestCase):
     def test_serializer_class(self):
         """
         Tests that get_serializer_class() returns the serializer_class attribute if it exists,
-        and that it doesn't error if no minimal serializer is defined, but pretty=True.
+        and that it doesn't error if no minimal serializer is defined, but minimal=True.
         """
         class TestTaskViewSet(viewsets.NamedModelViewSet):
             serializer_class = serializers.TaskSerializer
@@ -150,12 +150,12 @@ class TestGetSerializerClass(TestCase):
         self.assertEquals(viewset.get_serializer_class(), serializers.TaskSerializer)
 
         request = unittest.mock.MagicMock()
-        request.query_params = QueryDict('pretty=True')
+        request.query_params = QueryDict('minimal=True')
         viewset.request = request
 
         self.assertEquals(viewset.get_serializer_class(), serializers.TaskSerializer)
 
-    def test_pretty_query_param(self):
+    def test_minimal_query_param(self):
         """
         Tests that get_serializer_class() returns the correct serializer in the correct situations.
         """
@@ -170,12 +170,12 @@ class TestGetSerializerClass(TestCase):
         request.query_params = QueryDict()
         viewset.request = request
         self.assertEquals(viewset.get_serializer_class(), serializers.TaskSerializer)
-        # Test that it uses the full serializer with pretty=False
-        request.query_params = QueryDict('pretty=False')
+        # Test that it uses the full serializer with minimal=False
+        request.query_params = QueryDict('minimal=False')
         viewset.request = request
         self.assertEquals(viewset.get_serializer_class(), serializers.TaskSerializer)
-        # Test that it uses the minimal serializer with pretty=True
-        request.query_params = QueryDict('pretty=True')
+        # Test that it uses the minimal serializer with minimal=True
+        request.query_params = QueryDict('minimal=True')
         viewset.request = request
         self.assertEquals(viewset.get_serializer_class(), serializers.MinimalTaskSerializer)
 

--- a/pulpcore/tests/viewsets/test_base.py
+++ b/pulpcore/tests/viewsets/test_base.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from django.test import TestCase
 from rest_framework.serializers import ValidationError as DRFValidationError
 
-from pulpcore.app import models, viewsets
+from pulpcore.app import models, viewsets, serializers
 from pulpcore.common.constants import API_ROOT
 
 
@@ -123,6 +123,88 @@ class TestGetResource(TestCase):
                 "/{api_root}repositories/{pk}/versions/1/".format(api_root=API_ROOT, pk=repo.pk),
                 models.Repository
             )
+
+
+class TestGetSerializerClass(TestCase):
+
+    def test_serializer_class(self):
+        """
+        Tests that get_serializer_class() returns the serializer_class attribute if it exists.
+        """
+        class TestTaskViewSet(viewsets.NamedModelViewSet):
+            serializer_class = serializers.TaskSerializer
+
+        viewset = TestTaskViewSet()
+        self.assertEquals(viewset.get_serializer_class(), serializers.TaskSerializer)
+
+    def test_multiple_serializers(self):
+        """
+        Tests that get_serializer_class() returns the correct serializer when they have been
+        specified on a per-action basis.
+        """
+        class TestTaskViewSet(viewsets.NamedModelViewSet):
+            serializers = {
+                'list': serializers.MinimalTaskSerializer,
+                'default': serializers.TaskSerializer
+            }
+
+        viewset = TestTaskViewSet()
+        # Test the default serializer
+        viewset.action = 'retrieve'
+        self.assertEquals(viewset.get_serializer_class(), serializers.TaskSerializer)
+        # Test a specific action
+        viewset.action = 'list'
+        self.assertEquals(viewset.get_serializer_class(), serializers.MinimalTaskSerializer)
+
+    def test_defining_neither_fails(self):
+        """
+        Test that get_serializer_class() raises an AssertionError if you try to define neither
+        'serializer_class' nor 'serializers'.
+        """
+        class TestTaskViewSet(viewsets.NamedModelViewSet):
+            pass
+
+        with self.assertRaises(AssertionError):
+            TestTaskViewSet().get_serializer_class()
+
+    def test_defining_both_uses_dict(self):
+        """
+        Test that get_serializer_class() will use 'serializers' if both 'serializer_class' and
+        'serializers' are defined.
+        """
+        class TestTaskViewSet(viewsets.NamedModelViewSet):
+            serializer_class = serializers.MinimalTaskSerializer
+            serializers = {'default': serializers.TaskSerializer}
+
+        viewset = TestTaskViewSet()
+        viewset.action = 'list'
+        self.assertEquals(viewset.get_serializer_class(), serializers.TaskSerializer)
+
+    def test_serializers_without_default_fails(self):
+        """
+        Tests that get_serializer_class() raises an AssertionError if you defined 'serializers'
+        without providing a default serializer.
+        """
+        class TestTaskViewSet(viewsets.NamedModelViewSet):
+            serializers = {}
+
+        with self.assertRaises(AssertionError):
+            TestTaskViewSet().get_serializer_class()
+
+    def test_multiple_derived_viewsets(self):
+        """
+        Tests that get_serializer_class() works on a viewset derived from another viewset which
+        inherits from NamedModelViewSet.
+        """
+        class TestAlternateSerializer(serializers.ContentSerializer):
+            pass
+
+        class TestDerivedViewSet(viewsets.ContentViewSet):
+            serializers = {'default': TestAlternateSerializer}
+
+        viewset = TestDerivedViewSet()
+        viewset.action = 'list'
+        self.assertEquals(viewset.get_serializer_class(), TestAlternateSerializer)
 
 
 class TestGetParentFieldAndObject(TestCase):


### PR DESCRIPTION
Certain models, such as {RPM|Python|Ansible}Content or Task, have a lot of very verbose information that the user doesn't care much about.  We would like to provide some way for a user to filter out the less-useful information so that responses can be easily human-readable.

e.g.

```
[vagrant@pulp3 ~]$ http GET http://localhost:8000/pulp/api/v3/tasks/edbe9ad0-9787-4d76-97df-1411ff097fa6/?pretty=True
HTTP/1.1 200 OK
...

{
    "_href": "http://localhost:8000/pulp/api/v3/tasks/edbe9ad0-9787-4d76-97df-1411ff097fa6/",
    "created": "2018-06-28T16:13:54.241649Z",
    "finished_at": "2018-06-28T16:13:55.467281Z",
    "id": "edbe9ad0-9787-4d76-97df-1411ff097fa6",
    "parent": null,
    "started_at": "2018-06-28T16:13:54.312332Z",
    "state": "completed",
    "worker": "http://localhost:8000/pulp/api/v3/workers/e340248c-59b1-40ce-9638-d902eaaf6e79/"
}
```

vs.

```
[vagrant@pulp3 ~]$ http GET http://localhost:8000/pulp/api/v3/tasks/edbe9ad0-9787-4d76-97df-1411ff097fa6/
HTTP/1.1 200 OK
...
{
    "_href": "http://localhost:8000/pulp/api/v3/tasks/edbe9ad0-9787-4d76-97df-1411ff097fa6/",
    "created": "2018-06-28T16:13:54.241649Z",
    "created_resources": [
        "http://localhost:8000/pulp/api/v3/repositories/6a53ecd4-f65d-48d4-89e3-4d83ad1142c9/versions/1/"
    ],
    "error": null,
    "finished_at": "2018-06-28T16:13:55.467281Z",
    "id": "edbe9ad0-9787-4d76-97df-1411ff097fa6",
    "non_fatal_errors": [],
    "parent": null,
    "progress_reports": [
        {
            "done": 3,
            "message": "Add Content",
            "state": "completed",
            "suffix": "",
            "task": "http://localhost:8000/pulp/api/v3/tasks/edbe9ad0-9787-4d76-97df-1411ff097fa6/",
            "total": 3
        },
        {
            "done": 0,
            "message": "Remove Content",
            "state": "completed",
            "suffix": "",
            "task": "http://localhost:8000/pulp/api/v3/tasks/edbe9ad0-9787-4d76-97df-1411ff097fa6/",
            "total": 0
        }
    ],
    "spawned_tasks": [],
    "started_at": "2018-06-28T16:13:54.312332Z",
    "state": "completed",
    "worker": "http://localhost:8000/pulp/api/v3/workers/e340248c-59b1-40ce-9638-d902eaaf6e79/"
}
```

The approach currently used is to do this only for viewset "list" actions (multiple records at once), and not for viewset "retrieve" actions (a single specific record).  This is problematic for several reasons:

* API users, such as Katello or the bindings, cannot fetch detailed information en-masse.  Non-human consumers don't care about the verboseness and may need all the information.
* A human user user might want to see a minimal representation of just one model, such as a very large content model, e.g. Python Content [0]
* It's inconsistent, as a human you can't tell whether you're getting all the fields from the list view unless you compare it against a detail view.  Most will provide everything but a few won't.

With this new approach, a human user can provide the ```?pretty=True``` query parameter when making your GET request in order to get the restricted set of information, if the viewset supports it.

For viewsets which don't support minimal serializers, providing this param will do nothing. This means that we can inject it into every request the CLI makes without consequence.  If a minimal serializer is supported, then it will use it, if not, then it will just use the normal serializer.

It works on both "list" actions and "retrieve" actions and is more consistent because you know that unless you explicitly ask for less, you're getting everything.

[0] Another example usage: https://github.com/pulp/pulp_python/pull/156