### PR TITLE
Fixing missing hostname for deferred downloads

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -3,6 +3,7 @@ from itertools import chain
 import copy
 import logging
 import os
+import socket
 import sys
 import time
 from urlparse import urlunsplit
@@ -1531,7 +1532,7 @@ def _get_streamer_url(catalog_entry, signing_key):
         raise PulpCodedTaskException(error_codes.PLP1014, section='lazy', key='https_retrieval',
                                      reason=_('The value is not boolean'))
     retrieval_scheme = 'https' if https_retrieval else 'http'
-    host = pulp_conf.get('lazy', 'redirect_host')
+    host = (pulp_conf.get('lazy', 'redirect_host') or socket.getfqdn())
     port = pulp_conf.get('lazy', 'redirect_port')
     path_prefix = pulp_conf.get('lazy', 'redirect_path')
     netloc = (host + ':' + port) if port else host


### PR DESCRIPTION
A change was made in #4092 to allow users to use the server request
hostname as the redirect_host for on-demand repos by leaving host in the
lazy config as blank. However, the defered_download code doesn't have a
server request and therefore should default to socket.getfqdn() if
redirect_host is unset.

fixes #4120
https://pulp.plan.io/issues/4120