### PR TITLE
Remove unnecessary criteria of force_full rsync publish

### DIFF
--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -363,9 +363,7 @@ class Publisher(PublishStep):
         :return: Whether or not this publish should be in fast forward mode
         :rtype: bool
         """
-        force_full = False
-        config_force_full = self.get_config().get("force_full", False)
-        force_full = force_full | config_force_full
+        force_full = self.get_config().get("force_full", False)
         delete = self.get_config().get("delete", False)
 
         return not force_full and not delete and self.last_predist_last_published

--- a/server/pulp/plugins/rsync/publish.py
+++ b/server/pulp/plugins/rsync/publish.py
@@ -12,7 +12,6 @@ from pulp.common import dateutils
 from pulp.plugins.util.publish_step import PublishStep
 from pulp.server.config import config as pulp_config
 from pulp.server.exceptions import PulpCodedException
-from pulp.server.db.model.repository import RepoPublishResult
 from pulp.server.db.model import Distributor
 
 
@@ -334,19 +333,6 @@ class Publisher(PublishStep):
             scratchpad = self.distributor.scratchpad or {}
             self.last_predist_last_published = scratchpad.get("last_predist_last_published")
 
-        if self.last_published:
-            string_date = dateutils.format_iso8601_datetime(self.last_published)
-        else:
-            string_date = None
-
-        if self.predistributor:
-            search_params = {'repo_id': repo.id,
-                             'distributor_id': self.predistributor["distributor_id"],
-                             'started': {"$gte": string_date}}
-            self.predist_history = RepoPublishResult.get_collection().find(search_params)
-        else:
-            self.predist_history = []
-
         self.remote_path = self.get_remote_repo_path()
 
         if self.is_fastforward():
@@ -378,30 +364,11 @@ class Publisher(PublishStep):
         :rtype: bool
         """
         force_full = False
-        for entry in self.predist_history:
-            predistributor_force_full = entry.get("distributor_config", {}).get("force_full",
-                                                                                False)
-            force_full |= predistributor_force_full
-            if entry.get("result", "error") == "error":
-                force_full = True
-
-        if self.last_published:
-            last_published = self.last_published.replace(tzinfo=None)
-        else:
-            last_published = None
-
-        if self.last_deleted:
-            last_deleted = self.last_deleted.replace(tzinfo=None)
-        else:
-            last_deleted = None
-
         config_force_full = self.get_config().get("force_full", False)
         force_full = force_full | config_force_full
         delete = self.get_config().get("delete", False)
 
-        return not force_full and not delete and self.last_predist_last_published and \
-            ((last_deleted and last_published and last_published > last_deleted) or
-                not last_deleted)
+        return not force_full and not delete and self.last_predist_last_published
 
     def create_date_range_filter(self, start_date=None, end_date=None):
         """


### PR DESCRIPTION
Rsync publish after units removal or failed predistributor publish
doesn't have to be force_full publish, so remove them from criteria.

RepoPublishResult doesn't have distributor_config, so the criteria
of predistributor_force_full doesn't work, remove it.

closes #7185
https://pulp.plan.io/issues/7185