### PR TITLE
Prevent failing bulk_create to consume objects from generator

### DIFF
--- a/pulpcore/pulpcore/app/models/content.py
+++ b/pulpcore/pulpcore/app/models/content.py
@@ -37,10 +37,10 @@ class BulkCreateManager(models.Manager):
         Returns:
             List of instances that were inserted into the database.
         """
+        objs = list(objs)
         try:
             return super().bulk_create(objs, batch_size=batch_size)
         except IntegrityError:
-            objs = list(objs)
             for i in range(len(objs)):
                 try:
                     objs[i].save()

--- a/pulpcore/pulpcore/app/models/content.py
+++ b/pulpcore/pulpcore/app/models/content.py
@@ -58,6 +58,8 @@ class QueryMixin():
         """
         Returns a Q object that represents the model
         """
+        if self.pk:
+            return models.Q(pk=self.pk)
         try:
             kwargs = self.natural_key_dict()
         except AttributeError:
@@ -66,7 +68,7 @@ class QueryMixin():
         return models.Q(**kwargs)
 
 
-class Artifact(Model, QueryMixin):
+class Artifact(Model):
     """
     A file associated with a piece of content.
 
@@ -122,6 +124,15 @@ class Artifact(Model, QueryMixin):
 
     # Reliable digest fields ordered by algorithm strength.
     RELIABLE_DIGEST_FIELDS = DIGEST_FIELDS[:-3]
+
+    def q(self):
+        if self.pk:
+            return models.Q(pk=self.pk)
+        for digest_name in self.DIGEST_FIELDS:
+            digest_value = getattr(self, digest_name)
+            if digest_value:
+                return models.Q(**{digest_name: digest_value})
+        return models.Q()
 
     def is_equal(self, other):
         """


### PR DESCRIPTION
A failed bulk_create might have already iterated into the generator for
desired objects. This can be prevented by casting into a list first.

[noissue]