### PR TITLE
Mark pass_through write_only on Serializer

### DIFF
--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -23,9 +23,6 @@ class PublicationSerializer(ModelSerializer):
     _href = IdentityField(
         view_name='publications-detail'
     )
-    pass_through = serializers.BooleanField(
-        help_text=_('The publication is a pass-through for the repository version.')
-    )
     publisher = DetailRelatedField(
         help_text=_('The publisher that created this publication.'),
         queryset=models.Publisher.objects.all()
@@ -47,7 +44,6 @@ class PublicationSerializer(ModelSerializer):
     class Meta:
         model = models.Publication
         fields = ModelSerializer.Meta.fields + (
-            'pass_through',
             'publisher',
             'distributions',
             'repository_version',


### PR DESCRIPTION
This hides the pass_through option when serializing Publications.

re #4421
https://pulp.plan.io/issues/4421