### PR TITLE
Use force_close and concurrency restriction

### DIFF
--- a/plugin/pulpcore/plugin/download/file.py
+++ b/plugin/pulpcore/plugin/download/file.py
@@ -32,12 +32,12 @@ class FileDownloader(BaseDownloader):
         self._path = os.path.abspath(os.path.join(p.netloc, p.path))
         super().__init__(url, **kwargs)
 
-    async def run(self, extra_data=None):
+    async def _run(self, extra_data=None):
         """
         Read, validate, and compute digests on the `url`. This is a coroutine.
 
         This method provides the same return object type and documented in
-        :meth:`~pulpcore.plugin.download.BaseDownloader.run`.
+        :meth:`~pulpcore.plugin.download.BaseDownloader._run`.
 
         Args:
             extra_data (dict): Extra data passed to the downloader.

--- a/pulpcore/pulpcore/app/models/repository.py
+++ b/pulpcore/pulpcore/app/models/repository.py
@@ -104,7 +104,7 @@ class Remote(MasterModel):
     username = models.TextField(blank=True)
     password = models.TextField(blank=True)
     last_synced = models.DateTimeField(blank=True, null=True)
-    connection_limit = models.PositiveIntegerField(default=5)
+    connection_limit = models.PositiveIntegerField(default=20)
 
     class Meta:
         default_related_name = 'remotes'


### PR DESCRIPTION
Use force_close and concurrency restriction

The use of force_close was inspired by:

https://github.com/aio-libs/aiohttp/issues/2867#issuecomment-375278533

- Causes Factory and Downloaders to use force_close which causes the TCP
  connection to close with each request.
- Ups the default concurrency to 20
- Moves the concurrency restriction feature to the Downloaders and
  updates HttpDownloader and FileDownloader to use it.
- Stops using aiohttp for concurrency restriction because it's done in
  the downloaders.
- The Factory now configures the concurrency restriction using the value
  on the remote.
- creates a _run() method that subclassed Downloaders now need to
  implement instead of run().

https://pulp.plan.io/issues/4036
https://pulp.plan.io/issues/4075

closes #4036
closes #4075