### PR TITLE
Fix 500 error when accessing /pulp/api/v3/ as unauthed user

### DIFF
--- a/pulpcore/app/urls.py
+++ b/pulpcore/app/urls.py
@@ -144,7 +144,10 @@ urlpatterns.append(url(
     name='schema-redoc')
 )
 
-schema_view = get_schema_view(title='Pulp API')
+schema_view = get_schema_view(
+    title='Pulp API',
+    permission_classes=[permissions.AllowAny],
+)
 
 urlpatterns.append(url(r'^{api_root}$'.format(api_root=API_ROOT), schema_view))
 


### PR DESCRIPTION
fixes #4323
https://pulp.plan.io/issues/4323

This fixes the problem by dropping the requirement for an authed user. However, there's also [an unreleased fix in DRF](https://github.com/encode/django-rest-framework/pull/6429) that solves the 500 issue.