### PR TITLE
Changing the syntax for no-issue commits to [noissue]

### DIFF
--- a/.travis/validate_commit_message.py
+++ b/.travis/validate_commit_message.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 
 KEYWORDS = ['fixes', 'closes', 're', 'ref']
-NO_ISSUE = '#noissue'
+NO_ISSUE = '[noissue]'
 STATUSES = ['NEW', 'ASSIGNED', 'POST']
 
 sha = sys.argv[1]

--- a/docs/contributing/git.rst
+++ b/docs/contributing/git.rst
@@ -80,7 +80,7 @@ To reference multiple issues in a commit use a separate line for each one::
     fixes #124
 
 We strongly suggest that each commit is attached to an issue in Redmine. However, if you must create
-a commit for which there is no issue, add the tag ``#noissue`` to the commit's message.
+a commit for which there is no issue, add the tag ``[noissue]`` to the commit's message.
 
 Putting this all together, the following is an example of a good commit message::
 


### PR DESCRIPTION
Editing commit messages in vim causes lines starting with # to be
ignored so #noissue was not a good choice as a keyword. Use [noissue]
instead.