### PR TITLE
Add tests for creating resources using invalid data 

### DIFF
--- a/pulpcore/tests/functional/api/test_crud_repos.py
+++ b/pulpcore/tests/functional/api/test_crud_repos.py
@@ -34,11 +34,17 @@ class CRUDRepoTestCase(unittest.TestCase):
     def test_02_create_same_name(self):
         """Try to create a second repository with an identical name.
 
-        See: `Pulp Smash #1055
+        * `Pulp Smash #882 <https://github.com/PulpQE/pulp-smash/issues/882>`_.
+        * `Pulp Smash #1055
         <https://github.com/PulpQE/pulp-smash/issues/1055>`_.
         """
-        with self.assertRaises(HTTPError):
-            self.client.post(REPO_PATH, gen_repo(name=self.repo['name']))
+        self.client.response_handler = api.echo_handler
+        response = self.client.post(
+            REPO_PATH,
+            gen_repo(name=self.repo['name'])
+        )
+        self.assertIn('unique', response.json()['name'][0])
+        self.assertEqual(response.status_code, 400)
 
     @skip_if(bool, 'repo', False)
     def test_02_read_repo(self):

--- a/pulpcore/tests/functional/api/utils.py
+++ b/pulpcore/tests/functional/api/utils.py
@@ -1,0 +1,18 @@
+# coding=utf-8
+"""Utilities for pulpcore API tests."""
+import string
+from random import choice
+
+
+def gen_username(length=10, valid_characters=True):
+    """Generate username given a certain length or punctuation to be used."""
+    valid_punctuation = '@.+-_'
+    if valid_characters:
+        return ''.join(
+            choice(string.ascii_letters + string.digits + valid_punctuation)
+            for _ in range(length)
+        )
+    invalid_puntuation = ''.join(
+        value for value in string.punctuation if value not in valid_punctuation
+    )
+    return ''.join(choice(invalid_puntuation) for _ in range(length))


### PR DESCRIPTION
Add a test to verify messages when attempting to create a user with a long
`username` and `username` with invalid characters.

Besides that, refactor the test for create repos with the same name.

See: https://github.com/PulpQE/pulp-smash/issues/882

'[noissue]'