### PR TITLE
Rename artifact to _artifact

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_orphans.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_orphans.py
@@ -79,7 +79,7 @@ class DeleteOrphansTestCase(unittest.TestCase):
         )
 
         # Verify that the artifact is present on disk.
-        artifact_path = self.api_client.get(content['artifact'])['file']
+        artifact_path = self.api_client.get(content['_artifact'])['file']
         cmd = ('ls', artifact_path)
         self.cli_client.run(cmd, sudo=True)
 

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -324,7 +324,7 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase):
             get_content(self.repo, self.repo_version_hrefs[0])
         for repo_version_href in self.repo_version_hrefs[1:]:
             artifact_paths = get_artifact_paths(self.repo, repo_version_href)
-            self.assertIn(self.content[0]['artifact'], artifact_paths)
+            self.assertIn(self.content[0]['_artifact'], artifact_paths)
 
     def test_delete_last_version(self):
         """Delete the last repository version.
@@ -346,8 +346,8 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase):
         self.repo = self.client.get(self.repo['_href'])
         artifact_paths = get_artifact_paths(self.repo)
 
-        self.assertNotIn(self.content[-2]['artifact'], artifact_paths)
-        self.assertIn(self.content[-1]['artifact'], artifact_paths)
+        self.assertNotIn(self.content[-2]['_artifact'], artifact_paths)
+        self.assertIn(self.content[-1]['_artifact'], artifact_paths)
 
     def test_delete_middle_version(self):
         """Delete a middle version."""
@@ -359,7 +359,7 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase):
 
         for repo_version_href in self.repo_version_hrefs[index + 1:]:
             artifact_paths = get_artifact_paths(self.repo, repo_version_href)
-            self.assertIn(self.content[index]['artifact'], artifact_paths)
+            self.assertIn(self.content[index]['_artifact'], artifact_paths)
 
     def test_delete_publication(self):
         """Delete a publication.


### PR DESCRIPTION
Renaming to '_artifact' to be clearer that artifact
is part of pulpcore. as continue for #4206 refactor.
Fix for testing.

re: #4282
https://pulp.plan.io/issues/4282

Signed-off-by: Pavel Picka <ppicka@redhat.com>