### PR TITLE
Add test to ensure specific fields are returned from API

### DIFF
--- a/pulpcore/tests/functional/api/test_crud_users.py
+++ b/pulpcore/tests/functional/api/test_crud_users.py
@@ -44,6 +44,25 @@ class UsersCRUDTestCase(unittest.TestCase):
                 self.assertEqual(val, self.user[key])
 
     @skip_if(bool, 'user', False)
+    def test_02_read_user_with_specific_fields(self):
+        """Read a user byt its _href providing specific field name."""
+        for field in ('_href', 'username'):
+            user = self.client.get(
+                self.user['_href'],
+                params={'fields': field}
+            )
+            with self.subTest(key=field):
+                self.assertEqual((field,), tuple(user.keys()))
+
+    @skip_if(bool, 'user', False)
+    def test_02_read_user_without_specific_fields(self):
+        """Read a user by its href excluding specific fields."""
+        # requests doesn't allow the use of != in parameters.
+        url = '{}?fields!=username'.format(self.user['_href'])
+        user = self.client.get(url)
+        self.assertNotIn('username', user.keys())
+
+    @skip_if(bool, 'user', False)
     def test_02_read_username(self):
         """Read a user by its username.
 

--- a/pulpcore/tests/functional/api/test_tasks.py
+++ b/pulpcore/tests/functional/api/test_tasks.py
@@ -54,6 +54,37 @@ class TasksTestCase(unittest.TestCase):
                 self.assertEqual(task[key], val, task)
 
     @skip_if(bool, 'task', False)
+    def test_02_read_href_with_specific_fields(self):
+        """Read a task by its _href providing specific fields."""
+        fields = ('_href', 'state', 'worker')
+        task = self.client.get(
+            self.task['_href'],
+            params={'fields': ','.join(fields)}
+        )
+        self.assertEqual(sorted(fields), sorted(task.keys()))
+
+    @skip_if(bool, 'task', False)
+    def test_02_read_task_without_specific_fields(self):
+        """Read a task by its href excluding specific fields."""
+        # requests doesn't allow the use of != in parameters.
+        url = '{}?fields!=state'.format(self.task['_href'])
+        task = self.client.get(url)
+        self.assertNotIn('state', task.keys())
+
+    @skip_if(bool, 'task', False)
+    def test_02_read_task_with_minimal_fields(self):
+        """Read a task by its href filtering minimal fields."""
+        task = self.client.get(
+            self.task['_href'],
+            params={'minimal': True}
+        )
+        response_fields = task.keys()
+        self.assertNotIn('progress_reports', response_fields)
+        self.assertNotIn('spawned_tasks', response_fields)
+        self.assertNotIn('error', response_fields)
+        self.assertNotIn('non_fatal_errors', response_fields)
+
+    @skip_if(bool, 'task', False)
     def test_02_read_invalid_worker(self):
         """Read a task using an invalid worker name."""
         with self.assertRaises(HTTPError):


### PR DESCRIPTION
Tests to ensure specified fields as in `endpoint?fields=id,other,another` are strictly returned from the APIs

closes PulpQE/pulp-smash#1124

[noissue]