### PR TITLE
Fix indention that Shinx complains about

### DIFF
--- a/pulpcore/tasking/tasks.py
+++ b/pulpcore/tasking/tasks.py
@@ -165,7 +165,7 @@ def enqueue_with_reservation(func, resources, args=None, kwargs=None, options=No
         func (callable): The function to be run by RQ when the necessary locks are acquired.
         resources (list): A list of resources to reserve guaranteeing that only one task
             reserves these resources. Each resource can be either a (str) resource URL
-             or a (django.models.Model) resource instance.
+            or a (django.models.Model) resource instance.
         args (tuple): The positional arguments to pass on to the task.
         kwargs (dict): The keyword arguments to pass on to the task.
         options (dict): The options to be passed on to the task.
@@ -183,7 +183,7 @@ def enqueue_with_reservation(func, resources, args=None, kwargs=None, options=No
         options = dict()
 
     def as_url(r):
-        if isinstance(r,  str):
+        if isinstance(r, str):
             return r
         if isinstance(r, Model):
             return util.get_url(r)

--- a/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_crd_publications.py
@@ -28,7 +28,7 @@ from pulpcore.tests.functional.api.using_plugin.utils import (
     gen_file_remote,
     skip_if
 )
-from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
+from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
 
 
 class PublicationsTestCase(unittest.TestCase):

--- a/pulpcore/tests/functional/api/using_plugin/test_pagination.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pagination.py
@@ -14,7 +14,7 @@ from pulpcore.tests.functional.api.using_plugin.constants import (
     FILE_CONTENT_PATH
 )
 from pulpcore.tests.functional.api.using_plugin.utils import populate_pulp
-from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
+from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
 
 
 class PaginationTestCase(unittest.TestCase):

--- a/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_repo_versions.py
@@ -41,7 +41,7 @@ from pulpcore.tests.functional.api.using_plugin.utils import (
     populate_pulp,
     skip_if,
 )
-from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
+from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
 
 
 class AddRemoveContentTestCase(unittest.TestCase):

--- a/pulpcore/tests/functional/api/using_plugin/test_tasking.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_tasking.py
@@ -17,7 +17,7 @@ from pulpcore.tests.functional.api.using_plugin.constants import (
     FILE_REMOTE_PATH,
 )
 from pulpcore.tests.functional.api.using_plugin.utils import gen_file_remote
-from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
+from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
 
 
 class MultiResourceLockingTestCase(unittest.TestCase):

--- a/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_unlinking_repo.py
@@ -19,7 +19,7 @@ from pulpcore.tests.functional.api.using_plugin.constants import (
     FILE_PUBLISHER_PATH
 )
 from pulpcore.tests.functional.api.using_plugin.utils import gen_file_remote
-from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa:F401
+from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
 
 
 class RemotesPublishersTestCase(unittest.TestCase):


### PR DESCRIPTION
The enqueue_with_reservation is included in the pulpcore-plugin package
and its docstring in the docs. When building the pulpcore-plugin docs it
complains saying:

docstring of pulpcore.plugin.tasking.enqueue_with_reservation
:19:Unexpected indentation.

[noissue]
