### PR TITLE
Add priority to DeclarativeContent

### DIFF
--- a/plugin/pulpcore/plugin/stages/api.py
+++ b/plugin/pulpcore/plugin/stages/api.py
@@ -68,10 +68,16 @@ class Stage:
 
         while not shutdown:
             content = await in_q.get()
+            if getattr(content, 'priority', False):
+                yield [content]
+                continue
             shutdown = add_to_batch(batch, content)
             while not shutdown:
                 try:
                     content = in_q.get_nowait()
+                    if getattr(content, 'priority', False):
+                        yield [content]
+                        continue
                 except asyncio.QueueEmpty:
                     break
                 else:

--- a/plugin/pulpcore/plugin/stages/models.py
+++ b/plugin/pulpcore/plugin/stages/models.py
@@ -66,11 +66,12 @@ class DeclarativeContent:
         ValueError: If `content` is not specified.
     """
 
-    __slots__ = ('content', 'd_artifacts', 'extra_data')
+    __slots__ = ('content', 'd_artifacts', 'extra_data', 'priority')
 
-    def __init__(self, content=None, d_artifacts=None, extra_data=None):
+    def __init__(self, content=None, d_artifacts=None, extra_data=None, priority=False):
         if not content:
             raise ValueError(_("DeclarativeContent must have a 'content'"))
         self.content = content
         self.d_artifacts = d_artifacts or []
         self.extra_data = extra_data or {}
+        self.priority = priority


### PR DESCRIPTION
This allows DeclarativeContent objects to bypass the batching process.

[noissue]