### PR TITLE
Using async_post for pagination test cases

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_pagination.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pagination.py
@@ -2,7 +2,6 @@
 """Tests related to pagination."""
 import unittest
 from random import sample
-from threading import Lock, Thread
 
 from pulp_smash import api, config
 from pulp_smash.pulp3.constants import REPO_PATH
@@ -11,7 +10,7 @@ from pulp_smash.pulp3.utils import gen_repo, get_versions
 from pulpcore.tests.functional.api.using_plugin.constants import (
     FILE_MANY_FIXTURE_COUNT,
     FILE_MANY_FIXTURE_MANIFEST_URL,
-    FILE_CONTENT_PATH
+    FILE_CONTENT_PATH,
 )
 from pulpcore.tests.functional.api.using_plugin.utils import populate_pulp
 from pulpcore.tests.functional.api.using_plugin.utils import set_up_module as setUpModule  # noqa
@@ -37,49 +36,24 @@ class PaginationTestCase(unittest.TestCase):
         repos = self.client.get(REPO_PATH)
         self.assertEqual(len(repos), 0, repos)
 
-        # list.append() and list.pop() are thread-safe. ¶ We create 21 repos,
-        # because with page_size set to 10, this produces 3 pages, where the
-        # three three pages have unique combinations of values for the
-        # "previous" and "next" links.
-        repo_hrefs = []
-        repo_hrefs_lock = Lock()
         number_to_create = 21
 
-        def create_repos():
-            """Repeatedly create repos and append to ``repos_hrefs``."""
-            # "It's better to beg for forgiveness than to ask for permission."
-            while True:
-                repo_href = self.client.post(REPO_PATH, gen_repo())['_href']
-                with repo_hrefs_lock:
-                    if len(repo_hrefs) < number_to_create:
-                        repo_hrefs.append(repo_href)
-                    else:
-                        self.client.delete(repo_href)
-                        break
+        # create repos
+        created_repos = self.client.async_post(
+            [
+                {"url": REPO_PATH, "json": gen_repo()}
+                for _ in range(number_to_create)
+            ]
+        )
 
-        def delete_repos():
-            """Delete the repos listed in ``repos_href``."""
-            while True:
-                try:
-                    self.client.delete(repo_hrefs.pop())
-                except IndexError:
-                    break
+        # check results
+        repos = self.client.get(REPO_PATH, params={"page_size": 10})
+        self.assertEqual(len(repos), number_to_create, repos)
 
-        # Create repos, check results, and delete repos.
-        create_threads = tuple(Thread(target=create_repos) for _ in range(4))
-        delete_threads = tuple(Thread(target=delete_repos) for _ in range(8))
-        try:
-            for thread in create_threads:
-                thread.start()
-            for thread in create_threads:
-                thread.join()
-            repos = self.client.get(REPO_PATH, params={'page_size': 10})
-            self.assertEqual(len(repos), number_to_create, repos)
-        finally:
-            for thread in delete_threads:
-                thread.start()
-            for thread in delete_threads:
-                thread.join()
+        # delete repos
+        self.client.async_delete(
+            [{"url": repo["_href"]} for repo in created_repos]
+        )
 
     def test_content(self):
         """Test pagination for repository versions."""
@@ -91,15 +65,19 @@ class PaginationTestCase(unittest.TestCase):
         sample_size = min(FILE_MANY_FIXTURE_COUNT, 21)
         contents = sample(self.client.get(FILE_CONTENT_PATH), sample_size)
         repo = self.client.post(REPO_PATH, gen_repo())
-        self.addCleanup(self.client.delete, repo['_href'])
+        self.addCleanup(self.client.delete, repo["_href"])
 
-        for content in contents:
-            self.client.post(
-                repo['_versions_href'],
-                {'add_content_units': [content['_href']]}
-            )
+        self.client.async_post(
+            [
+                {
+                    "url": repo["_versions_href"],
+                    "json": {"add_content_units": [content["_href"]]},
+                }
+                for content in contents
+            ]
+        )
 
         # Verify pagination works for getting repo versions.
-        repo = self.client.get(repo['_href'])
-        repo_versions = get_versions(repo, {'page_size': 10})
+        repo = self.client.get(repo["_href"])
+        repo_versions = get_versions(repo, {"page_size": 10})
         self.assertEqual(len(repo_versions), sample_size, repo_versions)


### PR DESCRIPTION
Using the new `client.async_post` for repo pagination test cases.

Required PR: https://github.com/PulpQE/pulp-smash/pull/1171

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
