### PR TITLE
Adds pulp-content

### DIFF
--- a/bin/pulp-content
+++ b/bin/pulp-content
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+import aiohttp
+
+from pulpcore.content import server
+
+
+aiohttp.web.run_app(server())

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,5 @@ setup(
             'pulp-manager=pulpcore.app.entry_points:pulp_manager_entry_point'
         ]
     },
+    scripts=['bin/pulp-content'],
 )


### PR DESCRIPTION
The docs say a script called pulp-content is there to help run the
aiohttp server locally. This allows the content app to be run in a
simple way, similar to runserver from Django.

https://pulp.plan.io/issues/4218
re #4218