### PR TITLE
Remove usages of selectors.bug_is_fixed()

### DIFF
--- a/pulpcore/tests/functional/api/test_api_docs.py
+++ b/pulpcore/tests/functional/api/test_api_docs.py
@@ -4,7 +4,7 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config
 from pulp_smash.pulp3.constants import API_DOCS_PATH
 
 from tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -13,17 +13,14 @@ from tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 class ApiDocsTestCase(unittest.TestCase):
     """Test whether API auto generated docs are available.
 
-    This test targets the following issues:
+    This test targets the following issue:
 
-    * `Pulp #3552 <https://pulp.plan.io/issues/3552>`_
     * `Pulp Smash #893 <https://github.com/PulpQE/pulp-smash/issues/893>`_
     """
 
     def setUp(self):
         """Create an API Client."""
         cfg = config.get_config()
-        if not selectors.bug_is_fixed(3552, cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3552')
         self.client = api.Client(cfg)
 
     def test_valid_credentials(self):

--- a/pulpcore/tests/functional/api/test_auth.py
+++ b/pulpcore/tests/functional/api/test_auth.py
@@ -10,7 +10,7 @@ from urllib.parse import urljoin
 from requests.auth import AuthBase, HTTPBasicAuth
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import BASE_PATH, JWT_PATH, USER_PATH
 
 from tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -45,31 +45,27 @@ class AuthTestCase(unittest.TestCase):
                 auth=HTTPBasicAuth(*self.cfg.pulp_auth),
             )
 
+    @unittest.skip('https://pulp.plan.io/issues/3248')
     def test_jwt_success(self):
         """Perform JWT authentication with valid credentials.
 
         Assert that a response indicating success is returned.
         """
