### PR TITLE
Add support for pass-through publications.

### DIFF
--- a/pulpcore/pulpcore/app/models/publication.py
+++ b/pulpcore/pulpcore/app/models/publication.py
@@ -16,6 +16,9 @@ class Publication(Model):
 
     Fields:
         complete (models.BooleanField): State tracking; for internal use. Indexed.
+        pass_through (models.BooleanField): Indicates that the publication is a pass-through
+            to the repository version. Enabling pass-through has the same effect as creating
+            a PublishedArtifact for all of the content (artifacts) in the repository.
 
     Relations:
         publisher (models.ForeignKey): The publisher that created the publication.
@@ -38,12 +41,13 @@ class Publication(Model):
     """
 
     complete = models.BooleanField(db_index=True, default=False)
+    pass_through = models.BooleanField(default=False)
 
     publisher = models.ForeignKey('Publisher', on_delete=models.CASCADE)
     repository_version = models.ForeignKey('RepositoryVersion', on_delete=models.CASCADE)
 
     @classmethod
-    def create(cls, repository_version, publisher):
+    def create(cls, repository_version, publisher, pass_through=False):
         """
         Create a publication.
 
@@ -55,6 +59,10 @@ class Publication(Model):
                 version to be published.
             publisher (pulpcore.app.models.Publisher): The publisher used
                 to create the publication.
+            pass_through (bool): Indicates that the publication is a pass-through
+                to the repository version. Enabling pass-through has the same effect
+                as creating a PublishedArtifact for all of the content (artifacts)
+                in the repository.
 
         Returns:
             pulpcore.app.models.Publication: A created Publication in an incomplete state.
@@ -64,6 +72,7 @@ class Publication(Model):
         """
         with transaction.atomic():
             publication = cls(
+                pass_through=pass_through,
                 repository_version=repository_version,
                 publisher=publisher)
             publication.save()

--- a/pulpcore/pulpcore/app/serializers/repository.py
+++ b/pulpcore/pulpcore/app/serializers/repository.py
@@ -361,6 +361,9 @@ class PublicationSerializer(ModelSerializer):
     _href = IdentityField(
         view_name='publications-detail'
     )
+    pass_through = serializers.BooleanField(
+        help_text=_('The publication is a pass-through for the repository version.')
+    )
     publisher = DetailRelatedField(
         help_text=_('The publisher that created this publication.'),
         queryset=models.Publisher.objects.all()
@@ -382,6 +385,7 @@ class PublicationSerializer(ModelSerializer):
     class Meta:
         model = models.Publication
         fields = ModelSerializer.Meta.fields + (
+            'pass_through',
             'publisher',
             'distributions',
             'repository_version',


### PR DESCRIPTION
https://pulp.plan.io/issues/4020

Adds support for pass-through publications.  

Publishers would still use the `Publication` _context_ and may (optionally) set pass-through=True. In combination with this, the publisher can (optionally) add `PublishedMeta` and possibly `PublishedArtifacts` to customize how the publication is composed.

I still need to run EXMPLAIN to see what django has translated the content-artifact query to be sure it's efficient and using the indexes.

I'm not sure where/how to update the docs.  I'm inclined to capture pass-through in planned more comprehensive docs rewrite stores.