### PR TITLE
Use hyphen on test worker

### DIFF
--- a/pulpcore/tests/functional/api/test_workers.py
+++ b/pulpcore/tests/functional/api/test_workers.py
@@ -137,7 +137,7 @@ class OfflineWorkerTestCase(unittest.TestCase):
             WORKER_PATH, params={'online': True}
         )['results']
         for worker in workers:
-            if 'worker_99' in worker['name']:
+            if 'worker-99' in worker['name']:
                 self.worker.update(worker)
                 break
         self.assertNotEqual({}, self.worker)


### PR DESCRIPTION
The PR https://github.com/pulp/pulp/pull/3882 changed worker
unit names to use hyphens so test worker needs this update.

[noissue]

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
