### PR TITLE
Add diagrams to Concepts and Terminology

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,7 +46,7 @@ clean:
 
 diagrams:
 	mkdir -p $(DIAGRAM_BUILD_DIR)
-	plantuml diagrams_src/*.dot
+	python -m plantuml diagrams_src/*.dot
 	mv diagrams_src/*.png $(DIAGRAM_BUILD_DIR)/
 
 html:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -15,13 +15,24 @@ deb) is defined by a plugin.  Files that belong to a content unit are called
 :term:`artifacts<artifact>`. Each content unit can have 0 or many artifacts and artifacts can be
 shared by multiple content units.
 
+.. image:: ./_diagrams/concept-content.png
+    :align: center
+
 Content units in Pulp are organized by their membership in :term:`repositories<repository>` over
 time. Plugin users can add or remove content units to a repository. Each time the content set of a
 repository is changed, a new :term:`repository version<RepositoryVersion>` is created.
 
+.. image:: ./_diagrams/concept-repository.png
+    :align: center
+.. image:: ./_diagrams/concept-add-repo.png
+    :align: center
+
 Users can inform Pulp about external sources of content units, called :term:`remotes<remote>`.
 Plugins can define actions to interact with those sources. For example, most or all plugins define
 :term:`sync` to fetch content units from a remote and add them to a repository.
+
+.. image:: ./_diagrams/concept-remote.png
+    :align: center
 
 All content that is managed by Pulp can be hosted by the :term:`content app`. Users create
 type-specific :term:`publishers<publisher>` that provide the settings necessary to generate
@@ -29,3 +40,6 @@ a :term:`publication` for a content set in a repository version. A publication c
 metadata of the content set and the artifacts of each content unit in the content set. To host a
 publication, it must be assigned to a :term:`distribution`, which determines how and where a
 publication is served.
+
+.. image:: ./_diagrams/concept-publish.png
+    :align: center

--- a/docs/diagrams_src/concept-add-repo.dot
+++ b/docs/diagrams_src/concept-add-repo.dot
@@ -1,0 +1,21 @@
+@startuml
+rectangle "Add content to repository" {
+  (New Content Unit)
+  rectangle Repository {
+    usecase RV1 as "Repository Version 1
+    ---
+    contains:
+    Content Unit"
+    usecase RV2 as "Repository Version 2
+    ---
+    contains:
+    Content Unit
+    New Content Unit"
+    note "Adding new content to repository" as N
+  }
+
+  (New Content Unit) ..|> N
+  (RV1) -right-> N
+  N -right-> (RV2)
+}
+@enduml

--- a/docs/diagrams_src/concept-content.dot
+++ b/docs/diagrams_src/concept-content.dot
@@ -1,0 +1,21 @@
+@startuml
+rectangle Files {
+  (foo.rpm)
+  usecase Playbook as "Ansible Playbook
+  ---
+  contains:
+  vars/
+  templates/
+  files/
+  README"
+}
+
+rectangle "Content Unit RPM" {
+  (foo.rpm) --> (Artifact)
+}
+
+rectangle "Content Unit Ansible" {
+  (Artifact) as Artifact1
+  (Playbook) --> (Artifact1)
+}
+@enduml

--- a/docs/diagrams_src/concept-publish.dot
+++ b/docs/diagrams_src/concept-publish.dot
@@ -1,0 +1,9 @@
+@startuml
+(Repository Version) -right-> (Publisher)
+(Publisher) --> (Publication) : Publisher adds required metada\n due to content type
+(Publication) --> (Distribution)
+
+note left of Distribution
+  How and where to publish
+end note
+@enduml

--- a/docs/diagrams_src/concept-remote.dot
+++ b/docs/diagrams_src/concept-remote.dot
@@ -1,0 +1,27 @@
+@startuml
+rectangle "External sources" {
+
+  rectangle "Repository" {
+    usecase RV2 as "Repository Version 2
+    ---
+    contains:
+    Content Unit 1
+    Content Unit 2"
+    usecase RV3 as "Repository Version 3
+    ---
+    contains:
+    Content Unit 1
+    Content Unit 2
+    Content Units Remote"
+    note "Adding new content units\nfrom remote source" as N
+    RV2 -right-> N
+    N -right-> RV3
+  }
+
+  rectangle "Remote Source" {
+    (Content Units)
+  }
+
+  (Content Units) --> N
+}
+@enduml

--- a/docs/diagrams_src/concept-repository.dot
+++ b/docs/diagrams_src/concept-repository.dot
@@ -1,0 +1,11 @@
+@startuml
+rectangle "Create repository" {
+  (Content Unit 1)
+  (Content Unit 2)
+  rectangle "Repository" {
+    (Repository Version 1)
+  }
+  (Content Unit 1) --> (Repository Version 1)
+  (Content Unit 2) --> (Repository Version 1)
+}
+@enduml


### PR DESCRIPTION
Diagrams that illustrates all
of the concepts on the Concepts and Terminology page.

closes: #4100
https://pulp.plan.io/issues/4100

Signed-off-by: Pavel Picka <ppicka@redhat.com>