### PR TITLE
Improve Artifact generation and saving for content app

### DIFF
--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from pulpcore.content import Handler
+from pulpcore.plugin.models import Artifact, ContentArtifact
+
+from pulp_file.app.models import FileContent
+
+
+class HandlerSaveContentTestCase(TestCase):
+
+    def setUp(self):
+        self.f1 = FileContent.objects.create(relative_path='f1', digest='1')
+        self.f1.artifact = None
+        self.f2 = FileContent.objects.create(relative_path='f2', digest='1')
+        self.f2.artifact = None
+
+    def download_result_mock(self, path):
+        dr = Mock()
+        dr.artifact_attributes = {'size': 0}
+        for digest_type in Artifact.DIGEST_FIELDS:
+            dr.artifact_attributes[digest_type] = '1'
+        dr.path = SimpleUploadedFile(name=path, content='')
+        return dr
+
+    def test_save_content_artifact(self):
+        """Artifact needs to be created."""
+        cch = Handler()
+        new_artifact = cch._save_content_artifact(self.download_result_mock('f1'),
+                                                  ContentArtifact.objects.get(pk=self.f1.pk))
+        f1 = FileContent.objects.get(pk=self.f1.pk)
+        self.assertIsNotNone(new_artifact)
+        self.assertEqual(f1._artifacts.get().pk, new_artifact.pk)
+
+    def test_save_content_artifact_artifact_already_exists(self):
+        """Artifact turns out to already exist."""
+        cch = Handler()
+        new_artifact = cch._save_content_artifact(self.download_result_mock('f1'),
+                                                  ContentArtifact.objects.get(pk=self.f1.pk))
+
+        existing_artifact = cch._save_content_artifact(self.download_result_mock('f2'),
+                                                       ContentArtifact.objects.get(pk=self.f2.pk))
+        f2 = FileContent.objects.get(pk=self.f2.pk)
+        self.assertEqual(existing_artifact.pk, new_artifact.pk)
+        self.assertEqual(f2._artifacts.get().pk, existing_artifact.pk)


### PR DESCRIPTION
- Refactor Artifact generation for "on_demand" policy into method of its own.
  This allows derived plugin content handlers to customize the saving part.

- Don't fail if the Artifact already exists.  This may happen if multiple
  content instances share the same artifact or if the content type does not
  have enough metadata to ensure uniqueness without downloading the actual
  artifact (i.e. no digest in metadata).

fixes #4293
https://pulp.plan.io/issues/4293
