### PR TITLE
Use python3 for make diagrams

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,7 +46,7 @@ clean:
 
 diagrams:
 	mkdir -p $(DIAGRAM_BUILD_DIR)
-	python -m plantuml diagrams_src/*.dot
+	python3 -m plantuml diagrams_src/*.dot
 	mv diagrams_src/*.png $(DIAGRAM_BUILD_DIR)/
 
 html:


### PR DESCRIPTION
Make file uses python (which usually python2)
and requirements file is for python3.
Fixed for calling python3.

re: #4100
https://pulp.plan.io/issues/4100

Signed-off-by: Pavel Picka <ppicka@redhat.com>