### PR TITLE
Adds importing of the 'content' module

### DIFF
--- a/pulpcore/content/__init__.py
+++ b/pulpcore/content/__init__.py
@@ -1,14 +1,24 @@
-from aiohttp import web
+from contextlib import suppress
+from importlib import import_module
 
+from aiohttp import web
 from django.conf import settings
+from pulpcore.app.apps import pulp_plugin_configs
 
 from .handler import Handler
 
 
-handler = Handler()
+app = web.Application()
+
+CONTENT_MODULE_NAME = 'content'
 
 
 async def server(*args, **kwargs):
-    app = web.Application()
-    app.add_routes([web.get(settings.CONTENT_PATH_PREFIX + '{path:.+}', handler.stream_content)])
+    for pulp_plugin in pulp_plugin_configs():
+        if pulp_plugin.name != "pulpcore.app":
+            content_module_name = '{name}.{module}'.format(name=pulp_plugin.name,
+                                                           module=CONTENT_MODULE_NAME)
+            with suppress(ModuleNotFoundError):
+                import_module(content_module_name)
+    app.add_routes([web.get(settings.CONTENT_PATH_PREFIX + '{path:.+}', Handler().stream_content)])
     return app


### PR DESCRIPTION
The 'content' module needs to be auto-imported when the content app
starts so that loading is added to its startup sequence with this PR.
Importing is all we have to do and aiohttp's registration mechanisms
take over.

https://pulp.plan.io/issues/4273
re #4273