### PR TITLE
Make diagrams via doc builder script

### DIFF
--- a/.travis/docs-builder.py
+++ b/.travis/docs-builder.py
@@ -94,7 +94,7 @@ def main():
     print("Building the docs")
     docs_directory = os.sep.join([WORKING_DIR, 'docs'])
 
-    make_command = ['make', 'html']
+    make_command = ['make', 'diagrams', 'html']
     exit_code = subprocess.call(make_command, cwd=docs_directory)
     if exit_code != 0:
         raise RuntimeError('An error occurred while building the docs.')

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -3,6 +3,7 @@ django
 djangorestframework
 django-filter
 drf-nested-routers
+plantuml
 pyyaml
 psycopg2
 sphinx<1.8.0


### PR DESCRIPTION
To diagrams to be shown we need to call
'make diagrams' too.

closes: #4100
https://pulp.plan.io/issues/4100

Signed-off-by: Pavel Picka <ppicka@redhat.com>