### PR TITLE
Add http_giveup to Plugin API

### DIFF
--- a/plugin/pulpcore/plugin/download/__init__.py
+++ b/plugin/pulpcore/plugin/download/__init__.py
@@ -1,4 +1,4 @@
 from .base import BaseDownloader, DownloadResult  # noqa
 from .factory import DownloaderFactory  # noqa
 from .file import FileDownloader  # noqa
-from .http import HttpDownloader  # noqa
+from .http import http_giveup, HttpDownloader  # noqa


### PR DESCRIPTION
This is necessary for plugins that define their own Downloader.

[noissue]