### PR TITLE
Close HttpDownloader connections properly

### DIFF
--- a/docs/plugins/plugin-api/download.rst
+++ b/docs/plugins/plugin-api/download.rst
@@ -20,7 +20,7 @@ Basic Downloading
 
 The most basic downloading from a url can be done like this:
 
->>> downloader = HttpDownload('http://example.com/')
+>>> downloader = HttpDownloader('http://example.com/')
 >>> result = downloader.fetch()
 
 The example above downloads the data synchronously. The
@@ -37,8 +37,8 @@ Any downloader in the ``pulpcore.plugin.download`` package can be run in paralle
 that ``asyncio`` can schedule in parallel. Consider this example:
 
 >>> download_coroutines = [
->>>     HttpDownload('http://example.com/').run(),
->>>     HttpDownload('http://pulpproject.org/').run(),
+>>>     HttpDownloader('http://example.com/').run(),
+>>>     HttpDownloader('http://pulpproject.org/').run(),
 >>> ]
 >>>
 >>> loop = asyncio.get_event_loop()
@@ -86,7 +86,7 @@ supported urls.
     information.
 
 .. note::
-    All :class:`~pulpcore.plugin.download.HttpDownload` downloaders produced by the same
+    All :class:`~pulpcore.plugin.download.HttpDownloader` downloaders produced by the same
     remote instance share an `aiohttp` session, which provides a connection pool, connection
     reusage and keep-alives shared across all downloaders produced by a single remote.
 

--- a/plugin/pulpcore/plugin/download/http.py
+++ b/plugin/pulpcore/plugin/download/http.py
@@ -73,12 +73,12 @@ class HttpDownloader(BaseDownloader):
 
     Parallel Download:
         >>> download_coroutines = [
-        >>>     HttpDownload('http://example.com/').run(),
-        >>>     HttpDownload('http://pulpproject.org/').run(),
+        >>>     HttpDownloader('http://example.com/').run(),
+        >>>     HttpDownloader('http://pulpproject.org/').run(),
         >>> ]
         >>>
         >>> loop = asyncio.get_event_loop()
-        >>> done, not_done = loop.run_until_complete(asyncio.wait([download_coroutines]))
+        >>> done, not_done = loop.run_until_complete(asyncio.wait(download_coroutines))
         >>>
         >>> for task in done:
         >>>     try:
@@ -178,5 +178,5 @@ class HttpDownloader(BaseDownloader):
             to_return = await self._handle_response(response)
             await response.release()
         if self._close_session_on_finalize:
-            self.session.close()
+            await self.session.close()
         return to_return


### PR DESCRIPTION
The close() method is a coroutine so it needs to be awaited but it was
not. This was discovered during some testing of the HttpDownloader I was
doing outside of Pulp.

It also fixes some of the examples which used the wrong class name and
an await example that would have errored if run.

[noissue]
