### PR TITLE
Fix user serializer for custom user model

### DIFF
--- a/pulpcore/pulpcore/app/management/commands/reset-admin-password.py
+++ b/pulpcore/pulpcore/app/management/commands/reset-admin-password.py
@@ -1,8 +1,11 @@
 from gettext import gettext as _
 from getpass import getpass
 
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand, CommandError
+
+
+User = get_user_model()
 
 
 class Command(BaseCommand):

--- a/pulpcore/pulpcore/app/serializers/user.py
+++ b/pulpcore/pulpcore/app/serializers/user.py
@@ -2,11 +2,14 @@ from gettext import gettext as _
 
 from django.core import validators
 from django.contrib.auth.hashers import make_password
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
 from pulpcore.app.serializers import IdentityField, ModelSerializer
+
+
+User = get_user_model()
 
 
 class PasswordSerializer(serializers.CharField):

--- a/pulpcore/pulpcore/app/viewsets/user.py
+++ b/pulpcore/pulpcore/app/viewsets/user.py
@@ -1,10 +1,13 @@
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from django_filters.rest_framework import filters
 from rest_framework import mixins
 
 from pulpcore.app.serializers import UserSerializer
 from pulpcore.app.viewsets import NamedModelViewSet, BaseFilterSet
 from pulpcore.app.viewsets.base import NAME_FILTER_OPTIONS
+
+
+User = get_user_model()
 
 
 class UserFilter(BaseFilterSet):


### PR DESCRIPTION
In case of custom user model used, PasswordSerializer fails
because it relies on builtin into Django user model.
This patch add dynamic user model resolving.

closes #4077
