### PR TITLE
Do not search for dupes by pk

### DIFF
--- a/pulpcore/app/models/content.py
+++ b/pulpcore/app/models/content.py
@@ -58,8 +58,6 @@ class QueryMixin():
         """
         Returns a Q object that represents the model
         """
-        if self.pk:
-            return models.Q(pk=self.pk)
         try:
             kwargs = self.natural_key_dict()
         except AttributeError:


### PR DESCRIPTION
The ContentUnitSaver stage uses content.q() to retrieve the query for a
duplicate content unit. However, there are cases where the pk of the
content is set even when the save fails with an IntegrityError. This
means that content.q() will always search for content that does not
exist. Instead, we should always query by the natural key.

[noissue]

NOTE:
I'm not confident in the testing because because solves a problem that only happens in a WIP Docker PR. After making this change there were other problems in that PR (ContentArtifacts were not created during sync). Hopefully this PR will be helpful for https://github.com/pulp/pulp_docker/pull/294, and when finished @ipanova can confirm that this works.