### PR TITLE
Problem: release notes missing for 2.19.1

### DIFF
--- a/docs/user-guide/release-notes/2.19.x.rst
+++ b/docs/user-guide/release-notes/2.19.x.rst
@@ -3,6 +3,15 @@ Pulp 2.19 Release Notes
 =======================
 
 
+Pulp 2.19.1
+===========
+
+Bug Fixes
+---------
+
+See the list of :fixedbugs_pulp:`2.19.1`
+
+
 Pulp 2.19.0
 ===========
 


### PR DESCRIPTION
Solution: add release notes for 2.19.1

[noissue]

(cherry picked from commit fb6e75fd6a96d4dd33eb4f8c56490abcdca72fd5)