### PR TITLE
Fix storage path for published metadata.

### DIFF
--- a/pulpcore/pulpcore/app/models/storage.py
+++ b/pulpcore/pulpcore/app/models/storage.py
@@ -1,6 +1,8 @@
 import os
 import errno
 
+from uuid import uuid4
+
 from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import FileSystemStorage
@@ -141,7 +143,7 @@ def published_metadata_path(model, name):
         settings.MEDIA_ROOT,
         'published',
         'metadata',
-        str(model.pk),
+        str(uuid4()),
         name)
 
 


### PR DESCRIPTION
https://pulp.plan.io/issues/3878

With integer IDs the PK is not yet assigned (and no longer unique across tables).