### PR TITLE
[WIP, Pulp2] Mark an importer as 'feed-updated', when changing its feed.

### DIFF
--- a/common/pulp/common/plugins/importer_constants.py
+++ b/common/pulp/common/plugins/importer_constants.py
@@ -21,6 +21,9 @@ docstring for more information.
 # Location of the external source to sync
 KEY_FEED = 'feed'
 
+# Boolean indicating if external feed-url has changed since the last sync
+KEY_FEED_UPDATED = 'feed-updated'
+
 # Boolean indicating if the synchronized units should be verified by size and checksum
 KEY_VALIDATE = 'validate'
 

--- a/server/pulp/plugins/conduits/mixins.py
+++ b/server/pulp/plugins/conduits/mixins.py
@@ -294,6 +294,38 @@ class ImporterScratchPadMixin(object):
             _logger.exception(_('Error setting scratchpad for repo [%(r)s]') % {'r': self.repo_id})
             raise ImporterConduitException(e), None, sys.exc_info()[2]
 
+    def set_scratchpad_entry(self, key, value):
+        """
+        Add the specified key/value pair to the scratchpad, making sure the scratchpad exists
+        first if necessary.
+
+        :param key:     The key to be added to the scratchpad
+        :type  key:     basestring
+        :param value:   The value to assign to 'key', in the scratchpad
+        :type  value:   object
+        """
+        spad = self.get_scratchpad()
+        if not spad:
+            spad = {}
+        spad[key] = value
+        self.set_scratchpad(spad)
+
+    def get_scratchpad_entry(self, key):
+        """
+        Return the value of 'key' in the Importer's scratchpad.
+        Return None, if scratchpad doesn't exist or 'key' is not in scratchpad.
+
+        :param key:     The key to be queried
+        :type  key:     basestring
+        :rtype object
+        """
+        spad = self.get_scratchpad()
+        if spad:
+            return spad.get(key, None)
+        else:
+            return None
+
+
 
 class DistributorScratchPadMixin(object):
 

--- a/server/pulp/server/controllers/importer.py
+++ b/server/pulp/server/controllers/importer.py
@@ -8,6 +8,7 @@ from mongoengine import ValidationError
 
 from pulp.common import error_codes, tags
 from pulp.common.plugins import importer_constants
+from pulp.plugins.conduits.mixins import ImporterScratchPadMixin
 from pulp.plugins.config import PluginCallConfiguration
 from pulp.plugins.loader import api as plugin_api
 from pulp.server import exceptions
@@ -276,7 +277,9 @@ def update_importer_config(repo_id, importer_config):
         if v is not None:
             repo_importer.config[k] = v
             if k == importer_constants.KEY_FEED:
-                repo_importer._set_scratchpad_entry(importer_constants.KEY_FEED_UPDATED, True)
+                if not repo_importer.scratchpad:
+                    repo_importer.scratchpad = {}
+                repo_importer.scratchpad[importer_constants.KEY_FEED_UPDATED] = True
 
     validate_importer_config(repo_obj, repo_importer.importer_type_id, repo_importer.config)
     try:

--- a/server/pulp/server/controllers/importer.py
+++ b/server/pulp/server/controllers/importer.py
@@ -272,12 +272,11 @@ def update_importer_config(repo_id, importer_config):
     # e.g. basic_auth_username and basic_auth_password should be either both present or both absent.
     validate_importer_config(repo_obj, repo_importer.importer_type_id, repo_importer.config)
     repo_importer.save()
-
     for k, v in importer_config.iteritems():
         if v is not None:
             repo_importer.config[k] = v
             if k == importer_constants.KEY_FEED:
-                repo_importer.config[importer_constants.KEY_FEED_UPDATED] = True
+                repo_importer._set_scratchpad_entry(importer_constants.KEY_FEED_UPDATED, True)
 
     validate_importer_config(repo_obj, repo_importer.importer_type_id, repo_importer.config)
     try:

--- a/server/pulp/server/controllers/importer.py
+++ b/server/pulp/server/controllers/importer.py
@@ -276,6 +276,8 @@ def update_importer_config(repo_id, importer_config):
     for k, v in importer_config.iteritems():
         if v is not None:
             repo_importer.config[k] = v
+            if k == importer_constants.KEY_FEED:
+                repo_importer.config[importer_constants.KEY_FEED_UPDATED] = True
 
     validate_importer_config(repo_obj, repo_importer.importer_type_id, repo_importer.config)
     try:

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -365,6 +365,34 @@ class Importer(AutoRetryDocument):
                 else:
                     pem_file.write(self.config[config_key])
 
+    def _set_scratchpad_entry(self, key, value):
+        """
+        Add the specified key/value pair to the scratchpad, making sure the scratchpad exists
+        first if necessary.
+
+        :param key:     The key to be added to the scratchpad
+        :type  key:     basestring
+        :param value:   The value to assign to 'key', in the scratchpad
+        :type  value:   object
+        """
+        if not self.scratchpad:
+            self.scratchpad = {}
+        self.scratchpad[key] = value
+
+    def _get_scratchpad_entry(self, key):
+        """
+        Return the value of 'key' in the Importer's scratchpad.
+        Return None, if scratchpad doesn't exist or 'key' is not in scratchpad.
+
+        :param key:     The key to be queried
+        :type  key:     basestring
+        :rtype object
+        """
+        if self.scratchpad and key in self.scratchpad:
+            return self.scratchpad[importer_constants.KEY_FEED_UPDATED]
+        else:
+            return None
+
 
 signals.pre_delete.connect(Importer.pre_delete, sender=Importer)
 signals.pre_save.connect(Importer.pre_save, sender=Importer)

--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -365,34 +365,6 @@ class Importer(AutoRetryDocument):
                 else:
                     pem_file.write(self.config[config_key])
 
-    def _set_scratchpad_entry(self, key, value):
-        """
-        Add the specified key/value pair to the scratchpad, making sure the scratchpad exists
-        first if necessary.
-
-        :param key:     The key to be added to the scratchpad
-        :type  key:     basestring
-        :param value:   The value to assign to 'key', in the scratchpad
-        :type  value:   object
-        """
-        if not self.scratchpad:
-            self.scratchpad = {}
-        self.scratchpad[key] = value
-
-    def _get_scratchpad_entry(self, key):
-        """
-        Return the value of 'key' in the Importer's scratchpad.
-        Return None, if scratchpad doesn't exist or 'key' is not in scratchpad.
-
-        :param key:     The key to be queried
-        :type  key:     basestring
-        :rtype object
-        """
-        if self.scratchpad and key in self.scratchpad:
-            return self.scratchpad[importer_constants.KEY_FEED_UPDATED]
-        else:
-            return None
-
 
 signals.pre_delete.connect(Importer.pre_delete, sender=Importer)
 signals.pre_save.connect(Importer.pre_save, sender=Importer)


### PR DESCRIPTION
This allows us to re-evaluate the status of content at sync-time.

Required for #4265
https://pulp.plan.io/issues/4265