### PR TITLE
Pins redis client to version less than 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requirements = [
     'psycopg2-binary',
     'PyYAML',
     'rq>=0.12.0',
+    'redis<3.2.0',
     'setuptools',
     'dynaconf>=1.0.4',
     'whitenoise'


### PR DESCRIPTION
[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
