### PR TITLE
Problem: no config for building 2.19.0 docs

### DIFF
--- a/.travis/2.19.0.yaml
+++ b/.travis/2.19.0.yaml
@@ -1,0 +1,23 @@
+repositories:
+  - name: pulp
+    git_url: https://github.com/pulp/pulp.git
+    git_branch: 2.19.0
+    version: 2.19.0-1
+  - name: pulp_puppet
+    git_url: https://github.com/pulp/pulp_puppet.git
+    git_branch: 2.19.0
+  - name: pulp_rpm
+    git_url: https://github.com/pulp/pulp_rpm.git
+    git_branch: 2.19.0
+  - name: pulp_docker
+    git_url: https://github.com/pulp/pulp_docker.git
+    git_branch: 3.2.3
+  - name: pulp_ostree
+    git_url: https://github.com/pulp/pulp_ostree.git
+    git_branch: 1.4.0
+  - name: pulp_python
+    git_url: https://github.com/pulp/pulp_python.git
+    git_branch: 2.0.3
+  - name: crane
+    git_url: https://github.com/pulp/crane.git
+    git_branch: 3.3.1


### PR DESCRIPTION
Solution: add a config for building 2.19.0 docs

This is needed because I accidently put 2.19.1 beta docs into place of 2.19.0 docs on
docs.pulpproject.org

[noissue]