### PR TITLE
Remove consumer profiles by id

### DIFF
--- a/server/pulp/server/managers/consumer/profile.py
+++ b/server/pulp/server/managers/consumer/profile.py
@@ -80,7 +80,7 @@ class ProfileManager(object):
         """
         profile = ProfileManager.get_profile(consumer_id, content_type)
         collection = UnitProfile.get_collection()
-        collection.remove(profile)
+        collection.remove({'id': profile['id']})
 
     def consumer_deleted(self, id):
         """
@@ -91,7 +91,7 @@ class ProfileManager(object):
         """
         collection = UnitProfile.get_collection()
         for p in self.get_profiles(id):
-            collection.remove(p)
+            collection.remove({'id': p['id']})
 
     @staticmethod
     def get_profile(consumer_id, content_type):


### PR DESCRIPTION
Each profile is a dictionary. It's not reliable to use nested
dictionaries in criteria to remove a document from a collection
because Python doesn't guarantee key order in a dictionary
but it's important for MongoDB.
The solution is to remove by id, the rest of criteria is redundant.

closes #4654
https://pulp.plan.io/issues/4654