### PR TITLE
Docs: Remove Semicolon From Secret Example

### DIFF
--- a/docs/installation/configuration.rst
+++ b/docs/installation/configuration.rst
@@ -30,7 +30,7 @@ SECRET_KEY
 .. code-block:: python
    :linenos:
 
-   import random;
+   import random
 
    chars = 'abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)'
    print(''.join(random.choice(chars) for i in range(50)))


### PR DESCRIPTION
I don't believe python will complain about this but it doesn't look right. I tried searching different python standards and couldn't find anything about semicolons. So I am taking it out.

[noissue]