### PR TITLE
Problem: duplicate content can't by synced

### DIFF
--- a/plugin/pulpcore/plugin/stages/content_unit_stages.py
+++ b/plugin/pulpcore/plugin/stages/content_unit_stages.py
@@ -113,7 +113,8 @@ class ContentUnitSaver(Stage):
                 for declarative_content in batch:
                     if declarative_content.content.pk is None:
                             try:
-                                declarative_content.content.save()
+                                with transaction.atomic():
+                                    declarative_content.content.save()
                             except IntegrityError:
                                 declarative_content.content = \
                                     declarative_content.content.__class__.objects.get(

--- a/pulpcore/pulpcore/app/models/content.py
+++ b/pulpcore/pulpcore/app/models/content.py
@@ -58,8 +58,11 @@ class QueryMixin():
         """
         Returns a Q object that represents the model
         """
-        all_kwargs = model_to_dict(self)
-        kwargs = {k: v for k, v in all_kwargs.items() if v}
+        try:
+            kwargs = self.natural_key_dict()
+        except AttributeError:
+            all_kwargs = model_to_dict(self)
+            kwargs = {k: v for k, v in all_kwargs.items() if v}
         return models.Q(**kwargs)
 
 


### PR DESCRIPTION
Solution: fix the content unit saver stage

This patch addresses 2 problems:
    
1) Error because an exception was being caught during a transaction

2) The q() method did not provide the correct query for Content objects
    
closes #4170
https://pulp.plan.io/issues/4170
