### PR TITLE
Improves description of the range filters

### DIFF
--- a/pulpcore/pulpcore/app/viewsets/base.py
+++ b/pulpcore/pulpcore/app/viewsets/base.py
@@ -359,7 +359,7 @@ class BaseFilterSet(filterset.FilterSet):
         'istartswith': _('starts with'),
         'endswith': _('ends with'),
         'iendswith': _('ends with'),
-        'range': _('is in range of'),
+        'range': _('is between two comma separated'),
         'isnull': _('has a null'),
         'regex': _('matches regex'),
         'iregex': _('matches regex'),


### PR DESCRIPTION
Description of the range filters now look like this "Filter results where number is between two comma separated values"

closes #3826
https://pulp.plan.io/issues/3826