### PR TITLE
Update tests for find_repo_content_units() func

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1830,4 +1830,3 @@ class LazyUnitDownloadStep(DownloadEventListener):
         else:
             if not os.path.isfile(file_path):
                 raise IOError(_("The path '{path}' does not exist").format(path=file_path))
-


### PR DESCRIPTION
In (#4008) 033b2e656989e7ea2f68a10bf13d1a7c9c772bd6, the function
was updated to skip db query, if the expected results is empty.

It seems that it was forgotten to update tests, so this change
updates tests to reflect the change in #4008.

In this commit I've also fixed the repository.py file.
There was accidentally added unicode char to the end the repository.py file,
it caused failure during run of coverage tool in CI.

(cherry picked from commit 0e0b90587f6ff8587f103a58c14ae47a1fe62f64)