### PR TITLE
Problem: OpenAPI schema for created resource contains fields

### DIFF
--- a/pulpcore/pulpcore/app/serializers/task.py
+++ b/pulpcore/pulpcore/app/serializers/task.py
@@ -27,7 +27,7 @@ class CreatedResourceSerializer(ModelSerializer):
 
     class Meta:
         model = models.CreatedResource
-        fields = ModelSerializer.Meta.fields
+        fields = []
 
 
 class TaskSerializer(ModelSerializer):


### PR DESCRIPTION
Solution: remove the non-existing fields from the serializer

closes: #3965
https://pulp.plan.io/issues/3965