### PR TITLE
Add Pulp 3 container image built from PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,5 @@ jobs:
         - DB=postgres
         - TEST=docs
       if: type != pull_request
+    - stage: publish-container
+      script: bash .travis/deploy-container.sh $TRAVIS_TAG

--- a/.travis/deploy-container.sh
+++ b/.travis/deploy-container.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+
+echo "$QUAY_PASSWORD" | docker login -u "$QUAY_LOGIN" --password-stdin quay.io
+
+cd containers
+
+ansible-playbook build.yaml -e tag=$VERSION
+ansible-playbook push.yaml -e tag=$VERSION

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,23 @@
+# Pulp 3 Containers
+
+This directory contains assets and tooling for building Pulp 3 container images. The current image is an all-in-one image with different runtime scripts to assume each of the roles: pulp-core, pulp-worker and pulp-resource-manager.
+
+## Build
+
+The base image can be built with the help of an Ansible script. To build the base image:
+
+    ansible-playbook build.yaml
+
+The image can be customized to include any number of plugins as a build argument:
+
+    ansible-playbook build.yaml -e '{"plugins": ["pulp_file", "pulp_ansible"]}'
+
+## Push Image to Registry
+
+The built image can be pushed to a registry using an Ansible playbook. The default configuration will attempt to push the image to `quay.io/pulp`:
+
+    ansible-playbook push.yaml
+
+The image can be pushed to custom registry by specifying variables via the command line:
+
+    ansible-playbook push.yaml -e registry=docker.io -e project=myproject

--- a/containers/ansible.cfg
+++ b/containers/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+retry_files_enabled = False
+transport = local
+nocows = 1
+stdout_callback = yaml

--- a/containers/build.yaml
+++ b/containers/build.yaml
@@ -1,0 +1,26 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+    container_cli: 'docker'
+  vars_files:
+    - vars/defaults.yaml
+  tasks:
+    - name: 'Check for podman'
+      command: 'which podman'
+      register: podman_exists
+      ignore_errors: true
+
+    - set_fact:
+        container_cli: 'podman'
+      when: podman_exists | success
+
+    - name: 'Build images'
+      command: "{{ container_cli }} build --build-arg VERSION={{ tag }} --build-arg PLUGINS=\"{{ plugins | join(' ') }}\" -t {{ item }}:{{ tag }} ."
+      args:
+        chdir: "images/{{ item }}"
+      with_items: "{{ images }}"
+
+    - name: 'Tag images'
+      command: "{{ container_cli }} tag {{ item }}:{{ tag }} {{ registry }}/{{ project }}/{{ item }}:{{ tag }}"
+      with_items: "{{ images }}"

--- a/containers/images/pulp-core/Dockerfile
+++ b/containers/images/pulp-core/Dockerfile
@@ -1,0 +1,36 @@
+FROM centos:7
+
+ARG PLUGINS=""
+
+RUN echo "tsflags=nodocs" >> /etc/yum.conf && \
+		yum -y install epel-release centos-release-scl && \
+		yum -y install wget git rh-python36-python-pip && \
+		yum clean all
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV PYTHONUNBUFFERED=0
+ENV DJANGO_SETTINGS_MODULE=pulpcore.app.settings
+
+RUN mkdir -p /etc/pulp
+
+RUN scl enable rh-python36 'pip install gunicorn'
+RUN scl enable rh-python36 'pip install pulpcore'
+RUN scl enable rh-python36 'pip install $PLUGINS'
+
+COPY container-assets/settings.py /etc/pulp/settings.py
+RUN echo "SECRET_KEY = '`cat /dev/urandom | tr -dc 'a-z0-9!@#$%^&*(\-_=+)' | head -c 50`'" >> /etc/pulp/settings.py
+
+RUN scl enable rh-python36 "pulp-manager makemigrations pulp_app"
+RUN scl enable rh-python36 "pulp-manager makemigrations $PLUGINS"
+RUN scl enable rh-python36 "pulp-manager collectstatic --noinput"
+
+COPY container-assets/wait_on_postgres.py /usr/bin/wait_on_postgres.py
+COPY container-assets/wait_on_database_migrations.sh /usr/bin/wait_on_database_migrations.sh
+COPY container-assets/migrate_pulp.sh /usr/bin/migrate_pulp.sh
+COPY container-assets/pulp-core /usr/bin/pulp-core
+
+RUN echo "scl enable rh-python36 \"pulp-manager migrate --noinput $PLUGINS\"" >> /usr/bin/migrate_pulp.sh
+
+CMD ["/usr/bin/pulp-core"]

--- a/containers/images/pulp-core/container-assets/migrate_pulp.sh
+++ b/containers/images/pulp-core/container-assets/migrate_pulp.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+scl enable rh-python36 "pulp-manager migrate --noinput auth"
+scl enable rh-python36 "pulp-manager migrate --noinput"
+scl enable rh-python36 "pulp-manager reset-admin-password --password admin"

--- a/containers/images/pulp-core/container-assets/pulp-core
+++ b/containers/images/pulp-core/container-assets/pulp-core
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/usr/bin/wait_on_postgres.py
+/usr/bin/migrate_pulp.sh
+
+exec scl enable rh-python36 "gunicorn -b 0.0.0.0:8000 pulpcore.app.wsgi:application"

