### PR TITLE
Unpin the redis requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
     'drf-yasg',
     'psycopg2-binary',
     'PyYAML',
-    'redis >= 2.7.0, <3.0',
+    'redis',
     'rq>=0.12.0',
     'setuptools',
     'dynaconf>=1.0.4'


### PR DESCRIPTION
We're requiring rq >= 0.12 and redis < 3.0 but the new release of rq (0.13.0) requires redis >= 3.0 so our package requirements raise a conflict. I suggest we unpin the redis requirement and let pip install the right version of redis based on what rq needs.