### PR TITLE
Removing gen_file_publisher

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_auto_distribution.py
@@ -11,6 +11,7 @@ from pulp_smash.pulp3.constants import DISTRIBUTION_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
     delete_orphans,
     gen_distribution,
+    gen_publisher,
     gen_remote,
     gen_repo,
     get_added_content,
@@ -26,10 +27,7 @@ from tests.functional.api.using_plugin.constants import (
     FILE_PUBLISHER_PATH,
     FILE_REMOTE_PATH
 )
-from tests.functional.api.using_plugin.utils import (
-    gen_file_publisher,
-    populate_pulp,
-)
+from tests.functional.api.using_plugin.utils import populate_pulp
 from tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
 
 
@@ -85,7 +83,7 @@ class AutoDistributionTestCase(unittest.TestCase):
         repo = self.client.get(repo['_href'])
 
         # Create publisher.
-        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
+        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_publisher())
         self.addCleanup(self.client.delete, publisher['_href'])
 
         # Create a distribution
@@ -155,7 +153,7 @@ class SetupAutoDistributionTestCase(unittest.TestCase):
         # Create a repository and a publisher.
         repo = self.client.post(REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo['_href'])
-        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
+        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_publisher())
         self.addCleanup(self.client.delete, publisher['_href'])
 
         # Create a distribution.

--- a/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
@@ -13,6 +13,7 @@ from pulp_smash.pulp3.constants import (
 )
 from pulp_smash.pulp3.utils import (
     gen_distribution,
+    gen_publisher,
     gen_repo,
     publish,
     sync
@@ -23,7 +24,6 @@ from tests.functional.api.using_plugin.constants import (
     FILE_REMOTE_PATH
 )
 from tests.functional.api.using_plugin.utils import (
-    gen_file_publisher,
     gen_file_remote,
     skip_if
 )
@@ -47,7 +47,7 @@ class PublicationsTestCase(unittest.TestCase):
             body = gen_file_remote()
             cls.remote.update(cls.client.post(FILE_REMOTE_PATH, body))
             cls.publisher.update(
-                cls.client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
+                cls.client.post(FILE_PUBLISHER_PATH, gen_publisher())
             )
             sync(cls.cfg, cls.remote, cls.repo)
         except Exception:
@@ -175,7 +175,7 @@ class PublicationsTestCase(unittest.TestCase):
         Assert response returns an error 400 including ["Unexpected field"].
         """
         response = api.Client(self.cfg, api.echo_handler).post(
-            FILE_PUBLISHER_PATH, gen_file_publisher(foo='bar')
+            FILE_PUBLISHER_PATH, gen_publisher(foo='bar')
         )
         assert response.status_code == 400
         assert response.json()['foo'] == ['Unexpected field']

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -12,6 +12,7 @@ from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
     delete_orphans,
     delete_version,
+    gen_publisher,
     gen_repo,
     get_added_content,
     get_artifact_paths,
@@ -31,7 +32,6 @@ from tests.functional.api.using_plugin.constants import (
     FILE_REMOTE_PATH,
 )
 from tests.functional.api.using_plugin.utils import (
-    gen_file_publisher,
     gen_file_remote,
     populate_pulp,
     skip_if,
@@ -325,7 +325,7 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase):
         Delete a repository version, and verify the associated publication is
         also deleted.
         """
-        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
+        publisher = self.client.post(FILE_PUBLISHER_PATH, gen_publisher())
         self.addCleanup(self.client.delete, publisher['_href'])
 
         publication = publish(self.cfg, publisher, self.repo)

--- a/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
@@ -6,6 +6,7 @@ import unittest
 from pulp_smash import api, config
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
+    gen_publisher,
     gen_repo,
     get_content,
     publish,
@@ -16,7 +17,7 @@ from tests.functional.api.using_plugin.constants import (
     FILE_REMOTE_PATH,
     FILE_PUBLISHER_PATH
 )
-from tests.functional.api.using_plugin.utils import gen_file_publisher, gen_file_remote
+from tests.functional.api.using_plugin.utils import gen_file_remote
 from tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
 
 
@@ -51,7 +52,7 @@ class RemotesPublishersTestCase(unittest.TestCase):
         remote = client.post(FILE_REMOTE_PATH, body)
         self.addCleanup(client.delete, remote['_href'])
 
-        publisher = client.post(FILE_PUBLISHER_PATH, gen_file_publisher())
+        publisher = client.post(FILE_PUBLISHER_PATH, gen_publisher())
         self.addCleanup(client.delete, publisher['_href'])
 
         # Create and sync repos.

--- a/pulpcore/tests/functional/api/using_plugin/utils.py
+++ b/pulpcore/tests/functional/api/using_plugin/utils.py
@@ -6,7 +6,6 @@ from unittest import SkipTest
 from pulp_smash import api, selectors
 from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
-    gen_publisher,
     gen_repo,
     gen_remote,
     require_pulp_3,
@@ -70,16 +69,3 @@ def gen_file_remote(url=None, **kwargs):
         url = FILE_FIXTURE_MANIFEST_URL
 
     return gen_remote(url, **kwargs)
-
-
-def gen_file_publisher(**kwargs):
-    """Return a semi-random dict for use in creating a file Remote.
-
-    :param url: The URL of an external content source.
-    """
-    publisher = gen_publisher()
-    file_extra_fields = {
-        **kwargs
-    }
-    publisher.update(file_extra_fields)
-    return publisher


### PR DESCRIPTION
The function `gen_file_publisher` is useless so removing it in favor of `gen_publisher` which does the same.

[noissue]