### PR TITLE
Correct last_publish method call in distributor

### DIFF
--- a/server/pulp/plugins/file/distributor.py
+++ b/server/pulp/plugins/file/distributor.py
@@ -71,7 +71,7 @@ class FileDistributor(Distributor):
         :rtype:                 pulp.plugins.model.PublishReport
         """
         _logger.info(_('Beginning publish for repository <%(repo)s>') % {'repo': repo.id})
-        if not config.get("force_full", False) and publish_conduit.last_published:
+        if not config.get("force_full", False) and publish_conduit.last_publish:
             try:
                 return self.publish_repo_fast_forward(repo, publish_conduit, config)
             except FastForwardUnavailable:


### PR DESCRIPTION
In a recent commit to limit fast-forward publishing to repositories that
have been published before, "last_published" was mistaken for the
publish_conduit's "last_publish" method causing an attribute error.
This commit corrects the typo.

Closes #5659