### PR TITLE
Replace option "skip_fast_forward" with "force_full" for FileDistributor

### DIFF
--- a/server/pulp/plugins/file/distributor.py
+++ b/server/pulp/plugins/file/distributor.py
@@ -70,7 +70,7 @@ class FileDistributor(Distributor):
         :return:                report describing the publish operation
         :rtype:                 pulp.plugins.model.PublishReport
         """
-        if not config.get("skip_fast_forward", True):
+        if config.get("force_full", False):
             return self.publish_repo_fast_forward(repo, publish_conduit, config)
 
         progress_report = FilePublishProgressReport(publish_conduit)


### PR DESCRIPTION
In order to keep consistent with the option name "force_full" which is used in yum and rsync distributors, the option name "skip_fast_forward" will be replaced to with "force_full" in FileDistributor

ref #4799
https://pulp.plan.io/issues/4799