### PR TITLE
Disallow user creation/update

### DIFF
--- a/pulpcore/app/viewsets/user.py
+++ b/pulpcore/app/viewsets/user.py
@@ -19,8 +19,6 @@ class UserFilter(BaseFilterSet):
 
 
 class UserViewSet(NamedModelViewSet,
-                  mixins.CreateModelMixin,
-                  mixins.UpdateModelMixin,
                   mixins.RetrieveModelMixin,
                   mixins.ListModelMixin,
                   mixins.DestroyModelMixin):

--- a/pulpcore/tests/functional/api/test_crud_users.py
+++ b/pulpcore/tests/functional/api/test_crud_users.py
@@ -12,6 +12,7 @@ from pulpcore.tests.functional.utils import set_up_module as setUpModule  # noqa
 from pulpcore.tests.functional.utils import skip_if
 
 
+@unittest.skip("User creation via API is not allowed until Pulp has proper user management")
 class UsersCRUDTestCase(unittest.TestCase):
     """CRUD users."""
 
@@ -135,6 +136,7 @@ class UsersCRUDTestCase(unittest.TestCase):
         assert response.json()['foo'] == ['Unexpected field']
 
 
+@unittest.skip("User creation via API is not allowed until Pulp has proper user management")
 class InvalidUserCreateTestCase(unittest.TestCase):
     """Invalid user test creation.
 


### PR DESCRIPTION
One admin user will exist until the full support for user
management is added

closes #4313
https://pulp.plan.io/issues/4313