### PR TITLE
Rebuild content unit counts after unassociating units from a repo.

### DIFF
--- a/server/pulp/server/managers/repo/unit_association.py
+++ b/server/pulp/server/managers/repo/unit_association.py
@@ -391,15 +391,8 @@ class RepoUnitAssociationManager(object):
             }
             collection.remove(spec)
 
-            unique_count = sum(
-                1 for unit_id in unit_ids if not RepoUnitAssociationManager.association_exists(
-                    repo_id, unit_id, unit_type_id))
-            if not unique_count:
-                continue
-
-            repo_controller.update_unit_count(repo_id, unit_type_id, -unique_count)
-
         repo_controller.update_last_unit_removed(repo_id)
+        repo_controller.rebuild_content_unit_counts(repo)
 
         # Match the return type/format as copy
         serializable_units = [u.to_id_dict() for u in transfer_units]

--- a/server/test/unit/server/managers/repo/test_unit_association.py
+++ b/server/test/unit/server/managers/repo/test_unit_association.py
@@ -370,14 +370,11 @@ class RepoUnitAssociationManagerTests(base.PulpServerTests):
         self.manager.associate_unit_by_id(self.repo_id, self.unit_type_id, self.unit_id)
         self.manager.unassociate_unit_by_id(self.repo_id, self.unit_type_id, self.unit_id)
 
-        self.assertEqual(2, mock_ctrl.update_unit_count.call_count)
+        self.assertEqual(1, mock_ctrl.update_unit_count.call_count)
+        self.assertEqual(1, mock_ctrl.rebuild_content_unit_counts.call_count)
         self.assertEqual(mock_ctrl.update_unit_count.call_args_list[0][0][0], self.repo_id)
-        self.assertEqual(mock_ctrl.update_unit_count.call_args_list[1][0][1], self.unit_type_id)
+        self.assertEqual(mock_ctrl.update_unit_count.call_args_list[0][0][1], self.unit_type_id)
         self.assertEqual(mock_ctrl.update_unit_count.call_args_list[0][0][2], 1)
-
-        self.assertEqual(mock_ctrl.update_unit_count.call_args_list[1][0][0], self.repo_id)
-        self.assertEqual(mock_ctrl.update_unit_count.call_args_list[1][0][1], self.unit_type_id)
-        self.assertEqual(mock_ctrl.update_unit_count.call_args_list[1][0][2], -1)
 
     @mock.patch('pulp.server.managers.repo.unit_association.repo_controller')
     def test_unassociate_by_id_non_unique(self, mock_ctrl, mock_repo):


### PR DESCRIPTION
To avoid mistake sin counting removed units, especially in the cases
when there are dependant units which are removed as well.

re #3985
https://pulp.plan.io/issues/3985