### PR TITLE
Problem: suffix field is required in the serializer, but can be ''

### DIFF
--- a/pulpcore/pulpcore/app/serializers/progress.py
+++ b/pulpcore/pulpcore/app/serializers/progress.py
@@ -28,7 +28,8 @@ class ProgressReportSerializer(ModelSerializer):
     )
     suffix = serializers.CharField(
         help_text=_("The suffix to be shown with the progress report."),
-        read_only=True
+        read_only=True,
+        allow_blank=True
     )
     task = RelatedField(
         help_text=_("The task associated with this progress report."),


### PR DESCRIPTION
Solution: set allow_blank=True in the serializer

closes: #3964
https://pulp.plan.io/issues/3964