### PR TITLE
find_repo_content_units: skip db query if expected result is empty

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -234,6 +234,12 @@ def find_repo_content_units(
                                 __raw__={'_id': {'$in': list(ids_chunk)}})
             if unit_fields:
                 qs = qs.only(*unit_fields)
+            
+            # for performace reasons, do server-side counting of units the will be returned in result
+            # before we do actual query to db
+            # if expected count of units in result is zero, continue to next chunk of unit_ids 
+            if qs.count() == 0:
+                continue
 
             for unit in qs:
                 if skip and skip_count < skip:

--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -234,10 +234,10 @@ def find_repo_content_units(
                                 __raw__={'_id': {'$in': list(ids_chunk)}})
             if unit_fields:
                 qs = qs.only(*unit_fields)
-            
-            # for performace reasons, do server-side counting of units the will be returned in result
-            # before we do actual query to db
-            # if expected count of units in result is zero, continue to next chunk of unit_ids 
+
+            # for performace reasons, do server-side counting of units the will be returned in
+            # result before we do actual query to db
+            # if expected count of units in result is zero, continue to next chunk of unit_ids
             if qs.count() == 0:
                 continue
 
@@ -1836,3 +1836,4 @@ class LazyUnitDownloadStep(DownloadEventListener):
         else:
             if not os.path.isfile(file_path):
                 raise IOError(_("The path '{path}' does not exist").format(path=file_path))
+ 


### PR DESCRIPTION
For performance reasons, this change does server-side counting
of units that are expected to be in result before actual db query
happens. If expected count is zero, skip db query and continue to
the next chunk of unit ids.

The performance problem is noticable in RHSM-pulp for big repos
with 200k and more units associated. During associate action
results of the most of queries in affected code will be empty
so we can skip querying the db this way.

Without this fix, code will do eg. 200 unnecesary queries for repo
with 200k units which will take a lot time to finish that leads
to major performance regression.