### PR TITLE
Temporarily limit redis version

### DIFF
--- a/pulpcore/setup.py
+++ b/pulpcore/setup.py
@@ -13,6 +13,7 @@ requirements = [
     'drf-yasg',
     'psycopg2-binary',
     'PyYAML',
+    'redis >= 2.7.0, <3.0',
     'rq>=0.12.0',
     'setuptools',
     'dynaconf>=1.0.4'


### PR DESCRIPTION
This is due to a new redis version being available and RQ not being
compatible with it. RQ has not yet released a fix so Travis is broken.

Once https://github.com/rq/rq/pull/1015/files is merged we can stop
carrying this.

[noissue]
