### PR TITLE
Add tests for Offline workers in status and worker APIs

### DIFF
--- a/pulpcore/tests/functional/api/test_workers.py
+++ b/pulpcore/tests/functional/api/test_workers.py
@@ -1,13 +1,14 @@
 # coding=utf-8
 """Tests related to the workers."""
+import time
 import unittest
 from datetime import datetime, timedelta
 from random import choice
 
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config
-from pulp_smash.pulp3.constants import WORKER_PATH
+from pulp_smash import api, cli, config
+from pulp_smash.pulp3.constants import STATUS_PATH, WORKER_PATH
 
 from tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 from tests.functional.utils import skip_if
@@ -105,3 +106,76 @@ class WorkersTestCase(unittest.TestCase):
         """
         with self.assertRaises(HTTPError):
             self.client.delete(self.worker['_href'])
+
+
+class OfflineWorkerTestCase(unittest.TestCase):
+    """Test actions over offline workers.
+
+    This test targets the following issues:
+
+    * `Pulp #2659 <https://pulp.plan.io/issues/2659>`_
+    * `Pulp Smash #877 <https://github.com/PulpQE/pulp-smash/issues/877>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create an API Client and a ServiceManager."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.svc_mgr = cli.ServiceManager(cls.cfg, cls.cfg.get_hosts('api')[0])
+        cls.worker = {}
+        if not cls.svc_mgr.is_active(['pulp_worker@*']):
+            raise unittest.SkipTest(
+                'These tests require pulp workers running on systemd'
+            )
+
+    def test_01_start_new_worker(self):
+        """Start a new worker to be used in next assertions."""
+        self.svc_mgr.start(['pulp_worker@99'])
+        time.sleep(2)
+        workers = self.client.get(
+            WORKER_PATH, params={'online': True}
+        )['results']
+        for worker in workers:
+            if 'worker_99' in worker['name']:
+                self.worker.update(worker)
+                break
+        self.assertNotEqual({}, self.worker)
+        self.assertIn('resource_worker_99', self.worker['name'])
+
+    @skip_if(bool, 'worker', False)
+    def test_02_stop_worker(self):
+        """Stop the worker and assert it is offline."""
+        self.svc_mgr.stop(['pulp_worker@99'])
+        time.sleep(2)
+        worker = self.client.get(self.worker['_href'])
+        self.assertEqual(worker['online'], False)
+
+    @skip_if(bool, 'worker', False)
+    def test_03_status_api_omits_offline_worker(self):
+        """Status API doesn't show offline workers."""
+        online_workers = self.client.get(STATUS_PATH)['online_workers']
+        self.assertNotIn(
+            self.worker['_href'],
+            [worker['_href'] for worker in online_workers]
+        )
+
+    @skip_if(bool, 'worker', False)
+    def test_03_read_all_workers(self):
+        """Worker API shows all workers including offline."""
+        workers = self.client.get(WORKER_PATH)['results']
+        self.assertIn(
+            self.worker['_href'],
+            [worker['_href'] for worker in workers]
+        )
+
+    @skip_if(bool, 'worker', False)
+    def test_03_filter_offline_worker(self):
+        """Worker API filter only offline workers."""
+        workers = self.client.get(
+            WORKER_PATH, params={'online': False}
+        )['results']
+        self.assertIn(
+            self.worker['_href'],
+            [worker['_href'] for worker in workers]
+        )


### PR DESCRIPTION
closes PulpQE/pulp-smash#877

> Pulp3 to not show offline workers in the status endpoint
> Filter offline workers in workers endpoint

Requires: https://github.com/PulpQE/pulp-smash/pull/1146

[noissue]