### PR TITLE
Break loop if artifact found by digest

### DIFF
--- a/plugin/pulpcore/plugin/stages/artifact_stages.py
+++ b/plugin/pulpcore/plugin/stages/artifact_stages.py
@@ -84,6 +84,7 @@ class QueryExistingArtifacts(Stage):
                             digest_value = getattr(declarative_artifact.artifact, digest_name)
                             if digest_value and digest_value == getattr(artifact, digest_name):
                                 declarative_artifact.artifact = artifact
+                                break
             for content in batch:
                 if content is None:
                     continue


### PR DESCRIPTION
There is no need to continue searching for Artifacts, once we have found a
matching digest. The first match should be as good as the last one.