### PR TITLE
Remove Threads from pagination test case

### DIFF
--- a/pulpcore/tests/functional/api/using_plugin/test_pagination.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_pagination.py
@@ -2,7 +2,6 @@
 """Tests related to pagination."""
 import unittest
 from random import sample
-from threading import Lock, Thread
 
 from pulp_smash import api, config
 from pulp_smash.pulp3.constants import REPO_PATH
@@ -37,49 +36,16 @@ class PaginationTestCase(unittest.TestCase):
         repos = self.client.get(REPO_PATH)
         self.assertEqual(len(repos), 0, repos)
 
-        # list.append() and list.pop() are thread-safe. ¶ We create 21 repos,
-        # because with page_size set to 10, this produces 3 pages, where the
-        # three three pages have unique combinations of values for the
-        # "previous" and "next" links.
-        repo_hrefs = []
-        repo_hrefs_lock = Lock()
         number_to_create = 21
 
-        def create_repos():
-            """Repeatedly create repos and append to ``repos_hrefs``."""
-            # "It's better to beg for forgiveness than to ask for permission."
-            while True:
-                repo_href = self.client.post(REPO_PATH, gen_repo())['_href']
-                with repo_hrefs_lock:
-                    if len(repo_hrefs) < number_to_create:
-                        repo_hrefs.append(repo_href)
-                    else:
-                        self.client.delete(repo_href)
-                        break
+        # Create repos
+        for _ in range(number_to_create):
+            repo = self.client.post(REPO_PATH, gen_repo())
+            self.addCleanup(self.client.delete, repo['_href'])
 
-        def delete_repos():
-            """Delete the repos listed in ``repos_href``."""
-            while True:
-                try:
-                    self.client.delete(repo_hrefs.pop())
-                except IndexError:
-                    break
-
-        # Create repos, check results, and delete repos.
-        create_threads = tuple(Thread(target=create_repos) for _ in range(4))
-        delete_threads = tuple(Thread(target=delete_repos) for _ in range(8))
-        try:
-            for thread in create_threads:
-                thread.start()
-            for thread in create_threads:
-                thread.join()
-            repos = self.client.get(REPO_PATH, params={'page_size': 10})
-            self.assertEqual(len(repos), number_to_create, repos)
-        finally:
-            for thread in delete_threads:
-                thread.start()
-            for thread in delete_threads:
-                thread.join()
+        # assert results
+        repos = self.client.get(REPO_PATH, params={'page_size': 10})
+        self.assertEqual(len(repos), number_to_create, repos)
 
     def test_content(self):
         """Test pagination for repository versions."""


### PR DESCRIPTION
Make pagination sync to avoid threding problems as for now
timing is not an issue for this test case.

The asyncIO version is only twice fast as sync.
https://github.com/pulp/pulp/pull/3887

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
