### PR TITLE
Fix Warning Indentaion

### DIFF
--- a/docs/user-guide/installation/rhel_centos.rst
+++ b/docs/user-guide/installation/rhel_centos.rst
@@ -178,7 +178,7 @@ Server
 
          `SSLProtocol all -SSLv2 -SSLv3`
 
-  .. warning::
+   .. warning::
      It is recommended that the web server only serves Pulp services.
 
 #. Start Apache httpd and set it to start on boot. For Upstart based systems::


### PR DESCRIPTION
Fixes issue where numbering starts over on [user-guide/installation/rhel_centos](https://docs.pulpproject.org/user-guide/installation/rhel_centos.html). On step labelled "Start Apache httpd and set it to start on boot. For Upstart based systems:"