### PR TITLE
Fix clean_orphans

### DIFF
--- a/server/pulp/server/db/model/__init__.py
+++ b/server/pulp/server/db/model/__init__.py
@@ -956,7 +956,7 @@ class FileContentUnit(ContentUnit):
         Exposes the ability to clean up this unit as an orphan.
         """
         orphan_manger = factory.content_orphan_manager()
-        orphan_manger.delete_orphan_content_units_by_type(self._content_type_id, self.id)
+        orphan_manger.delete_orphan_content_units_by_type(self._content_type_id, [self.id])
 
     def get_symlink_name(self):
         """

--- a/server/test/unit/server/db/test_model.py
+++ b/server/test/unit/server/db/test_model.py
@@ -570,7 +570,7 @@ class TestFileContentUnit(unittest.TestCase):
     def test_clean_orphans(self, orphan_manager_delete_orphan):
         unit = TestFileContentUnit.TestUnit()
         unit.clean_orphans()
-        orphan_manager_delete_orphan.assert_called_once_with(unit._content_type_id, unit.id)
+        orphan_manager_delete_orphan.assert_called_once_with(unit._content_type_id, [unit.id])
 
 
 class TestSharedContentUnit(unittest.TestCase):


### PR DESCRIPTION
delete_orphan_content_units_by_type requires a list of unit ids.

Closes #9360