### PR TITLE
Problem: OpenAPI schema for RepositoryVersion 'retrieve' is wrong

### DIFF
--- a/pulpcore/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/pulpcore/app/serializers/__init__.py
@@ -29,7 +29,8 @@ from .repository import (  # noqa
     RepositoryPublishURLSerializer,
     RepositorySerializer,
     RepositorySyncURLSerializer,
-    RepositoryVersionSerializer
+    RepositoryVersionSerializer,
+    RepositoryVersionCreateSerializer
 )
 from .task import MinimalTaskSerializer, TaskSerializer, WorkerSerializer  # noqa
 from .user import UserSerializer  # noqa

--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -413,6 +413,25 @@ class RepositoryVersionSerializer(ModelSerializer, NestedHyperlinkedModelSeriali
         help_text=_('A list of counts of each type of content in this version.'),
         read_only=True
     )
+    base_version = NestedRelatedField(
+        required=False,
+        help_text=_('A repository version whose content was used as the initial set of content '
+                    'for this repository version'),
+        queryset=models.RepositoryVersion.objects.all(),
+        view_name='versions-detail',
+        lookup_field='number',
+        parent_lookup_kwargs={'repository_pk': 'repository__pk'},
+    )
+
+    class Meta:
+        model = models.RepositoryVersion
+        fields = ModelSerializer.Meta.fields + (
+            '_href', '_content_href', '_added_href', '_removed_href', 'number',
+            'content_summary', 'base_version'
+        )
+
+
+class RepositoryVersionCreateSerializer(ModelSerializer, NestedHyperlinkedModelSerializer):
     add_content_units = serializers.ListField(
         help_text=_('A list of content units to add to a new repository version'),
         write_only=True
@@ -433,7 +452,4 @@ class RepositoryVersionSerializer(ModelSerializer, NestedHyperlinkedModelSeriali
 
     class Meta:
         model = models.RepositoryVersion
-        fields = ModelSerializer.Meta.fields + (
-            '_href', '_content_href', '_added_href', '_removed_href', 'number',
-            'content_summary', 'add_content_units', 'remove_content_units', 'base_version'
-        )
+        fields = ['add_content_units', 'remove_content_units', 'base_version']

--- a/pulpcore/pulpcore/app/viewsets/repository.py
+++ b/pulpcore/pulpcore/app/viewsets/repository.py
@@ -31,7 +31,8 @@ from pulpcore.app.serializers import (
     PublicationSerializer,
     PublisherSerializer,
     RepositorySerializer,
-    RepositoryVersionSerializer
+    RepositoryVersionSerializer,
+    RepositoryVersionCreateSerializer
 )
 from pulpcore.app.viewsets import (
     AsyncRemoveMixin,
@@ -302,6 +303,11 @@ class RepositoryVersionViewSet(NamedModelViewSet,
             }
         )
         return OperationPostponedResponse(result, request)
+
+    def get_serializer_class(self):
+        if self.action == 'create':
+            return RepositoryVersionCreateSerializer
+        return RepositoryVersionSerializer
 
 
 class RemoteFilter(BaseFilterSet):


### PR DESCRIPTION
Solution: Create separate serializers for 'create' operation

The problem was that we had a single serializer for both GET and POST. DRF was able to
distinguish which fields were to be used for accepting POST body params and which fields to 
use when serializing for a GET response. DRF knows this because some fields are 'write_only'.
However, the drf_yasg library we use for generating OpenAPI schema does not take into account
the 'write_only' attribute of a field. As a result when it was using the serializer to
generate a schema for the GET response it was including the 'write_only' fields.

This patch introduces a new serializer that is only used for the 'create' operation of the
RepositoryVersion ViewSet. This serializer is only used to inspect the inbound data in the POST
body. It is not used for the response. The response is generated using the OperationPostponed
serializer.

closes: #3966
https://pulp.plan.io/issues/3966
