### PR TITLE
Pass extra_data as kwarg

### DIFF
--- a/plugin/pulpcore/plugin/download/base.py
+++ b/plugin/pulpcore/plugin/download/base.py
@@ -209,7 +209,7 @@ class BaseDownloader:
 
         """
         async with self.semaphore:
-            return await self._run(extra_data)
+            return await self._run(extra_data=extra_data)
 
     async def _run(self, extra_data=None):
         """


### PR DESCRIPTION
This is necessary if the overrides of this function have other kwargs
that need to be passed.

[noissue]