### PR TITLE
Problem: pulpcore does not have pass-through cache feature

### DIFF
--- a/pulpcore/app/models/publication.py
+++ b/pulpcore/app/models/publication.py
@@ -2,7 +2,7 @@ from django.db import models, transaction
 
 from . import storage
 from .base import MasterModel, Model
-from .repository import Publisher, Repository
+from .repository import Publisher, Remote, Repository
 from .task import CreatedResource
 
 
@@ -248,7 +248,9 @@ class BaseDistribution(Model):
         publication (models.ForeignKey): The current publication associated with
             the distribution.  This is the publication being served by Pulp through
             this relative URL path and settings.
-        content_guard ((models.ForeignKey): An optional content-guard.
+        content_guard (models.ForeignKey): An optional content-guard.
+        remote (models.ForeignKey): A remote that the content app can use to find content not
+            yet stored in Pulp.
     """
 
     name = models.CharField(max_length=255, db_index=True, unique=True)
@@ -258,6 +260,7 @@ class BaseDistribution(Model):
     publisher = models.ForeignKey(Publisher, null=True, on_delete=models.SET_NULL)
     repository = models.ForeignKey(Repository, null=True, on_delete=models.SET_NULL)
     content_guard = models.ForeignKey(ContentGuard, null=True, on_delete=models.SET_NULL)
+    remote = models.ForeignKey(Remote, null=True, on_delete=models.SET_NULL)
 
     class Meta:
         abstract = True

--- a/pulpcore/app/serializers/publication.py
+++ b/pulpcore/app/serializers/publication.py
@@ -126,6 +126,12 @@ class DistributionSerializer(ModelSerializer):
         source='base_path', read_only=True,
         help_text=_('The URL for accessing the publication as defined by this distribution.')
     )
+    remote = DetailRelatedField(
+        required=False,
+        help_text=_('FIX THIS TEXT'),
+        queryset=models.Remote.objects.all(),
+        allow_null=True
+    )
 
     class Meta:
         model = models.Distribution
@@ -137,6 +143,7 @@ class DistributionSerializer(ModelSerializer):
             'base_url',
             'repository',
             'content_guard',
+            'remote',
         )
 
     def _validate_path_overlap(self, path):

--- a/pulpcore/tests/unit/content/test_handler.py
+++ b/pulpcore/tests/unit/content/test_handler.py
@@ -11,9 +11,13 @@ class HandlerSaveContentTestCase(TestCase):
 
     def setUp(self):
         self.c1 = Content.objects.create()
-        ContentArtifact.objects.create(artifact=None, content=self.c1, relative_path='c1')
+        self.ca1 = ContentArtifact.objects.create(artifact=None, content=self.c1,
+                                                  relative_path='c1')
+        self.ra1 = Mock(content_artifact=self.ca1)
         self.c2 = Content.objects.create()
-        ContentArtifact.objects.create(artifact=None, content=self.c2, relative_path='c2')
+        self.ca2 = ContentArtifact.objects.create(artifact=None, content=self.c2,
+                                                  relative_path='c2')
+        self.ra2 = Mock(content_artifact=self.ca2)
 
     def download_result_mock(self, path):
         dr = Mock()
@@ -23,23 +27,20 @@ class HandlerSaveContentTestCase(TestCase):
         dr.path = SimpleUploadedFile(name=path, content='')
         return dr
 
-    def test_save_content_artifact(self):
+    def test_save_artifact(self):
         """Artifact needs to be created."""
         cch = Handler()
-        new_artifact = cch._save_content_artifact(self.download_result_mock('c1'),
-                                                  ContentArtifact.objects.get(pk=self.c1.pk))
+        new_artifact = cch._save_artifact(self.download_result_mock('c1'), self.ra1)
         c1 = Content.objects.get(pk=self.c1.pk)
         self.assertIsNotNone(new_artifact)
         self.assertEqual(c1._artifacts.get().pk, new_artifact.pk)
 
-    def test_save_content_artifact_artifact_already_exists(self):
+    def test_save_artifact_artifact_already_exists(self):
         """Artifact turns out to already exist."""
         cch = Handler()
-        new_artifact = cch._save_content_artifact(self.download_result_mock('c1'),
-                                                  ContentArtifact.objects.get(pk=self.c1.pk))
+        new_artifact = cch._save_artifact(self.download_result_mock('c1'), self.ra1)
 
-        existing_artifact = cch._save_content_artifact(self.download_result_mock('c2'),
-                                                       ContentArtifact.objects.get(pk=self.c2.pk))
+        existing_artifact = cch._save_artifact(self.download_result_mock('c2'), self.ra2)
         c2 = Content.objects.get(pk=self.c2.pk)
         self.assertEqual(existing_artifact.pk, new_artifact.pk)
         self.assertEqual(c2._artifacts.get().pk, existing_artifact.pk)


### PR DESCRIPTION
Solution: extend the content app to support pass-through cache

This patch enables the content app handler to look for a remote on a distribution. When a remote
is associated with a distribution, that remote is used to download content missing from Pulp.

re: #3894
https://pulp.plan.io/issues/3894