### PR TITLE
allow_blank for optional fields

### DIFF
--- a/pulpcore/pulpcore/app/serializers/content.py
+++ b/pulpcore/pulpcore/app/serializers/content.py
@@ -47,32 +47,38 @@ class ArtifactSerializer(base.ModelSerializer):
 
     md5 = serializers.CharField(
         help_text=_("The MD5 checksum of the file if available."),
-        required=False
+        required=False,
+        allow_blank=True
     )
 
     sha1 = serializers.CharField(
         help_text=_("The SHA-1 checksum of the file if available."),
-        required=False
+        required=False,
+        allow_blank=True
     )
 
     sha224 = serializers.CharField(
         help_text=_("The SHA-224 checksum of the file if available."),
-        required=False
+        required=False,
+        allow_blank=True
     )
 
     sha256 = serializers.CharField(
         help_text=_("The SHA-256 checksum of the file if available."),
-        required=False
+        required=False,
+        allow_blank=True
     )
 
     sha384 = serializers.CharField(
         help_text=_("The SHA-384 checksum of the file if available."),
-        required=False
+        required=False,
+        allow_blank=True
     )
 
     sha512 = serializers.CharField(
         help_text=_("The SHA-512 checksum of the file if available."),
-        required=False
+        required=False,
+        allow_blank=True
     )
 
     def validate(self, data):

--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -37,7 +37,8 @@ class RepositorySerializer(ModelSerializer):
     )
     description = serializers.CharField(
         help_text=_('An optional description.'),
-        required=False
+        required=False,
+        allow_blank=True
     )
     notes = GenericKeyValueRelatedField(
         help_text=_('A mapping of string keys to string values, for storing notes on this object.'),
@@ -58,7 +59,7 @@ class RemoteSerializer(MasterModelSerializer):
     _href = DetailIdentityField()
     name = serializers.CharField(
         help_text=_('A unique name for this remote.'),
-        validators=[UniqueValidator(queryset=models.Remote.objects.all())]
+        validators=[UniqueValidator(queryset=models.Remote.objects.all())],
     )
     url = serializers.CharField(
         help_text='The URL of an external content source.',
@@ -90,16 +91,19 @@ class RemoteSerializer(MasterModelSerializer):
     proxy_url = serializers.CharField(
         help_text='The proxy URL. Format: scheme://user:password@host:port',
         required=False,
+        allow_blank=True,
     )
     username = serializers.CharField(
         help_text='The username to be used for authentication when syncing.',
         write_only=True,
         required=False,
+        allow_blank=True,
     )
     password = serializers.CharField(
         help_text='The password to be used for authentication when syncing.',
         write_only=True,
         required=False,
+        allow_blank=True,
     )
     last_synced = serializers.DateTimeField(
         help_text='Timestamp of the most recent successful sync.',
@@ -256,7 +260,7 @@ class DistributionSerializer(ModelSerializer):
                 models.Distribution._meta.get_field('base_path').max_length
             )),
             UniqueValidator(queryset=models.Distribution.objects.all()),
-        ],
+        ]
     )
     publisher = DetailRelatedField(
         required=False,

--- a/pulpcore/pulpcore/app/serializers/status.py
+++ b/pulpcore/pulpcore/app/serializers/status.py
@@ -10,11 +10,11 @@ class VersionSerializer(serializers.Serializer):
     """
 
     component = serializers.CharField(
-        help_text=_("Name of a versioned component of Pulp")
+        help_text=_("Name of a versioned component of Pulp"),
     )
 
     version = serializers.CharField(
-        help_text=_("Version of the component (e.g. 3.0.0)")
+        help_text=_("Version of the component (e.g. 3.0.0)"),
     )
 
 

--- a/pulpcore/pulpcore/app/serializers/user.py
+++ b/pulpcore/pulpcore/app/serializers/user.py
@@ -41,7 +41,7 @@ class UserSerializer(ModelSerializer):
                         User._meta.get_field('username').max_length,
                         message=_('The length of username must be less than {} characters').format(
                             User._meta.get_field('username').max_length)),
-                    ],
+                    ]
     )
 
     password = PasswordSerializer(


### PR DESCRIPTION
Added allow_blank=True to all CharField serializers that are
not required.

fixes #3755
https://pulp.plan.io/issues/3755