### PR TITLE
Have DeclarativeVersion validate download digests

### DIFF
--- a/plugin/pulpcore/plugin/stages/artifact_stages.py
+++ b/plugin/pulpcore/plugin/stages/artifact_stages.py
@@ -166,8 +166,20 @@ class ArtifactDownloader(Stage):
                     for declarative_artifact in content.d_artifacts:
                         if declarative_artifact.artifact.pk is None:
                             # this needs to be downloaded
+                            expected_digests = {}
+                            validation_kwargs = {}
+                            for digest_name in declarative_artifact.artifact.DIGEST_FIELDS:
+                                digest_value = getattr(declarative_artifact.artifact, digest_name)
+                                if digest_value:
+                                    expected_digests[digest_name] = digest_value
+                            if expected_digests:
+                                validation_kwargs['expected_digests'] = expected_digests
+                            if declarative_artifact.artifact.size:
+                                expected_size = declarative_artifact.artifact.size
+                                validation_kwargs['expected_size'] = expected_size
                             downloader = declarative_artifact.remote.get_downloader(
-                                declarative_artifact.url
+                                declarative_artifact.url,
+                                **validation_kwargs
                             )
                             next_future = asyncio.ensure_future(downloader.run())
                             downloaders_for_content.append(next_future)


### PR DESCRIPTION
The downloaders created by DeclarativeVersion didn't specify any digest
or size information to use for validation even if it was available. I've
tested this code and it worked for me.

https://pulp.plan.io/issues/3844
re #3844