### PR TITLE
Fixes broken unit test around TaskStatus model

### DIFF
--- a/server/test/unit/server/db/model/test_dispatch.py
+++ b/server/test/unit/server/db/model/test_dispatch.py
@@ -157,7 +157,6 @@ class TestTaskStatus(unittest.TestCase):
             self.assertRaises(ValidationError, TaskStatus(task_id=task_id,
                                                           tags=invalid_tag).save)
 
-    @skip.skip_broken
     def test_state_validation(self):
         # Valid state
         valid_states = constants.CALL_STATES
@@ -165,7 +164,7 @@ class TestTaskStatus(unittest.TestCase):
             TaskStatus(task_id=str(uuid4()), state=valid_state).save()
 
         # Invalid state
-        invalid_states = [4, {}, uuid4(), object(), 'invalid_state', []]
+        invalid_states = [4, uuid4(), object(), 'invalid_state', []]
         for invalid_state in invalid_states:
             self.assertRaises(ValidationError, TaskStatus(task_id=str(uuid4()),
                                                           state=invalid_state).save)


### PR DESCRIPTION
The test uses a list of various objects as invalid inputs for a Task status. One of the objects is a dict
which mongoengine does not support as a value because it's not hashable. This patch removes the dict from
the list of possible bad inputs.

closes: #3955
https://pulp.plan.io/issues/3955