### PR TITLE
Add support for sha512

### DIFF
--- a/server/pulp/server/util.py
+++ b/server/pulp/server/util.py
@@ -34,14 +34,16 @@ TYPE_MD5 = md5().name
 TYPE_SHA = 'sha'
 TYPE_SHA1 = hashlib.sha1().name
 TYPE_SHA256 = hashlib.sha256().name
+TYPE_SHA512 = hashlib.sha512().name
 
-HASHLIB_ALGORITHMS = (TYPE_MD5, TYPE_SHA, TYPE_SHA1, TYPE_SHA256)
+HASHLIB_ALGORITHMS = (TYPE_MD5, TYPE_SHA, TYPE_SHA1, TYPE_SHA256, TYPE_SHA512)
 
 CHECKSUM_FUNCTIONS = {
     TYPE_MD5: md5,
     TYPE_SHA: hashlib.sha1,
     TYPE_SHA1: hashlib.sha1,
     TYPE_SHA256: hashlib.sha256,
+    TYPE_SHA512: hashlib.sha512,
 }
 
 

--- a/server/test/unit/server/test_util.py
+++ b/server/test/unit/server/test_util.py
@@ -259,11 +259,12 @@ class TestSanitizeChecksumType(unittest.TestCase):
 
 class TestGlobal(unittest.TestCase):
     def test_checksum_algorithm_mappings(self):
-        self.assertEqual(4, len(util.CHECKSUM_FUNCTIONS))
+        self.assertEqual(5, len(util.CHECKSUM_FUNCTIONS))
         self.assertEqual(util.CHECKSUM_FUNCTIONS[util.TYPE_MD5]().name, 'md5')
         self.assertEqual(util.CHECKSUM_FUNCTIONS[util.TYPE_SHA1], hashlib.sha1)
         self.assertEqual(util.CHECKSUM_FUNCTIONS[util.TYPE_SHA], hashlib.sha1)
         self.assertEqual(util.CHECKSUM_FUNCTIONS[util.TYPE_SHA256], hashlib.sha256)
+        self.assertEqual(util.CHECKSUM_FUNCTIONS[util.TYPE_SHA512], hashlib.sha512)
 
 
 class TestCalculateChecksums(unittest.TestCase):


### PR DESCRIPTION
This fixes the error:
  PLP1005: The checksum type 'sha512' is unknown.
reported also in https://github.com/NVIDIA/nvidia-docker/issues/811