### PR TITLE
Problem: ArtifactFileField can delete an existing artifact's file

### DIFF
--- a/plugin/pulpcore/plugin/stages/artifact_stages.py
+++ b/plugin/pulpcore/plugin/stages/artifact_stages.py
@@ -1,7 +1,5 @@
 import asyncio
 
-from django.core.files import File
-from django.core.files.storage import DefaultStorage
 from django.db.models import Q
 
 from pulpcore.plugin.models import Artifact, ProgressBar
@@ -234,18 +232,12 @@ class ArtifactSaver(Stage):
         Returns:
             The coroutine for this stage.
         """
-        storage_backend = DefaultStorage()
         async for batch in self.batches(in_q):
             artifacts_to_save = []
             for declarative_content in batch:
                 for declarative_artifact in declarative_content.d_artifacts:
                     if declarative_artifact.artifact.pk is None:
-                        src_path = str(declarative_artifact.artifact.file)
-                        dst_path = declarative_artifact.artifact.storage_path(None)
-                        with open(src_path, mode='rb') as input_file:
-                            django_file_obj = File(input_file)
-                            storage_backend.save(dst_path, django_file_obj)
-                        declarative_artifact.artifact.file = dst_path
+                        declarative_artifact.artifact.file = str(declarative_artifact.artifact.file)
                         artifacts_to_save.append(declarative_artifact.artifact)
 
             if artifacts_to_save:

--- a/pulpcore/pulpcore/app/models/fields.py
+++ b/pulpcore/pulpcore/app/models/fields.py
@@ -1,3 +1,7 @@
+import os
+from gettext import gettext as _
+
+from django.conf import settings
 from django.db.models import FileField
 
 from pulpcore.app.files import TemporaryDownloadedFile
@@ -23,6 +27,11 @@ class ArtifactFileField(FileField):
             Field's value just before saving.
 
         """
+        file_name = str(model_instance.file)
+        if file_name.startswith(os.path.join(settings.MEDIA_ROOT, 'artifact')):
+            raise ValueError(_('The file referenced by the Artifact is already present in '
+                               'Artifact storage. Files must be stored outside this location '
+                               'prior to Artifact creation.'))
         file = super().pre_save(model_instance, add)
         if file and file._committed and add:
             file._file = TemporaryDownloadedFile(open(file.name, 'rb'))


### PR DESCRIPTION
Solution: Add a check to see if the source file is already in artifact storage

Prior to this patch it was possible to break an existing artifact by passing a path to it's file
as the file for a new Artifact.

This patch also removes extraneous code in the ArtifactSaver stage. The code was present because
an assumption was made that bulk_save() on Artifacts would not call the presave handler on the
ArtifactFileField. However, this is not the case and the pre_save handler is getting called.

closes: #3915
https://pulp.plan.io/issues/3915

