### PR TITLE
Set last_publish as a start of publish [RHELDST-5086, #8778] 

### DIFF
--- a/server/pulp/server/controllers/repository.py
+++ b/server/pulp/server/controllers/repository.py
@@ -1234,7 +1234,7 @@ def check_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_con
         # Use raw pymongo not to fire the signal hander
         model.Distributor.objects(
             repo_id=repo_obj.repo_id,
-            distributor_id=dist_id).update(set__last_publish=publish_end_timestamp)
+            distributor_id=dist_id).update(set__last_publish=publish_start_timestamp)
 
         result_code = RepoPublishResult.RESULT_SKIPPED
         _logger.debug('publish skipped for repo [%s] with distributor ID [%s]' % (
@@ -1341,7 +1341,7 @@ def _do_publish(repo_obj, dist_id, dist_inst, transfer_repo, conduit, call_confi
     if not publish_report.canceled_flag:
         # Use raw pymongo not to fire the signal hander
         model.Distributor.objects(repo_id=repo_obj.repo_id, distributor_id=dist_id).\
-            update(set__last_publish=publish_end_timestamp)
+            update(set__last_publish=publish_start_timestamp)
 
     # Add a publish entry
     summary = publish_report.summary


### PR DESCRIPTION
When a repository is published, set last_publish field on distributor
to the start time of publish instead of finish time.

With this change pulp shouldn't falsely skip publish of a repo when
last_unit_added is set to the time between publish start and finish.