### PR TITLE
Support {id, href} by creating an IdentifierField

### DIFF
--- a/pulpcore/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/pulpcore/app/serializers/__init__.py
@@ -11,7 +11,10 @@ from .base import (  # noqa
     view_name_for_model,
     viewset_for_model,
     validate_unknown_fields,
-    AsyncOperationResponseSerializer
+    AsyncOperationResponseSerializer,
+    IdentifierField,
+    DetailIdentifierField,
+    NestedIdentifierField
 )
 from .fields import BaseURLField, ContentRelatedField, LatestVersionField  # noqa
 from .content import ContentSerializer, ArtifactSerializer  # noqa

--- a/pulpcore/pulpcore/app/serializers/progress.py
+++ b/pulpcore/pulpcore/app/serializers/progress.py
@@ -3,7 +3,7 @@ from gettext import gettext as _
 from rest_framework import serializers
 
 from pulpcore.app import models
-from pulpcore.app.serializers import ModelSerializer
+from pulpcore.app.serializers import IdentifierField, ModelSerializer
 
 
 class ProgressReportSerializer(ModelSerializer):
@@ -30,7 +30,7 @@ class ProgressReportSerializer(ModelSerializer):
         help_text=_("The suffix to be shown with the progress report."),
         read_only=True
     )
-    task = serializers.HyperlinkedRelatedField(
+    task = IdentifierField(
         help_text=_("The task associated with this progress report."),
         read_only=True,
         view_name='tasks-detail'


### PR DESCRIPTION
Using this new IdentifierField, relations are displayed with both `pk` and `href`. This allows bindings users to use the returned pk, and allows UI users to still be able to click hrefs.

```
{
    "id": "b3e5e4ad-91ba-4536-b62d-087df10e8921",
    "_href": "http://pulp3.dev:8000/pulp/api/v3/tasks/b3e5e4ad-91ba-4536-b62d-087df10e8921/",
    "created": "2018-08-03T15:51:16.694787Z",
    "state": "completed",
    "started_at": "2018-08-03T15:59:43.302492Z",
    "finished_at": "2018-08-03T15:59:45.579150Z",
    "non_fatal_errors": [],
    "error": null,
    "worker": {
        "_href": "http://pulp3.dev:8000/pulp/api/v3/workers/3/",
        "pk": 3
    },
    "parent": null,
    "spawned_tasks": [],
    "progress_reports": [
        {
            "message": "Add Content",
            "state": "completed",
            "total": 3,
            "done": 3,
            "suffix": "",
            "task": {
                "_href": "http://pulp3.dev:8000/pulp/api/v3/tasks/b3e5e4ad-91ba-4536-b62d-087df10e8921/",
                "pk": "b3e5e4ad-91ba-4536-b62d-087df10e8921"
            }
        },
        {
            "message": "Remove Content",
            "state": "completed",
            "total": 0,
            "done": 0,
            "suffix": "",
            "task": {
                "_href": "http://pulp3.dev:8000/pulp/api/v3/tasks/b3e5e4ad-91ba-4536-b62d-087df10e8921/",
                "pk": "b3e5e4ad-91ba-4536-b62d-087df10e8921"
            }
        }
    ],
    "created_resources": [
        {
            "_href": "http://pulp3.dev:8000/pulp/api/v3/repositories/1/versions/1/",
            "pk": 1,
            "number": 1
        }
    ]
}
```

Schema-wise this field is shown as:
```
worker:{  
    type:"object",
    properties:{  
        _href:{  
            type:"string",
            format:"uri"
        },
        pk:{  
            type:"string"
        }
    },
    additionalProperties:true
}
```
You can see the full schema here: https://gist.github.com/werwty/e445cbd2ac11a237b3971d65bb861a17

There's one more issue left with this implementation:
`RepositoryPublishURLSerializer` is still using the `NestedHyperlinkedRelatedField` (have to pass in href for now). This can be fixed by unnesting repoversion, or updateing `NestedIdentifierField` to take an object `{'pk': 1, 'number': 1}` as well as an url `/repositories/1/version/1/`
