### PR TITLE
Handle systems without fips_enabled in /proc

### DIFF
--- a/server/bin/pulp-gen-ca-certificate
+++ b/server/bin/pulp-gen-ca-certificate
@@ -15,7 +15,11 @@ END
 )
 
 PULP_CONF=(`python -c "$READ_PULP_CONF"`)
-FIPS_ENABLED=(`cat /proc/sys/crypto/fips_enabled`)
+if [ -e /proc/sys/crypto/fips_enabled ] ; then
+	FIPS_ENABLED=(`cat /proc/sys/crypto/fips_enabled`)
+else
+	FIPS_ENABLED=0
+fi
 
 TMP="$(mktemp -d)"
 CA_KEY=${PULP_CONF[0]}


### PR DESCRIPTION
When /proc/sys/crypto/fips_enabled doesn't exist, the pulp-gen-ca-certificate script fails and exits with code 1 because of set -e. By first checking if it exists we avoid this.

Fixes #3828

This is the same patch as https://github.com/pulp/pulp/pull/3542 but against 2-master.