### PR TITLE
Allow for MONGODB-X509 authentication to Mongo

### DIFF
--- a/server/etc/pulp/server.conf
+++ b/server/etc/pulp/server.conf
@@ -43,6 +43,10 @@
 #                    number of seeds specified. For version of MongoDB < 2.6, replica_set must also
 #                    be specified. Please note that 'all' will cause Pulp to halt if any of the
 #                    replica set members is not available. 'majority' is used by default.
+# x509_auth:         If true, authenticate using MONGODB-X509 mechanism and the cert pointed to by
+#                    ssl_certfile. Pre-Mongo3, username is also required (use the RFC2253-formatted subject
+#                    from the ssl_certfile cert). Fails unless ssl=true and ssl_certfile points to a
+#                    valid X509 certificate
 
 
 [database]
@@ -58,6 +62,7 @@
 # ca_path: /etc/pki/tls/certs/ca-bundle.crt
 # unsafe_autoretry: false
 # write_concern: majority
+# x509_auth: false
 
 
 # = Server =

--- a/server/pulp/server/config.py
+++ b/server/pulp/server/config.py
@@ -76,6 +76,7 @@ _default_values = {
         'ca_path': DEFAULT_CA_PATH,
         'unsafe_autoretry': 'false',
         'write_concern': 'majority',
+        'x509_auth': 'false',
     },
     'email': {
         'host': 'localhost',


### PR DESCRIPTION
Adds a config-setting, 'x509_auth: true/false', to the [database] stanza. Can
be used only if ssl: true and ssl_certfile: <path> are set, username: is the subject
of the specified client-PEM, and Mongo is set to clusterAuthMode = x509

closes #5512