### PR TITLE
Problem: Distribution is not available as an abstract model

### DIFF
--- a/plugin/pulpcore/plugin/models/__init__.py
+++ b/plugin/pulpcore/plugin/models/__init__.py
@@ -3,6 +3,7 @@
 
 from pulpcore.app.models import (  # noqa
     Artifact,
+    BaseDistribution,
     Content,
     ContentArtifact,
     ContentGuard,

--- a/pulpcore/pulpcore/app/models/__init__.py
+++ b/pulpcore/pulpcore/app/models/__init__.py
@@ -12,7 +12,13 @@ from .generic import (  # noqa
 )
 
 from .content import Artifact, Content, ContentArtifact, ContentGuard, RemoteArtifact  # noqa
-from .publication import Distribution, Publication, PublishedArtifact, PublishedMetadata  # noqa
+from .publication import (  # noqa
+    BaseDistribution,
+    Distribution,
+    Publication,
+    PublishedArtifact,
+    PublishedMetadata
+)
 from .repository import (  # noqa
     Exporter,
     Remote,


### PR DESCRIPTION
Solution: Add a BaseDistribution for plugin writers to use

This patch adds an abstract BaseDistribution model to the plugin api.

re: 3991
https://pulp.plan.io/issues/3991