-        if not selectors.bug_is_fixed(3248, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3248')
         token = _get_token(self.cfg)
-        (
-            api
-            .Client(self.cfg, api.json_handler)
-            .get(BASE_PATH, auth=JWTAuth(token)))
+        api.Client(self.cfg, api.json_handler).get(BASE_PATH, auth=JWTAuth(token))
 
+    @unittest.skip('https://pulp.plan.io/issues/3248')
     def test_jwt_failure(self):
         """Perform JWT authentication with invalid credentials.
 
         Assert that a response indicating failure is returned.
         """
-        if not selectors.bug_is_fixed(3248, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3248')
         self.cfg.pulp_auth[1] = utils.uuid4()  # randomize password
         with self.assertRaises(HTTPError):
             _get_token(self.cfg)
 
 
+@unittest.skip('https://pulp.plan.io/issues/3248')
 class JWTResetTestCase(unittest.TestCase):
     """Perform series of tests related to JWT reset."""
 
@@ -79,8 +75,6 @@ class JWTResetTestCase(unittest.TestCase):
         Also, verify that the tokens are valid.
         """
         self.cfg = config.get_config()
-        if not selectors.bug_is_fixed(3248, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3248')
         client = api.Client(self.cfg, api.json_handler)
 
         # Create a temporary user, so that we don't have to use the Pulp admin

--- a/pulpcore/tests/functional/api/test_crud_distributions.py
+++ b/pulpcore/tests/functional/api/test_crud_distributions.py
@@ -4,7 +4,7 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import DISTRIBUTION_PATH
 from pulp_smash.pulp3.utils import gen_distribution
 
@@ -52,9 +52,10 @@ class CRUDDistributionsTestCase(unittest.TestCase):
 
     @skip_if(bool, 'distribution', False)
     def test_02_read_distributions(self):
-        """Read a distribution using query parameters."""
-        if not selectors.bug_is_fixed(3082, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3082')
+        """Read a distribution using query parameters.
+
+        See: `Pulp #3082 <https://pulp.plan.io/issues/3082>`_
+        """
         unique_params = (
             {'name': self.distribution['name']},
             {'base_path': self.distribution['base_path']}

--- a/pulpcore/tests/functional/api/test_crud_repos.py
+++ b/pulpcore/tests/functional/api/test_crud_repos.py
@@ -4,7 +4,7 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import gen_repo
 
@@ -62,17 +62,19 @@ class CRUDRepoTestCase(unittest.TestCase):
 
     @skip_if(bool, 'repo', False)
     def test_02_read_all_repos(self):
-        """Ensure name is displayed when listing repositories."""
-        if not selectors.bug_is_fixed(2824, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/2824')
+        """Ensure name is displayed when listing repositories.
+
+        See Pulp #2824 <https://pulp.plan.io/issues/2824>`_
+        """
         for repo in self.client.get(REPO_PATH)['results']:
             self.assertIsNotNone(repo['name'])
 
     @skip_if(bool, 'repo', False)
     def test_03_fully_update_name(self):
-        """Update a repository's name using HTTP PUT."""
-        if not selectors.bug_is_fixed(3101, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3101')
+        """Update a repository's name using HTTP PUT.
+
+        See: `Pulp #3101 <https://pulp.plan.io/issues/3101>`_
+        """
         self.do_fully_update_attr('name')
 
     @skip_if(bool, 'repo', False)
@@ -97,9 +99,10 @@ class CRUDRepoTestCase(unittest.TestCase):
 
     @skip_if(bool, 'repo', False)
     def test_03_partially_update_name(self):
-        """Update a repository's name using HTTP PATCH."""
-        if not selectors.bug_is_fixed(3101, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3101')
+        """Update a repository's name using HTTP PATCH.
+
+        See: `Pulp #3101 <https://pulp.plan.io/issues/3101>`_
+        """
         self.do_partially_update_attr('name')
 
     @skip_if(bool, 'repo', False)

--- a/pulpcore/tests/functional/api/test_crud_users.py
+++ b/pulpcore/tests/functional/api/test_crud_users.py
@@ -4,7 +4,7 @@ import unittest
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import USER_PATH
 
 from tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -45,9 +45,10 @@ class UsersCRUDTestCase(unittest.TestCase):
 
     @skip_if(bool, 'user', False)
     def test_02_read_username(self):
-        """Read a user by its username."""
-        if not selectors.bug_is_fixed(3142, self.cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3142')
+        """Read a user by its username.
+
+        See: `Pulp Issue #3142 <https://pulp.plan.io/issues/3142>`_
+        """
         page = self.client.get(USER_PATH, params={
             'username': self.user['username']
         })
@@ -71,8 +72,6 @@ class UsersCRUDTestCase(unittest.TestCase):
     def test_03_fully_update_user(self):
         """Update a user info using HTTP PUT."""
         attrs = _gen_verbose_user_attrs()
-        if not selectors.bug_is_fixed(3125, self.cfg.pulp_version):
-            attrs['username'] = self.user['username']
         self.client.put(self.user['_href'], attrs)
         user = self.client.get(self.user['_href'])
         for key, val in attrs.items():
@@ -86,8 +85,6 @@ class UsersCRUDTestCase(unittest.TestCase):
     def test_03_partially_update_user(self):
         """Update a user info using HTTP PATCH."""
         attrs = _gen_verbose_user_attrs()
-        if not selectors.bug_is_fixed(3125, self.cfg.pulp_version):
-            del attrs['username']
         self.client.patch(self.user['_href'], attrs)
         user = self.client.get(self.user['_href'])
         for key, val in attrs.items():

--- a/pulpcore/tests/functional/api/test_workers.py
+++ b/pulpcore/tests/functional/api/test_workers.py
@@ -6,7 +6,7 @@ from random import choice
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config
 from pulp_smash.pulp3.constants import WORKER_PATH
 
 from tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -70,8 +70,6 @@ class WorkersTestCase(unittest.TestCase):
     @skip_if(bool, 'worker', False)
     def test_03_positive_filters(self):
         """Read a worker using a set of query parameters."""
-        if not selectors.bug_is_fixed(3586, self.cfg.pulp_version):
-            raise self.skipTest('https://pulp.plan.io/issues/3586')
         page = self.client.get(WORKER_PATH, params={
             'last_heartbeat__gte': self.worker['last_heartbeat'],
             'name': self.worker['name'],
@@ -91,8 +89,6 @@ class WorkersTestCase(unittest.TestCase):
     @skip_if(bool, 'worker', False)
     def test_04_negative_filters(self):
         """Read a worker with a query that does not match any worker."""
-        if not selectors.bug_is_fixed(3586, self.cfg.pulp_version):
-            raise self.skipTest('https://pulp.plan.io/issues/3586')
         page = self.client.get(WORKER_PATH, params={
             'last_heartbeat__gte': str(datetime.now() + timedelta(days=1)),
             'name': self.worker['name'],

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_version.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_version.py
@@ -7,7 +7,7 @@ from time import sleep
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, selectors, utils
+from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
     delete_version,
@@ -58,8 +58,6 @@ class AddRemoveContentTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class-wide variables."""
         cls.cfg = config.get_config()
-        if not selectors.bug_is_fixed(3502, cls.cfg.pulp_version):
-            raise unittest.SkipTest('https://pulp.plan.io/issues/3502')
         cls.client = api.Client(cls.cfg, api.json_handler)
         cls.remote = {}
         cls.repo = {}

--- a/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
@@ -4,7 +4,7 @@
 import unittest
 from urllib.parse import urljoin
 
-from pulp_smash import api, config, selectors
+from pulp_smash import api, config
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
     gen_remote,
@@ -47,8 +47,6 @@ class RemotesPublishersTestCase(unittest.TestCase):
            are associated with different repositories.
         """
         cfg = config.get_config()
-        if not selectors.bug_is_fixed(3502, cfg.pulp_version):
-            self.skipTest('https://pulp.plan.io/issues/3502')
 
         # Create an remote and publisher.
         client = api.Client(cfg, api.json_handler)
@@ -79,8 +77,6 @@ class RemotesPublishersTestCase(unittest.TestCase):
         publications = []
         for repo in repos:
             publications.append(publish(cfg, publisher, repo))
-            if selectors.bug_is_fixed(3354, cfg.pulp_version):
-                self.addCleanup(client.delete, publications[-1]['_href'])
         self.assertEqual(
             publications[0]['publisher'],
             publications[1]['publisher']


### PR DESCRIPTION
Now that Smash tests are in the same repo as the code under test, we no
longer need to look to an external source (Redmine) to determine whether
an issue should be tested.

When adding a new test for funtionality which does not exist or is broken, decorate the test or test class with @unittest.skip("https://pulp.plan.io/issue/..."), and the patch which adds or fixes this functionality should remove the skip decorator to re-enable the test.

This has several benefits - it means the PR test runner will always run
the tests for the functionality being added/fixed so long as the
developer has properly re-enabled the test. It should also make the
tests faster by a small degree, and less reliant on external connections.