### PR TITLE
Allow building docs with warnings

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS           = -W -n
+SPHINXOPTS           = -n
 SPHINXBUILD          = sphinx-build
 PAPER                =
 BUILDDIR             = _build


### PR DESCRIPTION
A newer version of Sphinx warns about something that used to be ok,
but we run Sphinx with "treat warnings as errors" flag. At this
stage in Pulp 2's lifecycle, disabling this is fine.

closes: #6597
https://pulp.plan.io/issues/6597