### PR TITLE
Fix broken test_priv_key

### DIFF
--- a/server/test/unit/server/managers/auth/cert/test_cert_generator.py
+++ b/server/test/unit/server/managers/auth/cert/test_cert_generator.py
@@ -56,8 +56,8 @@ class TestCertGeneration(unittest.TestCase):
 
         # Verify
         self.assertTrue(pem.startswith('-----BEGIN RSA PRIVATE KEY-----'))
-        # Verify that the key size is 2048 bits
-        self.assertEqual(len(pem) == 1679)
+        # Verify that the key size is (probably) at least 2048 bits
+        self.assertGreaterEqual(len(pem), 1650)
 
     def test_generation(self):
         # Setup


### PR DESCRIPTION
This test was broken in two ways.

(1) assertEqual(x == y) doesn't make sense. It needed to be either
    assertTrue(x == y) or assertEqual(x, y).

(2) Test was flaky because the output of "openssl genrsa 2048" is not
    guaranteed to be a specific number of bytes in length. Due to the
    way base64 encoding works, depending on the precise bits generated,
    the output may or may not need to be padded with some trailing "="
    characters. 1679 was only correct in the case where exactly two
    "=" characters would be generated.

Make the test more fuzzy so it doesn't depend so much on precisely how
the private key is encoded.