### PR TITLE
Respect last_unit_added when deciding whether to publish

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1166,6 +1166,11 @@ def check_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_con
         the_timestamp = dateutils.format_iso8601_datetime(last_published)
         last_updated = model.RepositoryContentUnit.objects(repo_id=repo_obj.repo_id,
                                                            updated__gte=the_timestamp).count()
+        if not last_updated:
+            # There is no newer RepositoryContentUnit than last publish;
+            # however, a unit shared between multiple repos could still have been mutated,
+            # in which case it will be reflected in last_unit_added.
+            last_updated = repo_obj.last_unit_added and repo_obj.last_unit_added > last_published
         units_removed = last_unit_removed is not None and last_unit_removed > last_published
         dist_updated = dist.last_updated > last_published
 


### PR DESCRIPTION
This is a follow-up to commits for issue #5951.
Previous commits made it so that mutating an erratum unit would set
last_unit_added on all affected repos; however, the code for deciding
whether to skip publish ignored this field and only looked at
RepositoryContentUnits, so the commits didn't fix the issue.

Fix this by checking last_unit_added as well, so we cover both the
"new RepositoryContentUnits created for the repo" and "unit shared
between multiple repos was updated" cases. Erratum units are the only
type known to fall into the latter case.

re: #5951
https://pulp.plan.io/issues/5951