### PR TITLE
Improve performance of publish with iso_distributor via fast-forward

### DIFF
--- a/server/pulp/server/util.py
+++ b/server/pulp/server/util.py
@@ -254,7 +254,8 @@ def copytree(src, dst, symlinks=False, ignore=None):
     else:
         ignored_names = set()
 
-    os.makedirs(dst)
+    if not os.path.exists(dst):
+        os.makedirs(dst)
     errors = []
     for name in names:
         if name in ignored_names:


### PR DESCRIPTION
Only symlinks for those incremental or changed files are generated
and copied to target directories, then the publish gets faster.

ref #4708
https://pulp.plan.io/issues/4708