### PR TITLE
Ansible installer link to docs

### DIFF
--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -21,6 +21,12 @@ Fedora, CentOS, and Mac OSX.
 
     $ sudo setenforce 0
 
+Ansible Installation
+--------------------
+
+To use ansible roles to install Pulp 3 instead of manual setup refer to
+`Pulp 3 Ansible installer <https://github.com/pulp/ansible-pulp3/>`_.
+
 PyPI Installation
 -----------------
 


### PR DESCRIPTION
Added ansible installer link to
pulp 3 docs.

closes #4098

https://pulp.plan.io/issues/4098

Signed-off-by: Pavel Picka <ppicka@redhat.com>
