### PR TITLE
Pass DeclarativeArtifact.extra_data to downloader

### DIFF
--- a/plugin/pulpcore/plugin/download/file.py
+++ b/plugin/pulpcore/plugin/download/file.py
@@ -32,12 +32,15 @@ class FileDownloader(BaseDownloader):
         self._path = os.path.abspath(os.path.join(p.netloc, p.path))
         super().__init__(url, **kwargs)
 
-    async def run(self):
+    async def run(self, extra_data=None):
         """
         Read, validate, and compute digests on the `url`. This is a coroutine.
 
         This method provides the same return object type and documented in
         :meth:`~pulpcore.plugin.download.BaseDownloader.run`.
+
+        Args:
+            extra_data (dict): Extra data passed to the downloader.
         """
         async with aiofiles.open(self._path, 'rb') as f_handle:
             while True:

--- a/plugin/pulpcore/plugin/download/http.py
+++ b/plugin/pulpcore/plugin/download/http.py
@@ -159,7 +159,7 @@ class HttpDownloader(BaseDownloader):
                               url=self.url)
 
     @backoff.on_exception(backoff.expo, aiohttp.ClientResponseError, max_tries=10, giveup=giveup)
-    async def run(self):
+    async def run(self, extra_data=None):
         """
         Download, validate, and compute digests on the `url`. This is a coroutine.
 
@@ -169,6 +169,9 @@ class HttpDownloader(BaseDownloader):
 
         This method provides the same return object type and documented in
         :meth:`~pulpcore.plugin.download.BaseDownloader.run`.
+
+        Args:
+            extra_data (dict): Extra data passed by the downloader.
         """
         async with self.session.get(self.url) as response:
             response.raise_for_status()

--- a/plugin/pulpcore/plugin/stages/artifact_stages.py
+++ b/plugin/pulpcore/plugin/stages/artifact_stages.py
@@ -190,7 +190,10 @@ class ArtifactDownloaderRunner():
                     declarative_artifact.url,
                     **validation_kwargs
                 )
-                downloaders_for_content.append(downloader.run())
+                # Custom downloaders may need extra information to complete the request.
+                downloaders_for_content.append(
+                    downloader.run(extra_data=declarative_artifact.extra_data)
+                )
 
         return downloaders_for_content
 

--- a/plugin/tests/unit/stages/test_artifactdownloader.py
+++ b/plugin/tests/unit/stages/test_artifactdownloader.py
@@ -27,7 +27,7 @@ class DownloaderMock:
         cls.downloads = 0
         cls.canceled = 0
 
-    async def run(self):
+    async def run(self, extra_data=None):
         DownloaderMock.running += 1
         try:
             await asyncio.sleep(int(self.url))


### PR DESCRIPTION
Note: I'm not sure what the intended use of
DeclarativeArtifact.extra_data, so I am not sure if this goes outside
the intended scope.

Use Case: During Docker sync, certain requests need specific headers
that are not shared with the entire session. Since Artifact downloads
happen in pulpcore rather than the plugin, there is no way to pass extra
arguments to downloader.run(). I suspect that this problem would exist
for any plugin that needs specially formed request to download Artifacts.

This pattern would allow Artifact downloaders to:
  1. Add arbitrary headers to certain requests (like Docker V1 vs V2
      artifact downloads)
  2. Add arbitrary query parameters
  3. dynamically set http verbs

1 is my use case, though 2 and 3 are hypothetical.

[noissue]