### PR TITLE
Update Pulp Smash configuration file

### DIFF
--- a/.travis/pulp-smash-config.json
+++ b/.travis/pulp-smash-config.json
@@ -1,20 +1,18 @@
 {
     "pulp": {
         "auth": ["admin", "admin"],
+        "selinux enabled": false,
         "version": "3"
     },
-    "systems": [
+    "hosts": [
         {
             "hostname": "localhost",
             "roles": {
-                "amqp broker": {"service": "rabbitmq"},
-                "api": {"port": 8000, "scheme": "http"},
-                "mongod": {},
-                "pulp cli": {},
+                "api": {"port": 8000, "scheme": "http", "service": "nginx"},
                 "pulp resource manager": {},
                 "pulp workers": {},
-                "shell": {"transport": "local"},
-                "squid": {}
+                "redis": {},
+                "shell": {"transport": "local"}
             }
         }
     ]


### PR DESCRIPTION
Pulp Smash recently updated its configuration machinery to properly
handle both Pulp 2 and Pulp 3. As a result, the definition of a valid
configuration file has changed. Update the Pulp Smash configuration file
used for testing accordingly.

See: https://github.com/PulpQE/pulp-smash/pull/1101