### PR TITLE
Problem: streamer decodes data while streaming

### DIFF
--- a/server/pulp/plugins/importer.py
+++ b/server/pulp/plugins/importer.py
@@ -62,7 +62,7 @@ class Importer(object):
         return Importer.build_downloader(url, nectar_config)
 
     @staticmethod
-    def get_downloader_for_db_importer(importer, url, working_dir=None, **options):
+    def get_downloader_for_db_importer(importer, url, working_dir=None, stream=False, **options):
         """
         Get a configured downloader for the given DB model of an Importer.
 
@@ -75,11 +75,14 @@ class Importer(object):
         :type  working_dir: str
         :param options:     Extended configuration.
         :type options:      dict
+        :param stream:      If true, the raw response is returned. If false, a decoded
+                            response is returned.
+        :type stream:       bool
         :return:            A configured downloader.
         :rtype:             nectar.downloaders.base.Downloader
         :raise ValueError:  When the URL scheme is not supported.
         """
-        nectar_config = importer_to_nectar_config(importer, working_dir=working_dir)
+        nectar_config = importer_to_nectar_config(importer, working_dir=working_dir, stream=stream)
         return Importer.build_downloader(url, nectar_config)
 
     # -- plugin lifecycle -----------------------------------------------------

--- a/server/pulp/plugins/util/nectar_config.py
+++ b/server/pulp/plugins/util/nectar_config.py
@@ -33,7 +33,7 @@ IMPORTER_DOWNLOADER_CONFIG_MAP = (
 )
 
 
-def importer_to_nectar_config(importer, working_dir=None):
+def importer_to_nectar_config(importer, working_dir=None, stream=False):
     """
     Translates a Pulp Importer into a DownloaderConfig instance.
 
@@ -48,6 +48,9 @@ def importer_to_nectar_config(importer, working_dir=None):
     :type  importer:    pulp.server.db.model.Importer
     :param working_dir: Allow the caller to override the working directory used
     :type  working_dir: str
+    :param stream:      If true, the raw response is returned. If false, a decoded
+                        response is returned.
+    :type stream:       bool
 
     :rtype: nectar.config.DownloaderConfig
     """
@@ -65,6 +68,7 @@ def importer_to_nectar_config(importer, working_dir=None):
     if constants.KEY_SSL_CLIENT_KEY in config:
         del config[constants.KEY_SSL_CLIENT_KEY]
         download_config_kwargs['ssl_client_key_path'] = importer.tls_client_key_path
+    download_config_kwargs['stream'] = stream
 
     return importer_config_to_nectar_config(config, working_dir, download_config_kwargs)
 

--- a/streamer/pulp/streamer/server.py
+++ b/streamer/pulp/streamer/server.py
@@ -250,7 +250,7 @@ class Streamer(Resource):
                 repo_controller.get_importer_by_id(entry.importer_id)
             model.config = config.flatten()
             downloader = importer.get_downloader_for_db_importer(
-                model, entry.url, working_dir='/tmp')
+                model, entry.url, working_dir='/tmp', stream=True)
             listener = DownloadListener(self, request)
             downloader.event_listener = listener
             downloader.session = self.session_cache.get_or_create(request.uri, downloader)

--- a/streamer/setup.py
+++ b/streamer/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'iniparse',
         'mongoengine >= 0.7.10',
-        'nectar >= 1.4.0',
+        'nectar >= 1.6.0',
         'setuptools',
     ] + twisted,
     entry_points={


### PR DESCRIPTION
Solution: configure nectar downloaders to not decode responses

This patch relies on a new config option for the nectar downloaders.

re: #4603
https://pulp.plan.io/issues/4603