### PR TITLE
Problem: static files are not available on user installs

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -90,17 +90,7 @@ In Production
 
 For production environments, configure static content as follows:
 
-1. Pick the URL static content is served at, e.g. ``/static/`` and set that as the STATIC_URL in the
-settings.yaml file. Then select the path on the local filesystem where static content will be
-stored, and set that as STATIC_ROOT.
-
-2. Configure your webserver to serve the STATIC_ROOT directory's contents at the STATIC_URL url.
-
-3. Once configured, collect all of the static content into place using the ``collectstatic`` command
+Collect all of the static content into place using the ``collectstatic`` command
 as follows::
 
     $ pulp-manager collectstatic
-
-For more information on scaling your static content, configuring object storage to serve your static
-media, and other topics refer to the
-`Django Static Media docs <https://docs.djangoproject.com/en/2.0/howto/static-files/deployment/>`_

--- a/docs/installation/instructions.rst
+++ b/docs/installation/instructions.rst
@@ -78,11 +78,9 @@ PyPI Installation
    $ pulp-manager migrate --noinput
    $ pulp-manager reset-admin-password --password admin
 
-9. Collect and Serve Static Media
+9. Collect Static Media for live docs and browsable API
 
-   Pulp will operate correctly without static media being served, but if browsing the Pulp API with
-   a web browser you probably want to configure it. See :ref:`static-content` for more info on
-   collecting and serving static content.
+   $ pulp-manager collectstatic --noinput
 
 10. Run Pulp:
 ::

--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -16,7 +16,7 @@ from pkg_resources import iter_entry_points
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
@@ -88,6 +88,7 @@ for app in OPTIONAL_APPS:
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ requirements = [
     'PyYAML',
     'rq>=0.12.0',
     'setuptools',
-    'dynaconf>=1.0.4'
+    'dynaconf>=1.0.4',
+    'whitenoise'
 ]
 
 setup(


### PR DESCRIPTION
Solution: collect static files before releasing to PyPI

This patch adds the 'whitenoise' middleware that serves static content for Pulp. 'whitenoise' is configured
to serve static content found in pulpcore/app/static directory. This means that after installing pulp, the user
will need to run the 'pulp-manager collectstatic' command to get all the static content into the directory.

closes #4180
https://pulp.plan.io/issues/4180