### PR TITLE
Fix Pulp on Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,23 @@
 sudo: required
 # https://docs.travis-ci.com/user/trusty-ci-environment/
-dist: trusty
+dist: xenial
 language: python
 python:
     # python versions used in el7 SCL & supported fedora
     - "3.5"
     - "3.6"
+    - "3.7"
 env:
   matrix:
-  - DJANGO_MAX=1.11.100 DB=postgres TEST=pulp
-  - DJANGO_MAX=2.2.100 DB=postgres TEST=pulp
-  - TEST=docs
+    - DJANGO_MAX=2.2.100 DB=postgres TEST=pulp
+    - TEST=docs
   global:
     secure: kzbI/DagIGIOFjVEyLyYGEi/xVwiq5M8FCEM3mOtXK9ocYs1Ky1ABkcgLrOLBb+S7SMNjy4XnUWGUxhBGWQLDw2/OimKFoHpCHGt1Cb4rXhWDSVPGgDXQzyW8pJsPKtAbemfx5a4oRP82vmpgB/htJ+8dE5CIAZWU8d9dbvQbro=
 matrix:
   fast_finish: true
 addons:
     # postgres versions provided by el7 RHSCL (lowest supportable version)
-    postgresql: "9.5"
+    postgresql: "9.6"
 services:
     - postgresql
     - redis-server

--- a/pulpcore/pulpcore/tasking/tasks.py
+++ b/pulpcore/pulpcore/tasking/tasks.py
@@ -85,7 +85,7 @@ def _queue_reserved_task(func, inner_task_id, resources, inner_args, inner_kwarg
             else:
                 task_status.state = TASK_STATES.RUNNING
                 task_status.save()
-                q = Queue('resource_manager', connection=redis_conn, async=False)
+                q = Queue('resource_manager', connection=redis_conn, is_async=False)
                 q.enqueue(func, args=inner_args, kwargs=inner_kwargs, job_id=inner_task_id,
                           timeout=TASK_TIMEOUT, **options)
                 task_status.state = TASK_STATES.COMPLETED

--- a/pulpcore/setup.py
+++ b/pulpcore/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as f:
 
 requirements = [
     'coreapi',
-    'Django>=1.11',
+    'Django>=2.0',
     'django-filter',
     'djangorestframework',
     'djangorestframework-queryfields',
@@ -13,7 +13,7 @@ requirements = [
     'drf-yasg',
     'psycopg2-binary',
     'PyYAML',
-    'rq>=0.11.0',
+    'rq>=0.12.0',
     'setuptools',
     'pulpcore-common'
 ]
@@ -39,6 +39,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
RQ changed an argument name from 'async' to 'is_async' because
the former is now a reserved keyword.