### PR TITLE
Pin version of sphinx to 1.7.9 while 1.8 has a bug

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -5,6 +5,6 @@ django-filter
 drf-nested-routers
 pyyaml
 psycopg2
-sphinx
+sphinx<1.8.0
 sphinx-rtd-theme
 sphinxcontrib-openapi


### PR DESCRIPTION
Related to this commit also:
https://github.com/pulp/pulp/commit/6dde2e11fee849822554c1c8dbb9fb221f3588d0

[noissue]
