### PR TITLE
Move imports so wsgi uses dynaconf settings

### DIFF
--- a/pulpcore/pulpcore/app/wsgi.py
+++ b/pulpcore/pulpcore/app/wsgi.py
@@ -9,11 +9,11 @@ https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 
 import os
 
-from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pulpcore.app.settings")
 
 # https://github.com/rochacbruno/dynaconf/issues/89
 from dynaconf.contrib import django_dynaconf  # noqa
+from django.core.wsgi import get_wsgi_application # noqa
 
 application = get_wsgi_application()


### PR DESCRIPTION
In development, wsgi is always launched using the manage.py, so the dynaconf imports there are fine. For non-development environments, wsgi might run by a systemd unit file directly.