### PR TITLE
Add --ignore-existing to remote_mkdir

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -75,7 +75,7 @@ class RSyncPublishStep(PublishStep):
         """
         tmpdir = os.path.join(self.get_working_dir(), '.tmp')
         os.makedirs(os.path.join(tmpdir, path.lstrip("/")))
-        args = ['rsync', '-avrK', '-f+ */']
+        args = ['rsync',  '-avrK', '--ignore-existing', '-f+ */']
         args.extend(self.make_authentication())
         args.extend(self.make_extra_args())
         args.append("%s/" % tmpdir)

--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -75,7 +75,7 @@ class RSyncPublishStep(PublishStep):
         """
         tmpdir = os.path.join(self.get_working_dir(), '.tmp')
         os.makedirs(os.path.join(tmpdir, path.lstrip("/")))
-        args = ['rsync',  '-avrK', '--ignore-existing', '-f+ */']
+        args = ['rsync', '-avrK', '--ignore-existing', '-f+ */']
         args.extend(self.make_authentication())
         args.extend(self.make_extra_args())
         args.append("%s/" % tmpdir)


### PR DESCRIPTION
To avoid recreating existing parts of directory structure --ignore-existing is
added to arguments passed to rsync when calling remote_mkdir