### PR TITLE
Fix $date operator to work with $and or $or

### DIFF
--- a/server/pulp/server/db/model/criteria.py
+++ b/server/pulp/server/db/model/criteria.py
@@ -499,9 +499,13 @@ class DateOperator(object):
             if matched:
                 query[key] = translated
                 continue
-            if not isinstance(value, dict):
+            if isinstance(value, dict):
+                DateOperator.apply(value)
                 continue
-            DateOperator.apply(value)
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        DateOperator.apply(item)
 
     @staticmethod
     def translate(value):

--- a/server/test/unit/server/db/model/test_criteria.py
+++ b/server/test/unit/server/db/model/test_criteria.py
@@ -348,6 +348,21 @@ class TestDateOperator(unittest.TestCase):
         criteria.DateOperator.apply(query)
         self.assertTrue(isinstance(query['created']['$gt'], datetime))
 
+    def test_apply_multiple_conditions(self):
+        query = {
+            '$and': [
+                {'created': {
+                    '$gt': {'$date': '2013-12-01T14:35:00Z'}
+                }},
+                {'updated': {
+                    '$lt': {'$date': '2020-05-15T14:35:00Z'}
+                }},
+            ]
+        }
+        criteria.DateOperator.apply(query)
+        self.assertTrue(isinstance(query['$and'][0]['created']['$gt'], datetime))
+        self.assertTrue(isinstance(query['$and'][1]['updated']['$lt'], datetime))
+
     def test_translate(self):
         value = {'$date': '2013-12-01T14:35:00Z'}
         matched, translated = criteria.DateOperator.translate(value)


### PR DESCRIPTION
Queries with $date operator doesn't work as expected
with $and or $or operators. $date operator descends
only on dicts and ignores everything else. This fix
modifies $date operator to descend on list too so
it works with $and or $or operators.

Closes #5700