### PR TITLE
Use multi-resource locking when additional_repos override is passed

### DIFF
--- a/server/test/unit/server/webservices/views/test_repositories.py
+++ b/server/test/unit/server/webservices/views/test_repositories.py
@@ -1817,8 +1817,8 @@ class TestRepoAssociate(unittest.TestCase):
             raise AssertionError('OperationPostponed should be raise for an associate task')
 
         task_tags = [mock_tags.resource_tag(), mock_tags.resource_tag(), mock_tags.action_tag()]
-        mock_associate.apply_async_with_reservation.assert_called_once_with(
-            mock_tags.RESOURCE_REPOSITORY_TYPE, 'mock_dest_repo',
+        mock_associate.apply_async_with_reservation_list.assert_called_once_with(
+            [(mock_tags.RESOURCE_REPOSITORY_TYPE, 'mock_dest_repo')],
             ['mock_source_repo', 'mock_dest_repo'],
             {'criteria': mock_crit.return_value.to_dict.return_value,
              'import_config_override': None}, tags=task_tags


### PR DESCRIPTION
The RPM plugin needs to accept more than one source and destination
repository for copy operations. The "additional_repos" flag is being
added to deal with this. Core needs to look for this flag in the
override config and then, when present, lock on all the repo ids present
within as well as the directly-specified source and destination repo
ids.

re: #5067
https://pulp.plan.io/issues/5067