### PR TITLE
default redirect_host to None

### DIFF
--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -364,7 +364,7 @@
 #
 # redirect_host:
 #   The host FQDN or IP to which requests are redirected. Defaults to
-#   the local host's fully qualified domain name.
+#   the host specified in the original request.
 #
 # redirect_port:
 #   The TCP port to which requests are redirected. By default no port

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -133,7 +133,7 @@ _default_values = {
         'worker_timeout': '30',
     },
     'lazy': {
-        'redirect_host': socket.getfqdn(),
+        'redirect_host': '',
         'redirect_port': '',
         'redirect_path': '/streamer/',
         'https_retrieval': 'true',


### PR DESCRIPTION
this allows to use the host from the incoming request for the redirect

closes #4092