--- a/containers/images/pulp-core/container-assets/settings.py
+++ b/containers/images/pulp-core/container-assets/settings.py
@@ -1,0 +1,11 @@
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.dummy',
+        'NAME': 'pulp',
+        'USER': 'pulp',
+        'CONN_MAX_AGE': 0,
+    },
+}
+
+STATIC_ROOT = '/var/lib/pulp/static'

--- a/containers/images/pulp-core/container-assets/wait_on_database_migrations.sh
+++ b/containers/images/pulp-core/container-assets/wait_on_database_migrations.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+database_migrated=false
+
+echo "Checking for database migrations"
+while [ $database_migrated = false ]; do
+  scl enable rh-python36 "pulp-manager showmigrations | grep '\[ \]'"
+  if [ $? -gt 0 ]; then
+    echo "Database migrated!"
+    database_migrated=true
+  else
+    sleep 5
+  fi
+done
+
+if [ $database_migrated = false ]; then
+  echo "Database not migrated in time, exiting"
+  exit 1
+else
+  exit 0
+fi

--- a/containers/images/pulp-core/container-assets/wait_on_postgres.py
+++ b/containers/images/pulp-core/container-assets/wait_on_postgres.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+
+import sys
+import socket
+import time
+import os
+
+if __name__ == '__main__':
+
+    postgres_is_alive = False
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    tries = 0
+    print ("Waiting on postgresql to start...")
+    while not postgres_is_alive and tries < 100:
+        tries += 1
+        try:
+            print("Checking postgres host %s" % os.environ['POSTGRES_SERVICE_HOST'])
+            s.connect((os.environ['POSTGRES_SERVICE_HOST'], 5432))
+        except socket.error:
+            time.sleep(3)
+        else:
+            postgres_is_alive = True
+
+    if postgres_is_alive:
+        print ("Postgres started!")
+        sys.exit(0)
+    else:
+        print ("Unable to reach postgres on port 5432")
+        sys.exit(1)

--- a/containers/images/pulp-resource-manager/Dockerfile
+++ b/containers/images/pulp-resource-manager/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/pulp/pulp-core:latest
+
+COPY container-assets/pulp-resource-manager /usr/bin/pulp-resource-manager
+
+CMD ["/usr/bin/pulp-resource-manager"]

--- a/containers/images/pulp-resource-manager/container-assets/pulp-resource-manager
+++ b/containers/images/pulp-resource-manager/container-assets/pulp-resource-manager
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/usr/bin/wait_on_postgres.py
+/usr/bin/wait_on_database_migrations.sh
+
+exec scl enable rh-python36 "rq worker --url 'redis://$REDIS_SERVICE_HOST:$REDIS_SERVICE_PORT' -n resource_manager@%h -w 'pulpcore.tasking.worker.PulpWorker'"

--- a/containers/images/pulp-worker/Dockerfile
+++ b/containers/images/pulp-worker/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/pulp/pulp-core:latest
+
+COPY container-assets/pulp-worker /usr/bin/pulp-worker
+
+CMD ["/usr/bin/pulp-worker"]

--- a/containers/images/pulp-worker/container-assets/pulp-worker
+++ b/containers/images/pulp-worker/container-assets/pulp-worker
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/usr/bin/wait_on_postgres.py
+/usr/bin/wait_on_database_migrations.sh
+
+exec scl enable rh-python36 "rq worker --url 'redis://${REDIS_SERVICE_HOST}:${REDIS_SERVICE_PORT}' -n reserved_resource_worker_${PULP_WORKER_NUMBER}@${HOSTNAME} -w 'pulpcore.tasking.worker.PulpWorker'"

--- a/containers/push.yaml
+++ b/containers/push.yaml
@@ -1,0 +1,23 @@
+---
+- hosts: localhost
+  vars:
+    container_cli: 'docker'
+  vars_files:
+    - vars/defaults.yaml
+  tasks:
+    - name: 'Check for podman'
+      command: 'which podman'
+      register: podman_exists
+      ignore_errors: true
+
+    - set_fact:
+        container_cli: 'podman'
+      when: podman_exists | success
+
+    - name: 'Tag images'
+      command: "{{ container_cli }} tag {{ item }}:{{ tag }} {{ registry }}/{{ project }}/{{ item }}:{{ tag }}"
+      with_items: "{{ images }}"
+
+    - name: 'Push images'
+      command: "{{ container_cli }} push {{ registry }}/{{ project }}/{{ item }}:{{ tag }}"
+      with_items: "{{ images }}"

--- a/containers/vars/defaults.yaml
+++ b/containers/vars/defaults.yaml
@@ -1,0 +1,9 @@
+---
+images:
+  - pulp-core
+  - pulp-worker
+  - pulp-resource-manager
+registry: quay.io
+project: pulp
+tag: latest
+plugins: []


### PR DESCRIPTION
In our discussions, the idea was for this to live in the Pulp main repository and to at least start off as an all-in-one image. There is related work to add running via the containers to the Ansible installer (https://github.com/pulp/ansible-pulp3/pull/45). There are still some gaps to address here in terms of process:

 1) How to CI the image build itself
 2) How to auto-build the image with PyPi released assets
 3) Creation of the registry project the image will live on
 4) Testing the resulting image in a deployment / Pulp smash scenario

I'm sure there are some other elements to address but this gets us started.

This was inspired by my POC project [carafe](https://github.com/ehelms/carafe).
