### PR TITLE
Django requirement (<2.0.0) limit for python 2.7

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -7,6 +7,8 @@ PYTHON_MAJOR_MINOR = '%s.%s' % (sys.version_info[0], sys.version_info[1])
 # Django 1.8.0 requires Python >= 2.7
 if PYTHON_MAJOR_MINOR < '2.7':
     DJANGO_REQUIRES = 'django >=1.4.0, <1.8.0'
+elif PYTHON_MAJOR_MINOR < '3.0':
+    DJANGO_REQUIRES = 'django>=1.4.0, <2.0.0'
 else:
     DJANGO_REQUIRES = 'django>=1.4.0'
 


### PR DESCRIPTION
dev environment is failing on trying to install django 2.x which ends with 'not supported on python 2.7' error message. Limiting upper version leads to successful installation.