### PR TITLE
Sign authentication certificates using SHA256

### DIFF
--- a/server/pulp/server/managers/auth/cert/cert_generator.py
+++ b/server/pulp/server/managers/auth/cert/cert_generator.py
@@ -74,7 +74,7 @@ class CertGenerationManager(object):
         sn = SerialNumber()
         serial = sn.getSerialNumber()
 
-        cmd = 'openssl x509 -req -sha1 -CA %s -CAkey %s -set_serial %s -days %d' % \
+        cmd = 'openssl x509 -req -sha256 -CA %s -CAkey %s -set_serial %s -days %d' % \
               (ca_cert, ca_key, serial, expiration)
         p = subprocess.Popen(cmd, shell=True, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Clients such as Fedora 33 have a default OpenSSL configuration
that doesn't allow the usage of SHA1 signed certificates.

See more information at:
https://fedoraproject.org/wiki/Changes/StrongCryptoSettings2

closes #8317