### PR TITLE
Problem: wrong OpenAPI schema of repo version list, create APIs

### DIFF
--- a/pulpcore/app/openapigenerator.py
+++ b/pulpcore/app/openapigenerator.py
@@ -104,7 +104,7 @@ class PulpOpenAPISchemaGenerator(OpenAPISchemaGenerator):
         """
         resource_path = '%s}/' % path.rsplit(sep='}', maxsplit=1)[0]
         if resource_path.endswith('_pk}/'):
-            resource_path = '%s{id}/' % resource_path.rsplit(sep='{', maxsplit=1)[0]
+            resource_path = '%s{_id}/' % resource_path.rsplit(sep='{', maxsplit=1)[0]
         return resource_path
 
     @staticmethod


### PR DESCRIPTION
Solution: update the schema generator to account for _id introduced as part of https://pulp.plan.io/issues/4206

closes: #4447
https://pulp.plan.io/issues/4447