### PR TITLE
Modify response_handler for populate_pulp function

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/utils.py
+++ b/pulpcore/tests/functional/api/using_plugin/utils.py
@@ -45,7 +45,7 @@ def populate_pulp(cfg, url=None):
     if url is None:
         url = FILE_FIXTURE_MANIFEST_URL
 
-    client = api.Client(cfg, api.json_handler)
+    client = api.Client(cfg, api.page_handler)
     remote = {}
     repo = {}
     try:


### PR DESCRIPTION
Modify `response_handler` used by populate_pulp to be `page_handler`.
For Pulp 3 `page_handler` should be the prefered one.

See: https://pulp-smash.readthedocs.io/en/latest/api/pulp_smash.api.html?highlight=page_handler#pulp_smash.api.page_handler

'[noissue]'


