### PR TITLE
If repository hasn't been published before, publish without fast-foward

### DIFF
--- a/devel/pulp/devel/mock_distributor.py
+++ b/devel/pulp/devel/mock_distributor.py
@@ -6,7 +6,7 @@ from pulp.plugins.model import PublishReport
 
 
 def get_publish_conduit(type_id=None, existing_units=None, pkg_dir=None, checksum_type="sha",
-                        repodata=None):
+                        repodata=None, last_published=None):
     def build_success_report(summary, details):
         return PublishReport(True, summary, details)
 
@@ -58,6 +58,7 @@ def get_publish_conduit(type_id=None, existing_units=None, pkg_dir=None, checksu
     publish_conduit.build_success_report = build_success_report
     publish_conduit.get_repo_scratchpad.side_effect = get_repo_scratchpad
     publish_conduit.get_scratchpad.side_effect = get_scratchpad
+    publish_conduit.last_published = last_published
     return publish_conduit
 
 

--- a/server/pulp/plugins/file/distributor.py
+++ b/server/pulp/plugins/file/distributor.py
@@ -71,7 +71,7 @@ class FileDistributor(Distributor):
         :rtype:                 pulp.plugins.model.PublishReport
         """
         _logger.info(_('Beginning publish for repository <%(repo)s>') % {'repo': repo.id})
-        if not config.get("force_full", False):
+        if not config.get("force_full", False) and publish_conduit.last_published:
             try:
                 return self.publish_repo_fast_forward(repo, publish_conduit, config)
             except FastForwardUnavailable:


### PR DESCRIPTION
If repository hasn't been published before and there's no unit
associated with it, no PULP_MANIFEST is published to destination
publish directory.
With this fix, empty manifest is created in destination directory
indicating that published repo is empty

Closes #5659