### PR TITLE
Problem: DownloadResult is missing response headers

### DIFF
--- a/plugin/pulpcore/plugin/download/base.py
+++ b/plugin/pulpcore/plugin/download/base.py
@@ -12,7 +12,7 @@ from pulpcore.exceptions import DigestValidationError, SizeValidationError
 log = logging.getLogger(__name__)
 
 
-DownloadResult = namedtuple('DownloadResult', ['url', 'artifact_attributes', 'path'])
+DownloadResult = namedtuple('DownloadResult', ['url', 'artifact_attributes', 'path', 'headers'])
 """
 Args:
     url (str): The url corresponding with the download.
@@ -20,6 +20,8 @@ Args:
     artifact_attributes (dict): Contains keys corresponding with
         :class:`~pulpcore.plugin.models.Artifact` fields. This includes the computed digest values
         along with size information.
+    headers (dict): HTTP response headers. The keys are header names. The values are header
+        content.
 """
 
 

--- a/plugin/pulpcore/plugin/download/file.py
+++ b/plugin/pulpcore/plugin/download/file.py
@@ -50,4 +50,4 @@ class FileDownloader(BaseDownloader):
                     break  # the reading is done
                 self.handle_data(chunk)
             return DownloadResult(path=self._path, artifact_attributes=self.artifact_attributes,
-                                  url=self.url)
+                                  url=self.url, headers=None)

--- a/plugin/pulpcore/plugin/download/http.py
+++ b/plugin/pulpcore/plugin/download/http.py
@@ -156,7 +156,7 @@ class HttpDownloader(BaseDownloader):
                 break  # the download is done
             self.handle_data(chunk)
         return DownloadResult(path=self.path, artifact_attributes=self.artifact_attributes,
-                              url=self.url)
+                              url=self.url, headers=response.headers)
 
     @backoff.on_exception(backoff.expo, aiohttp.ClientResponseError, max_tries=10, giveup=giveup)
     async def run(self, extra_data=None):


### PR DESCRIPTION
Solution: Add response header to the DownloadResult

The HttpDownloader now adds the response headers to the DownloadResult.

closes #4061
https://pulp.plan.io/issues/4061