### PR TITLE
Make publisher for publications optional

### DIFF
--- a/pulpcore/pulpcore/app/models/publication.py
+++ b/pulpcore/pulpcore/app/models/publication.py
@@ -43,7 +43,7 @@ class Publication(Model):
     complete = models.BooleanField(db_index=True, default=False)
     pass_through = models.BooleanField(default=False)
 
-    publisher = models.ForeignKey('Publisher', on_delete=models.CASCADE)
+    publisher = models.ForeignKey('Publisher', on_delete=models.CASCADE, null=True)
     repository_version = models.ForeignKey('RepositoryVersion', on_delete=models.CASCADE)
 
     @classmethod


### PR DESCRIPTION
Set `publisher` field at `Publication` model nullable.

fixes #4038

