### PR TITLE
Add better support for related model saving

### DIFF
--- a/docs/plugins/plugin-api/stages.rst
+++ b/docs/plugins/plugin-api/stages.rst
@@ -62,6 +62,7 @@ Content Related Stages
 
 .. autoclass:: pulpcore.plugin.stages.ContentUnitSaver
    :special-members: __call__
+   :private-members: _pre_save, _post_save
 
 .. autoclass:: pulpcore.plugin.stages.QueryExistingContentUnits
    :special-members: __call__


### PR DESCRIPTION
Adds pre_save() and post_save() handlers to ContentUnitSaver that plugin
writers can override on subclasses.

https://pulp.plan.io/issues/3953
closes #3953