### PR TITLE
Add sleep calls to prevent task upsert errors

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1401,6 +1401,9 @@ def download_deferred():
     )
     download_step.start()
 
+    # ugly hack to prevent task collisons. see #4428
+    time.sleep(0.5)
+
 
 @celery.task(base=Task)
 def download_repo(repo_id, verify_all_units=False):

--- a/server/pulp/server/managers/consumer/applicability.py
+++ b/server/pulp/server/managers/consumer/applicability.py
@@ -4,6 +4,7 @@ Contains content applicability management classes
 import hashlib
 import itertools
 import json
+import time
 
 from gettext import gettext as _
 from logging import getLogger
@@ -176,6 +177,9 @@ class ApplicabilityRegenerationManager(object):
             # Regenerate applicability data for given profiles and repo id
             ApplicabilityRegenerationManager.regenerate_applicability(all_profiles_hash,
                                                                       profiles, repo_id)
+
+        # ugly hack to prevent task collisons. see #4428
+        time.sleep(0.5)
 
     @staticmethod
     def regenerate_applicability(all_profiles_hash, profiles, bound_repo_id):


### PR DESCRIPTION
Adding a couple sleep calls to slow down tasks that finish too soon.
This will hopefully prevent NotUniqueError we've seen.

fixes #4428
https://pulp.plan.io/issues/4428