### PR TITLE
Don't fail migration in case there is no exception code

### DIFF
--- a/server/pulp/server/db/migrations/0029_applicability_schema_change.py
+++ b/server/pulp/server/db/migrations/0029_applicability_schema_change.py
@@ -51,7 +51,7 @@ def migrate(*args, **kwargs):
     try:
         rpa_collection.drop_index("profile_hash_-1_repo_id_-1")
     except pymongo.errors.OperationFailure as e:
-        if e.code == 27:
+        if not e.code or e.code == 27:
             # index not found - good, it's been removed before
             pass
         else:


### PR DESCRIPTION
Not all MongoDB versions report a specific code when index is not found.

closes #4225
https://pulp.plan.io/issues/4225