### PR TITLE
Rename connection_limit to download_concurrency

### DIFF
--- a/pulpcore/app/models/repository.py
+++ b/pulpcore/app/models/repository.py
@@ -66,7 +66,8 @@ class Remote(MasterModel):
             Format: scheme://user:password@host:port
         username (models.TextField): The username to be used for authentication when syncing.
         password (models.TextField): The password to be used for authentication when syncing.
-        connection_limit (models.PositiveIntegerField): Total number of simultaneous connections.
+        download_concurrency (models.PositiveIntegerField): Total number of
+            simultaneous connections.
         policy (models.TextField): The policy to use when downloading content.
 
     Relations:
@@ -113,7 +114,7 @@ class Remote(MasterModel):
     proxy_url = models.TextField()
     username = models.TextField()
     password = models.TextField()
-    connection_limit = models.PositiveIntegerField(default=20)
+    download_concurrency = models.PositiveIntegerField(default=20)
     policy = models.TextField(choices=POLICY_CHOICES, default=IMMEDIATE)
 
     class Meta:

--- a/pulpcore/app/serializers/repository.py
+++ b/pulpcore/app/serializers/repository.py
@@ -109,7 +109,7 @@ class RemoteSerializer(MasterModelSerializer):
         help_text='Timestamp of the most recent update of the remote.',
         read_only=True
     )
-    connection_limit = serializers.IntegerField(
+    download_concurrency = serializers.IntegerField(
         help_text='Total number of simultaneous connections.',
         required=False,
         min_value=1
@@ -127,7 +127,7 @@ class RemoteSerializer(MasterModelSerializer):
         fields = MasterModelSerializer.Meta.fields + (
             'name', 'url', 'validate', 'ssl_ca_certificate', 'ssl_client_certificate',
             'ssl_client_key', 'ssl_validation', 'proxy_url', 'username', 'password', 'last_updated',
-            'connection_limit', 'policy')
+            'download_concurrency', 'policy')
 
 
 class RepositorySyncURLSerializer(serializers.Serializer):


### PR DESCRIPTION
Rename the 'connection_limit' to 'download_concurrency'
throughout the codebase and comments in the codebase to
variable name to be more understandable.

re: #4114
https://pulp.plan.io/issues/4114

Signed-off-by: Pavel Picka <ppicka@redhat.com>