### PR TITLE
Fix parameter name for autodoc defaults in Sphinx < 1.8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,7 +105,7 @@ pygments_style = 'sphinx'
 # Set autodoc default options
 # Document all module/class/etc members, even if they have no docstring.
 # Show class inheritance, and group class members together by type (attr, method, etc)
-autodoc_default_options = ['members', 'undoc-members']
+autodoc_default_flags = ['members', 'undoc-members']
 autodoc_member_order = 'groupwise'
 autoclass_content = 'both'
 


### PR DESCRIPTION
[noissue]
