### PR TITLE
Fix relevant security gaps reported by SonarQube SAST scan

### DIFF
--- a/common/pulp/common/pic.py
+++ b/common/pulp/common/pic.py
@@ -20,7 +20,7 @@ PORT = 443
 PATH_PREFIX = '/pulp/api'
 AUTH_SCHEME = 'basic'  # can also be 'oauth' (XXX not really)
 USER = 'admin'
-PASSWORD = 'admin'
+PASSWORD = None
 
 LOG_BODIES = True
 
@@ -50,6 +50,8 @@ class RequestError(Exception):
 
 def _auth_header():
     def _basic_auth_header():
+        if PASSWORD is None:
+            raise RuntimeError("You must provide the password to connect to Pulp")
         raw = ':'.join((USER, PASSWORD))
         encoded = base64.encodestring(raw)[:-1]
         return {'Authorization': 'Basic %s' % encoded}

--- a/playpen/v2_plugins/harness/harness.py
+++ b/playpen/v2_plugins/harness/harness.py
@@ -547,7 +547,7 @@ class Harness:
 
 class PulpConnection:
 
-    def __init__(self, host='localhost', port=443, path_prefix='/pulp/api', user='admin', password='admin'):
+    def __init__(self, host='localhost', port=443, path_prefix='/pulp/api', user='admin', password=None):
         self.host = host
         self.port = port
         self.path_prefix = path_prefix
@@ -580,6 +580,8 @@ class PulpConnection:
         if not isinstance(body, types.NoneType):
             body = json.dumps(body)
 
+        if self.password is None:
+            raise RuntimeError("You must provide a password to connect to Pulp")
         raw = ':'.join((self.user, self.password))
         encoded = base64.encodestring(raw)[:-1]
         auth_header = {'Authorization': 'Basic %s' % encoded}

--- a/server/test/unit/plugins/util/test_metadata_writer.py
+++ b/server/test/unit/plugins/util/test_metadata_writer.py
@@ -67,7 +67,7 @@ class MetadataWriterTests(unittest.TestCase):
 
         os.makedirs(parent_path, mode=0000)
         self.assertRaises(RuntimeError, context._open_metadata_file_handle)
-        os.chmod(parent_path, 0777)
+        os.chmod(parent_path, 0700)
 
     def test_open_handle_file_exists(self):
 


### PR DESCRIPTION
SonarQube SAST scan reported some security hotspots for the pulp package[1]. This patch fixes some of
the relevant medium and high priority security gaps reported in the scan.

[1] https://sonarqube.corp.redhat.com/security_hotspots?id=rcm-pulp&branch=2-master

Change-Id: Ieef43b0094293c788616bdc38d17d5d2d01ef1b9