### PR TITLE
Fix SSL error and correct handling of Remote.ssl_validation.

### DIFF
--- a/plugin/pulpcore/plugin/download/factory.py
+++ b/plugin/pulpcore/plugin/download/factory.py
@@ -73,22 +73,22 @@ class DownloaderFactory:
             sslcontext = ssl.create_default_context(cafile=self._remote.ssl_ca_certificate.name)
             if self._remote.ssl_client_key.name and self._remote.ssl_client_certificate.name:
                 sslcontext.load_cert_chain(
-                    self._remote.ssl_client_key.name,
-                    self._remote.ssl_client_certificate.name
+                    self._remote.ssl_client_certificate.name,
+                    self._remote.ssl_client_key.name
                 )
         else:
             if self._remote.ssl_client_key.name and self._remote.ssl_client_certificate.name:
                 sslcontext = ssl.create_default_context()
                 sslcontext.load_cert_chain(
-                    self._remote.ssl_client_key.name,
-                    self._remote.ssl_client_certificate.name
+                    self._remote.ssl_client_certificate.name,
+                    self._remote.ssl_client_key.name
                 )
 
         if sslcontext:
             tcp_conn_opts['ssl_context'] = sslcontext
-
-        if self._remote.ssl_validation:
-            tcp_conn_opts['verify_ssl'] = self._remote.ssl_validation
+            if not self._remote.ssl_validation:
+                sslcontext.check_hostname = False
+                sslcontext.verify_mode = ssl.CERT_NONE
 
         if self._remote.connection_limit:
             tcp_conn_opts['limit'] = self._remote.connection_limit


### PR DESCRIPTION
https://pulp.plan.io/issues/4062

Corrected passing the certificate and key arguments when building the ssl_context.

The `Remote.ssl_validation` documentation indicates that it controls whether or not the sever (peer) certificate is verified by the downloader.  Discovered this was not implemented correctly in the factory during testing and corrected.