### PR TITLE
Fix last_publish method call

### DIFF
--- a/devel/pulp/devel/mock_distributor.py
+++ b/devel/pulp/devel/mock_distributor.py
@@ -6,7 +6,7 @@ from pulp.plugins.model import PublishReport
 
 
 def get_publish_conduit(type_id=None, existing_units=None, pkg_dir=None, checksum_type="sha",
-                        repodata=None, last_published=None):
+                        repodata=None, last_published="2019-12-05 19:40:26.284627"):
     def build_success_report(summary, details):
         return PublishReport(True, summary, details)
 
@@ -52,13 +52,16 @@ def get_publish_conduit(type_id=None, existing_units=None, pkg_dir=None, checksu
             scratchpad = {"checksum_type": checksum_type, 'published_distributions': {}}
         return scratchpad
 
+    def last_publish():
+        return last_published
+
     publish_conduit = mock.Mock(spec=RepoPublishConduit)
     publish_conduit.get_units.side_effect = get_units
     publish_conduit.build_failure_report = build_failure_report
     publish_conduit.build_success_report = build_success_report
     publish_conduit.get_repo_scratchpad.side_effect = get_repo_scratchpad
     publish_conduit.get_scratchpad.side_effect = get_scratchpad
-    publish_conduit.last_published = last_published
+    publish_conduit.last_publish.side_effect = last_publish
     return publish_conduit
 
 

--- a/server/pulp/plugins/file/distributor.py
+++ b/server/pulp/plugins/file/distributor.py
@@ -71,7 +71,7 @@ class FileDistributor(Distributor):
         :rtype:                 pulp.plugins.model.PublishReport
         """
         _logger.info(_('Beginning publish for repository <%(repo)s>') % {'repo': repo.id})
-        if not config.get("force_full", False) and publish_conduit.last_publish:
+        if not config.get("force_full", False) and publish_conduit.last_publish():
             try:
                 return self.publish_repo_fast_forward(repo, publish_conduit, config)
             except FastForwardUnavailable:

--- a/server/test/unit/plugins/file/test_distributor.py
+++ b/server/test/unit/plugins/file/test_distributor.py
@@ -234,10 +234,7 @@ class FileDistributorTest(unittest.TestCase):
             cloned_unit.unit_key['name'] = "foo%d.rpm" % (i)
             cloned_unit.unit_key['checksum'] = "sum%s" % (1000000000 + i)
             units.append(cloned_unit)
-        new_conduit = get_publish_conduit(
-            existing_units=units,
-            last_published="2019-12-05 19:40:26.284627"
-        )
+        new_conduit = get_publish_conduit(existing_units=units)
         distributor.publish_repo(self.repo, new_conduit, PluginCallConfiguration({}, {}, {}))
         # Verify if do publish with force full after trying with fast forward
         self.assertEqual(distributor.get_hosting_locations.call_count, 3)
@@ -248,10 +245,7 @@ class FileDistributorTest(unittest.TestCase):
             cloned_unit.unit_key['name'] = "fooa%d.rpm" % (i)
             cloned_unit.unit_key['checksum'] = "suma%s" % (1000000000 + i)
             units.append(cloned_unit)
-        new_conduit = get_publish_conduit(
-            existing_units=units,
-            last_published="2019-12-05 19:40:26.284627"
-        )
+        new_conduit = get_publish_conduit(existing_units=units)
         distributor.publish_repo(self.repo, new_conduit, PluginCallConfiguration({}, {}, {}))
         # Verify if do publish with fast forward
         self.assertEqual(distributor.get_hosting_locations.call_count, 4)
@@ -272,10 +266,7 @@ class FileDistributorTest(unittest.TestCase):
             cloned_unit.unit_key['name'] = "foo%d.rpm" % (i)
             cloned_unit.unit_key['checksum'] = "sum%s" % (1000000000 + i)
             units.append(cloned_unit)
-        new_conduit = get_publish_conduit(
-            existing_units=units,
-            last_published="2019-12-05 19:40:26.284627"
-        )
+        new_conduit = get_publish_conduit(existing_units=units)
         distributor.publish_repo(self.repo, new_conduit, PluginCallConfiguration({}, {}, {}))
         # Verify if do publish with force full finally after trying with fast forward
         self.assertEqual(distributor.get_hosting_locations.call_count, 3)
@@ -286,10 +277,7 @@ class FileDistributorTest(unittest.TestCase):
             cloned_unit.unit_key['name'] = "food%d.rpm" % (i)
             cloned_unit.unit_key['checksum'] = "sumd%s" % (1000000000 + i)
             units.append(cloned_unit)
-        new_conduit = get_publish_conduit(
-            existing_units=units,
-            last_published="2019-12-05 19:40:26.284627"
-        )
+        new_conduit = get_publish_conduit(existing_units=units)
         distributor.publish_repo(self.repo, new_conduit, PluginCallConfiguration({}, {}, {}))
         # Verify if do publish with fast forward
         self.assertEqual(distributor.get_hosting_locations.call_count, 4)
@@ -582,3 +570,16 @@ class FileDistributorTest(unittest.TestCase):
         mock_normpath.assert_called_once_with(target_path)
         mock_isabs.assert_called_once_with('../../fizz')
         mock_join.assert_not_called()
+
+    @patch('pulp.server.managers.repo._common.get_working_directory', spec_set=True)
+    def test_first_publish_empty_repo(self, mock_get_working, force_full=False):
+        mock_get_working.return_value = self.temp_dir
+        # Publish an empty repository for the first time
+        distributor = self.create_distributor_with_mocked_api_calls()
+        config = PluginCallConfiguration({}, {}, {'force_full': force_full})
+        new_conduit = get_publish_conduit(existing_units=[], last_published=None)
+        distributor.publish_repo(self.repo, new_conduit, config)
+        manifest_file = os.path.join(self.target_dir, MANIFEST_FILENAME)
+
+        # Ensure PULP_MANIFEST is created
+        self.assertTrue(os.path.exists(manifest_file))


### PR DESCRIPTION
Method last_publish was not called properly so that a bound
method was used instead of its return. It made publish always
be fast-forward no matter repo has been published or not when
force_full=True is not set.

Added new case for testing this and fixed tests added before.

Closes #5659