### PR TITLE
Let core decide whether to use "_artifact" or "_artifacts"

### DIFF
--- a/pulpcore/app/serializers/__init__.py
+++ b/pulpcore/app/serializers/__init__.py
@@ -14,7 +14,12 @@ from .base import (  # noqa
     AsyncOperationResponseSerializer
 )
 from .fields import BaseURLField, ContentRelatedField, LatestVersionField  # noqa
-from .content import ArtifactSerializer, ContentSerializer  # noqa
+from .content import (  # noqa
+    ArtifactSerializer,
+    NoArtifactContentSerializer,
+    SingleArtifactContentSerializer,
+    MultipleArtifactContentSerializer,
+)
 from .progress import ProgressReportSerializer  # noqa
 from .publication import (  # noqa
     ContentGuardSerializer,

--- a/pulpcore/app/serializers/content.py
+++ b/pulpcore/app/serializers/content.py
@@ -11,9 +11,32 @@ from pulpcore.app.serializers import base, fields
 UNIQUE_ALGORITHMS = ['sha256', 'sha384', 'sha512']
 
 
-class ContentSerializer(base.MasterModelSerializer):
+class BaseContentSerializer(base.MasterModelSerializer):
     _href = base.DetailIdentityField()
 
+    class Meta:
+        model = models.Content
+        fields = base.MasterModelSerializer.Meta.fields
+
+
+class NoArtifactContentSerializer(BaseContentSerializer):
+
+    class Meta:
+        model = models.Content
+        fields = base.MasterModelSerializer.Meta.fields
+
+
+class SingleArtifactContentSerializer(BaseContentSerializer):
+    _artifact = fields.SingleContentArtifactField(
+        help_text=_("Artifact file representing the physical content"),
+    )
+
+    class Meta:
+        model = models.Content
+        fields = base.MasterModelSerializer.Meta.fields + ('_artifact',)
+
+
+class MultipleArtifactContentSerializer(BaseContentSerializer):
     _artifacts = fields.ContentArtifactsField(
         help_text=_("A dict mapping relative paths inside the Content to the corresponding"
                     "Artifact URLs. E.g.: {'relative/path': "

--- a/pulpcore/app/viewsets/content.py
+++ b/pulpcore/app/viewsets/content.py
@@ -6,7 +6,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework.response import Response
 
 from pulpcore.app.models import Artifact, Content, ContentArtifact
-from pulpcore.app.serializers import ArtifactSerializer, ContentSerializer
+from pulpcore.app.serializers import ArtifactSerializer, MultipleArtifactContentSerializer
 from pulpcore.app.viewsets.base import BaseFilterSet, NamedModelViewSet
 
 from .custom_filters import (
@@ -80,7 +80,6 @@ class ContentFilter(BaseFilterSet):
     class Meta:
         model = Content
         fields = {
-            '_type': ['exact', 'in'],
             'repository_version': ['exact'],
             'repository_version_added': ['exact'],
             'repository_version_removed': ['exact'],
@@ -92,9 +91,10 @@ class ContentViewSet(NamedModelViewSet,
                      mixins.RetrieveModelMixin,
                      mixins.ListModelMixin):
     endpoint_name = 'content'
-    queryset = Content.objects.all()
-    serializer_class = ContentSerializer
     filterset_class = ContentFilter
+    # These are just placeholders, the plugin writer would replace them with the actual
+    queryset = Content.objects.all()
+    serializer_class = MultipleArtifactContentSerializer
 
     @transaction.atomic
     def create(self, request):

--- a/pulpcore/tests/functional/api/using_plugin/test_orphans.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_orphans.py
@@ -79,7 +79,7 @@ class DeleteOrphansTestCase(unittest.TestCase):
         )
 
         # Verify that the artifact is present on disk.
-        artifact_path = self.api_client.get(content['artifact'])['file']
+        artifact_path = self.api_client.get(content['_artifact'])['file']
         cmd = ('ls', artifact_path)
         self.cli_client.run(cmd, sudo=True)
 

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -324,7 +324,7 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase):
             get_content(self.repo, self.repo_version_hrefs[0])
         for repo_version_href in self.repo_version_hrefs[1:]:
             artifact_paths = get_artifact_paths(self.repo, repo_version_href)
-            self.assertIn(self.content[0]['artifact'], artifact_paths)
+            self.assertIn(self.content[0]['_artifact'], artifact_paths)
 
     def test_delete_last_version(self):
         """Delete the last repository version.
@@ -346,8 +346,8 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase):
         self.repo = self.client.get(self.repo['_href'])
         artifact_paths = get_artifact_paths(self.repo)
 
-        self.assertNotIn(self.content[-2]['artifact'], artifact_paths)
-        self.assertIn(self.content[-1]['artifact'], artifact_paths)
+        self.assertNotIn(self.content[-2]['_artifact'], artifact_paths)
+        self.assertIn(self.content[-1]['_artifact'], artifact_paths)
 
     def test_delete_middle_version(self):
         """Delete a middle version."""
@@ -359,7 +359,7 @@ class AddRemoveRepoVersionTestCase(unittest.TestCase):
 
         for repo_version_href in self.repo_version_hrefs[index + 1:]:
             artifact_paths = get_artifact_paths(self.repo, repo_version_href)
-            self.assertIn(self.content[index]['artifact'], artifact_paths)
+            self.assertIn(self.content[index]['_artifact'], artifact_paths)
 
     def test_delete_publication(self):
         """Delete a publication.

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -13,9 +13,9 @@ class HandlerSaveContentTestCase(TestCase):
 
     def setUp(self):
         self.f1 = FileContent.objects.create(relative_path='f1', digest='1')
-        self.f1.artifact = None
+        ContentArtifact.objects.create(artifact=None, content=self.f1, relative_path='f1')
         self.f2 = FileContent.objects.create(relative_path='f2', digest='1')
-        self.f2.artifact = None
+        ContentArtifact.objects.create(artifact=None, content=self.f2, relative_path='f2')
 
     def download_result_mock(self, path):
         dr = Mock()


### PR DESCRIPTION
Remove boilerplate from the plugins. Plugins must define a
"multiple_artifacts_per_content" attribute on their Serializer subclass
Meta class, and core will look at that to decide which to use.

re: 4340
https://pulp.plan.io/issues/4340