### PR TITLE
Whitenoise should not write to python dir

### DIFF
--- a/pulpcore/app/settings.py
+++ b/pulpcore/app/settings.py
@@ -16,7 +16,8 @@ from pkg_resources import iter_entry_points
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = '/var/lib/pulp/static/'
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 


### PR DESCRIPTION
When running the whitenoise command it was writing to the python path
which it should not be able to do.

https://pulp.plan.io/issues/4180
closes #4180