### PR TITLE
Make an Artifact from a PulpTemporaryUploadedFile

### DIFF
--- a/docs/plugins/plugin-api/download.rst
+++ b/docs/plugins/plugin-api/download.rst
@@ -220,6 +220,6 @@ descendants of BaseDownloader.
 Validation Exceptions
 ---------------------
 
-.. autoclass:: pulpcore.plugin.download.DigestValidationError
-.. autoclass:: pulpcore.plugin.download.SizeValidationError
-.. autoclass:: pulpcore.plugin.download.DownloaderValidationError
+.. autoclass:: pulpcore.exceptions.DigestValidationError
+.. autoclass:: pulpcore.exceptions.SizeValidationError
+.. autoclass:: pulpcore.exceptions.ValidationError

--- a/plugin/pulpcore/plugin/download/__init__.py
+++ b/plugin/pulpcore/plugin/download/__init__.py
@@ -1,6 +1,4 @@
 from .base import BaseDownloader, DownloadResult  # noqa
-from .exceptions import (DigestValidationError, DownloaderValidationError,  # noqa
-                         SizeValidationError)  # noqa
 from .factory import DownloaderFactory  # noqa
 from .file import FileDownloader  # noqa
 from .http import HttpDownloader  # noqa

--- a/plugin/pulpcore/plugin/download/base.py
+++ b/plugin/pulpcore/plugin/download/base.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 
 from pulpcore.app.models import Artifact
-from .exceptions import DigestValidationError, SizeValidationError
+from pulpcore.exceptions import DigestValidationError, SizeValidationError
 
 
 log = logging.getLogger(__name__)
@@ -109,11 +109,11 @@ class BaseDownloader:
         :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
 
         Raises:
-            :class:`~pulpcore.plugin.download.DigestValidationError`: When any of the
-                ``expected_digest`` values don't match the digest of the data passed to
+            :class:`~pulpcore.exceptions.DigestValidationError`: When any of the ``expected_digest``
+                values don't match the digest of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
-            :class:`~pulpcore.plugin.download.SizeValidationError`: When the
-                ``expected_size`` value doesn't match the size of the data passed to
+            :class:`~pulpcore.exceptions.SizeValidationError`: When the ``expected_size`` value
+                doesn't match the size of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
         """
         self._writer.flush()
@@ -162,8 +162,8 @@ class BaseDownloader:
         Validate all digests validate if ``expected_digests`` is set
 
         Raises:
-            :class:`~pulpcore.plugin.download.DigestValidationError`: When any of the
-                ``expected_digest`` values don't match the digest of the data passed to
+            :class:`~pulpcore.exceptions.DigestValidationError`: When any of the ``expected_digest``
+                values don't match the digest of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
         """
         if self.expected_digests:
@@ -176,8 +176,8 @@ class BaseDownloader:
         Validate the size if ``expected_size`` is set
 
         Raises:
-            :class:`~pulpcore.plugin.download.SizeValidationError`: When the
-                ``expected_size`` value doesn't match the size of the data passed to
+            :class:`~pulpcore.exceptions.SizeValidationError`: When the ``expected_size`` value
+                doesn't match the size of the data passed to
                 :meth:`~pulpcore.plugin.download.BaseDownloader.handle_data`.
         """
         if self.expected_size:

--- a/plugin/pulpcore/plugin/serializers.py
+++ b/plugin/pulpcore/plugin/serializers.py
@@ -1,5 +1,6 @@
 # Import Serializers in platform that are potentially useful to plugin writers
 from pulpcore.app.serializers import (  # noqa
+    ArtifactSerializer,
     AsyncOperationResponseSerializer,
     ContentGuardSerializer,
     ContentSerializer,

--- a/pulpcore/pulpcore/exceptions/__init__.py
+++ b/pulpcore/pulpcore/exceptions/__init__.py
@@ -1,2 +1,3 @@
 from .base import PulpException, exception_to_dict, ResourceImmutableError  # noqa
 from .http import MissingResource  # noqa
+from .validation import DigestValidationError, SizeValidationError, ValidationError  # noqa

--- a/pulpcore/pulpcore/exceptions/validation.py
+++ b/pulpcore/pulpcore/exceptions/validation.py
@@ -3,14 +3,14 @@ from gettext import gettext as _
 from pulpcore.exceptions import PulpException
 
 
-class DownloaderValidationError(PulpException):
+class ValidationError(PulpException):
     """
-    A base class for all Download Validation Errors.
+    A base class for all Validation Errors.
     """
     pass
 
 
-class DigestValidationError(DownloaderValidationError):
+class DigestValidationError(ValidationError):
     """
     Raised when a file fails to validate a digest checksum.
     """
@@ -22,7 +22,7 @@ class DigestValidationError(DownloaderValidationError):
         return _("A file failed validation due to checksum.")
 
 
-class SizeValidationError(DownloaderValidationError):
+class SizeValidationError(ValidationError):
     """
     Raised when a file fails to validate a size checksum.
     """


### PR DESCRIPTION
Adds the Artifact.create_and_validate staticmethod that creates an
in-memory, unsaved Artifact from a PulpTemporaryUploadedFile. Uploaded
files to Pulp show up with that type so that is convenient for plugin
writers. Also as the file is received by Django it auto-computes all of
the digest types.

This PR also moves SizeValidationError and DigestValidation error to
pulpcore.exceptions instead of living in pulpcore.plugin.downloads.

The ArtifactSerializer is also exposed via the plugin API with this
change also.

https://pulp.plan.io/issues/4072
closes #4072
