### PR TITLE
Set the auth private key size to be 2048 bits

### DIFF
--- a/server/pulp/server/managers/auth/cert/cert_generator.py
+++ b/server/pulp/server/managers/auth/cert/cert_generator.py
@@ -178,7 +178,7 @@ class SerialNumber:
 
 
 def _make_priv_key():
-    cmd = 'openssl genrsa 1024'
+    cmd = 'openssl genrsa 2048'
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     p.wait()
     exit_code = p.returncode

--- a/server/test/unit/server/managers/auth/cert/test_cert_generator.py
+++ b/server/test/unit/server/managers/auth/cert/test_cert_generator.py
@@ -56,6 +56,8 @@ class TestCertGeneration(unittest.TestCase):
 
         # Verify
         self.assertTrue(pem.startswith('-----BEGIN RSA PRIVATE KEY-----'))
+        # Verify that the key size is 2048 bits
+        self.assertEqual(len(pem) == 1679)
 
     def test_generation(self):
         # Setup


### PR DESCRIPTION
Clients such as Fedora 33 have a default OpenSSL configuration
that doesn't allow the usage of 1024 bit keys.

See more information at:
https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2

closes #8317