### PR TITLE
Fix broken TestStreamer.test_get_downloader

### DIFF
--- a/streamer/test/unit/streamer/test_server.py
+++ b/streamer/test/unit/streamer/test_server.py
@@ -354,7 +354,7 @@ class TestStreamer(unittest.TestCase):
         controller.get_importer_by_id.assert_called_once_with(entry.importer_id)
         config.flatten.assert_called_once_with()
         importer.get_downloader_for_db_importer.assert_called_once_with(
-            model, entry.url, working_dir='/tmp')
+            model, entry.url, working_dir='/tmp', stream=True)
         listener.assert_called_once_with(streamer, request)
         self.assertEqual(downloader, importer.get_downloader_for_db_importer.return_value)
         self.assertEqual(downloader.event_listener, listener.return_value)


### PR DESCRIPTION
This autotest was broken by commit 48d365f157e, which changed
a call to get_downloader_for_db_importer without updating this
related test.