### PR TITLE
Fix regression of #6387

### DIFF
--- a/server/pulp/server/db/model/consumer.py
+++ b/server/pulp/server/db/model/consumer.py
@@ -277,9 +277,7 @@ class UnitProfile(Model):
     """
 
     collection_name = 'consumer_unit_profiles'
-    unique_indices = (
-        ('consumer_id', 'content_type'),
-    )
+    unique_indices = Model.unique_indices + (('consumer_id', 'content_type'),)
 
     def __init__(self, consumer_id, content_type, profile, profile_hash=None):
         """

--- a/server/pulp/server/managers/consumer/applicability.py
+++ b/server/pulp/server/managers/consumer/applicability.py
@@ -703,7 +703,7 @@ def _add_profiles_to_consumer_map_and_get_hashes(consumer_ids, consumer_map):
     :rtype:              list
     """
     profiles = UnitProfile.get_collection().find(
-        {'consumer_id': {'$in': consumer_ids}},
+        {'consumer_id': {'$in': consumer_ids}, 'profile': {'$ne': []}},
         projection=['consumer_id', 'profile_hash'])
     all_profiles_hashes = set()
     for p in profiles:


### PR DESCRIPTION
Regenerate applicability task and retrieve applicability request
are not using the same all_profiles_hash to save and lookup the
repo profile applicability.

closes: #6851
https://pulp.plan.io/issues/6851