### PR TITLE
Add tests for base_version and repository versions

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/constants.py
+++ b/pulpcore/tests/functional/api/using_plugin/constants.py
@@ -33,7 +33,10 @@ FILE2_FIXTURE_MANIFEST_URL = urljoin(FILE2_FIXTURE_URL, 'PULP_MANIFEST')
 FILE_MANY_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-many/')
 """The URL to a file repository containing many files."""
 
-FILE_MANY_FIXTURE_MANIFEST_URL = urljoin(FILE_MANY_FIXTURE_URL, 'PULP_MANIFEST')
+FILE_MANY_FIXTURE_MANIFEST_URL = urljoin(
+    FILE_MANY_FIXTURE_URL,
+    'PULP_MANIFEST'
+)
 """The URL to a file repository manifest"""
 
 FILE_MANY_FIXTURE_COUNT = 250
@@ -42,7 +45,13 @@ FILE_MANY_FIXTURE_COUNT = 250
 FILE_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'file-large/')
 """The URL to a file repository containing a large number of files."""
 
-FILE_LARGE_FIXTURE_MANIFEST_URL = urljoin(FILE_LARGE_FIXTURE_URL, 'PULP_MANIFEST')
+FILE_LARGE_FIXTURE_COUNT = 10
+"""The number of packages available at :data:`FILE_LARGE_FIXTURE_URL`."""
+
+FILE_LARGE_FIXTURE_MANIFEST_URL = urljoin(
+    FILE_LARGE_FIXTURE_URL,
+    'PULP_MANIFEST'
+)
 """The URL to a file repository manifest."""
 
 FILE_URL = urljoin(FILE_FIXTURE_URL, '1.iso')

--- a/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
@@ -26,7 +26,10 @@ from tests.functional.api.using_plugin.constants import (
     FILE_PUBLISHER_PATH,
     FILE_REMOTE_PATH
 )
-from tests.functional.api.using_plugin.utils import gen_file_publisher, populate_pulp
+from tests.functional.api.using_plugin.utils import (
+    gen_file_publisher,
+    populate_pulp,
+)
 from tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
 
 


### PR DESCRIPTION
Add tests to verify that `base_version` can be used to create another
repository version. Using the same repository, and a different one.

Besides that, add a test to assure that an HTTP exception is raised when using
a non-exitent `base_version`.

closes: #4035
https://pulp.plan.io/issues/4035