### PR TITLE
Problem: mirror is defined as a string in OpenAPI schema

### DIFF
--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -137,9 +137,8 @@ class RepositorySyncURLSerializer(serializers.Serializer):
         }
     )
 
-    mirror = fields.ChoiceField(
+    mirror = fields.BooleanField(
         required=False,
-        choices=[True, False],
         default=True,
         help_text=_('The synchronization mode, True for "mirror" and False for "additive" mode.')
     )


### PR DESCRIPTION
Solution: change the ChoiceField to a BooleanField

Auto generated bindings were sending a string 'true' for the default. The REST API would respond
with a 400 error. Since the two choices were 'true' and 'false', it was more appropriate to use a
boolean field. The OpenAPI schema now correctly describes this field as a boolean.

[noissue]

