### PR TITLE
Add test to assert that error should be raised when passing invalid parameters to CRUD API

### DIFF
--- a/pulpcore/tests/functional/api/test_crud_distributions.py
+++ b/pulpcore/tests/functional/api/test_crud_distributions.py
@@ -25,7 +25,9 @@ class CRUDDistributionsTestCase(unittest.TestCase):
     def test_01_create_distribution(self):
         """Create a distribution."""
         body = gen_distribution()
-        type(self).distribution = self.client.post(DISTRIBUTION_PATH, body)
+        type(self).distribution = self.client.post(
+            DISTRIBUTION_PATH, body
+        )
         for key, val in body.items():
             with self.subTest(key=key):
                 self.assertEqual(self.distribution[key], val)
@@ -94,6 +96,17 @@ class CRUDDistributionsTestCase(unittest.TestCase):
         self.client.delete(self.distribution['_href'])
         with self.assertRaises(HTTPError):
             self.client.get(self.distribution['_href'])
+
+    def test_negative_create_distribution_with_invalid_parameter(self):
+        """Attempt to create distribution passing invalid parameter.
+
+        Assert response returns an error 400 including ["Unexpected field"].
+        """
+        response = api.Client(self.cfg, api.echo_handler).post(
+            DISTRIBUTION_PATH, gen_distribution(foo='bar')
+        )
+        assert response.status_code == 400
+        assert response.json()['foo'] == ['Unexpected field']
 
 
 class DistributionBasePathTestCase(unittest.TestCase):

--- a/pulpcore/tests/functional/api/test_crud_repos.py
+++ b/pulpcore/tests/functional/api/test_crud_repos.py
@@ -36,10 +36,8 @@ class CRUDRepoTestCase(unittest.TestCase):
         See: `Pulp Smash #1055
         <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
         """
-        body = gen_repo()
-        body['name'] = self.repo['name']
         with self.assertRaises(HTTPError):
-            self.client.post(REPO_PATH, body)
+            self.client.post(REPO_PATH, gen_repo(name=self.repo['name']))
 
     @skip_if(bool, 'repo', False)
     def test_02_read_repo(self):
@@ -131,3 +129,14 @@ class CRUDRepoTestCase(unittest.TestCase):
         # verify the delete
         with self.assertRaises(HTTPError):
             self.client.get(self.repo['_href'])
+
+    def test_negative_create_repo_with_invalid_parameter(self):
+        """Attempt to create repository passing extraneous invalid parameter.
+
+        Assert response returns an error 400 including ["Unexpected field"].
+        """
+        response = api.Client(self.cfg, api.echo_handler).post(
+            REPO_PATH, gen_repo(foo='bar')
+        )
+        assert response.status_code == 400
+        assert response.json()['foo'] == ['Unexpected field']

--- a/pulpcore/tests/functional/api/test_crud_users.py
+++ b/pulpcore/tests/functional/api/test_crud_users.py
@@ -101,6 +101,19 @@ class UsersCRUDTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             self.client.get(self.user['_href'])
 
+    def test_negative_create_user_with_invalid_parameter(self):
+        """Attempt to create user passing invalid parameter.
+
+        Assert response returns an error 400 including ["Unexpected field"].
+        """
+        attrs = _gen_verbose_user_attrs()
+        attrs['foo'] = 'bar'
+        response = api.Client(self.cfg, api.echo_handler).post(
+            USER_PATH, attrs
+        )
+        assert response.status_code == 400
+        assert response.json()['foo'] == ['Unexpected field']
+
 
 def _gen_verbose_user_attrs():
     """Generate a dict with lots of user attributes.

--- a/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
@@ -126,3 +126,25 @@ class PublicationsTestCase(unittest.TestCase):
         self.client.delete(self.publication['_href'])
         with self.assertRaises(HTTPError):
             self.client.get(self.publication['_href'])
+
+    def test_negative_create_file_remote_with_invalid_parameter(self):
+        """Attempt to create file remote passing invalid parameter.
+
+        Assert response returns an error 400 including ["Unexpected field"].
+        """
+        response = api.Client(self.cfg, api.echo_handler).post(
+            FILE_REMOTE_PATH, gen_file_remote(foo='bar')
+        )
+        assert response.status_code == 400
+        assert response.json()['foo'] == ['Unexpected field']
+
+    def test_negative_create_file_publisher_with_invalid_parameter(self):
+        """Attempt to create file publisher passing invalid parameter.
+
+        Assert response returns an error 400 including ["Unexpected field"].
+        """
+        response = api.Client(self.cfg, api.echo_handler).post(
+            FILE_PUBLISHER_PATH, gen_file_publisher(foo='bar')
+        )
+        assert response.status_code == 400
+        assert response.json()['foo'] == ['Unexpected field']


### PR DESCRIPTION
Add test to assert that error should be raised when passing invalid extraneous parameters to CRUD APIs.

closes PulpQE/pulp-smash#1085

[noissue]