### PR TITLE
Updates latest version to 3.0

### DIFF
--- a/.travis/docs-builder.py
+++ b/.travis/docs-builder.py
@@ -13,7 +13,7 @@ WORKING_DIR = os.path.join(os.environ['TRAVIS_BUILD_DIR'], '../working')
 VERSION_REGEX = "(\s*)(version)(\s*)(=)(\s*)(['\"])(.*)(['\"])(.*)"
 RELEASE_REGEX = "(\s*)(release)(\s*)(=)(\s*)(['\"])(.*)(['\"])(.*)"
 
-LATEST = '2.21'
+LATEST = '3.0'
 
 USERNAME = 'doc_builder'
 HOSTNAME = '8.43.85.236'


### PR DESCRIPTION
This patch ensures that pulp 2 docs never publish to the root of docs.pulpproject.org again.
Docs will continue to be published to docs.pulpproject.org/en/2.Y/.

[noissue]